### PR TITLE
fix(shortcuts): support custom tab switching keybindings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -785,11 +785,15 @@ function App() {
 
   const handleSwitchTab = useCallback(
     (index: number) => {
-      if (tabs.length === 0) return;
-      const target = index === -1 ? tabs[tabs.length - 1] : tabs[index];
-      if (target) setActiveTabId(target.id);
+      const leaf =
+        terminalWindows && activeTabId
+          ? findTerminalWindowLeafByTabId(terminalWindows, activeTabId)
+          : null;
+      const tabIds = leaf?.tabIds ?? tabs.map((tab) => tab.id);
+      const targetTabId = index === -1 ? tabIds[tabIds.length - 1] : tabIds[index];
+      if (targetTabId) setActiveTabId(targetTabId);
     },
-    [tabs, setActiveTabId],
+    [activeTabId, setActiveTabId, tabs, terminalWindows],
   );
 
   const handleToggleLeftSidebar = useCallback(() => {

--- a/src/components/settings/KeyboardShortcutsTab.tsx
+++ b/src/components/settings/KeyboardShortcutsTab.tsx
@@ -4,8 +4,10 @@ import { MdEdit, MdRefresh, MdSearch } from "react-icons/md";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { useApp } from "@/context/AppContext";
 import {
+  formatIndexedKeysForDisplay,
   formatKeysForDisplay,
   keyEventToHotkeyString,
+  keyEventToIndexedHotkeyString,
   resolveKeys,
   SHORTCUT_CATEGORIES,
   SHORTCUT_REGISTRY,
@@ -29,7 +31,10 @@ export function KeyboardShortcutsTab() {
       return {
         ...def,
         keys,
-        displayKeys: formatKeysForDisplay(keys),
+        displayKeys:
+          def.id === "tab.switchTo"
+            ? formatIndexedKeysForDisplay(keys)
+            : formatKeysForDisplay(keys),
         isCustom: def.id in overrides,
       };
     });
@@ -146,7 +151,10 @@ export function KeyboardShortcutsTab() {
         return;
       }
 
-      const combo = keyEventToHotkeyString(e);
+      const combo =
+        recordingId === "tab.switchTo"
+          ? keyEventToIndexedHotkeyString(e)
+          : keyEventToHotkeyString(e);
       if (combo) {
         setPendingKeys(combo);
       }
@@ -257,7 +265,11 @@ function ShortcutRow({
   recorderRef,
   t,
 }: ShortcutRowProps) {
-  const keysToDisplay = pendingKeys ? formatKeysForDisplay(pendingKeys) : shortcut.displayKeys;
+  const keysToDisplay = pendingKeys
+    ? shortcut.id === "tab.switchTo"
+      ? formatIndexedKeysForDisplay(pendingKeys)
+      : formatKeysForDisplay(pendingKeys)
+    : shortcut.displayKeys;
   const keyParts = keysToDisplay.split("+").filter(Boolean);
 
   return (

--- a/src/components/settings/KeyboardShortcutsTab.tsx
+++ b/src/components/settings/KeyboardShortcutsTab.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MdEdit, MdRefresh, MdSearch } from "react-icons/md";
+import { toast } from "sonner";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { useApp } from "@/context/AppContext";
 import {
   formatIndexedKeysForDisplay,
   formatKeysForDisplay,
+  isValidIndexedShortcutTemplate,
   keyEventToHotkeyString,
-  keyEventToIndexedHotkeyString,
   resolveKeys,
   SHORTCUT_CATEGORIES,
   SHORTCUT_REGISTRY,
@@ -135,6 +136,23 @@ export function KeyboardShortcutsTab() {
     updateAppSettings({ keybindings: {} });
   };
 
+  const handleIndexedShortcutCapture = useCallback(
+    (combo: string) => {
+      if (isValidIndexedShortcutTemplate(combo)) {
+        const next = { ...overrides, "tab.switchTo": combo };
+        updateAppSettings({ keybindings: next });
+      } else {
+        const next = { ...overrides };
+        delete next["tab.switchTo"];
+        updateAppSettings({ keybindings: next });
+        toast.error(t("settings.keybindingsIndexedInvalid"));
+      }
+      setRecordingId(null);
+      setPendingKeys(null);
+    },
+    [overrides, updateAppSettings, t],
+  );
+
   useEffect(() => {
     if (!recordingId) return;
 
@@ -151,18 +169,25 @@ export function KeyboardShortcutsTab() {
         return;
       }
 
-      const combo =
-        recordingId === "tab.switchTo"
-          ? keyEventToIndexedHotkeyString(e)
-          : keyEventToHotkeyString(e);
+      const combo = keyEventToHotkeyString(e);
       if (combo) {
-        setPendingKeys(combo);
+        if (recordingId === "tab.switchTo") {
+          handleIndexedShortcutCapture(combo);
+        } else {
+          setPendingKeys(combo);
+        }
       }
     };
 
     window.addEventListener("keydown", handleKeyDown, true);
     return () => window.removeEventListener("keydown", handleKeyDown, true);
-  }, [recordingId, pendingKeys, handleCancelRecording, handleConfirmRecording]);
+  }, [
+    recordingId,
+    pendingKeys,
+    handleCancelRecording,
+    handleConfirmRecording,
+    handleIndexedShortcutCapture,
+  ]);
 
   useEffect(() => {
     if (!recordingId) return;
@@ -276,8 +301,8 @@ function ShortcutRow({
     <div
       ref={recorderRef}
       className={`flex flex-col gap-2 px-3 py-3 sm:flex-row sm:items-center sm:justify-between transition-colors ${
-        isRecording ? "bg-primary/5 ring-1 ring-inset ring-primary/20 rounded-lg" : ""
-      }`}
+        isRecording && shortcut.id === "tab.switchTo" ? "sm:flex-wrap" : ""
+      } ${isRecording ? "bg-primary/5 ring-1 ring-inset ring-primary/20 rounded-lg" : ""}`}
     >
       <div className="flex items-center gap-2 min-w-0">
         <span className="text-sm text-foreground truncate">{t(shortcut.labelKey)}</span>
@@ -366,6 +391,11 @@ function ShortcutRow({
           </>
         )}
       </div>
+      {isRecording && shortcut.id === "tab.switchTo" && (
+        <p className="w-full text-xs text-muted-foreground">
+          {t("settings.keybindingsIndexedHint")}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -30,7 +30,7 @@ import {
   sendSessionInput,
   sendSessionInputWithSync,
 } from "@/lib/sessionInput";
-import { matchesKeyEvent } from "@/lib/shortcutRegistry";
+import { matchesKeyEvent, resolveIndexedKeys } from "@/lib/shortcutRegistry";
 import { registerTerminalContextProvider } from "@/lib/terminalContext";
 import {
   applyTerminalInputData,
@@ -698,9 +698,9 @@ export default function XTerminal({
 
     let lastSelection = "";
 
-    const kb = terminalAppSettings.keybindings;
     terminal.attachCustomKeyEventHandler((e) => {
       if (e.type !== "keydown") return true;
+      const kb = terminalAppSettingsRef.current.keybindings;
 
       if (matchesKeyEvent(resolveShortcutKeys("terminal.copy", kb), e)) {
         e.preventDefault();
@@ -753,16 +753,16 @@ export default function XTerminal({
         "view.openSettings",
         "terminal.manageSyncGroups",
         "special.lockScreen",
-        "tab.switchTo",
       ];
       for (const sid of swallowIds) {
-        if (sid === "tab.switchTo") {
-          if ((e.ctrlKey || e.metaKey) && !e.shiftKey && /^Digit[1-9]$/.test(e.code)) {
-            return false;
-          }
-          continue;
-        }
         if (matchesKeyEvent(resolveShortcutKeys(sid, kb), e)) {
+          return false;
+        }
+      }
+      for (let tabNumber = 1; tabNumber <= 9; tabNumber += 1) {
+        if (
+          matchesKeyEvent(resolveIndexedKeys(resolveShortcutKeys("tab.switchTo", kb), tabNumber), e)
+        ) {
           return false;
         }
       }

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -368,6 +368,9 @@ function preserveAppSettingsReferences(prev: AppSettings, next: AppSettings): Ap
     ? prev.cloud_sync
     : next.cloud_sync;
   const ui = areSettingsValuesEqual(prev.ui, next.ui) ? prev.ui : next.ui;
+  const keybindings = areSettingsValuesEqual(prev.keybindings, next.keybindings)
+    ? prev.keybindings
+    : next.keybindings;
 
   if (
     general === prev.general &&
@@ -382,7 +385,8 @@ function preserveAppSettingsReferences(prev: AppSettings, next: AppSettings): Ap
     diagnostics === prev.diagnostics &&
     ai === prev.ai &&
     cloudSync === prev.cloud_sync &&
-    ui === prev.ui
+    ui === prev.ui &&
+    keybindings === prev.keybindings
   ) {
     return prev;
   }
@@ -402,6 +406,7 @@ function preserveAppSettingsReferences(prev: AppSettings, next: AppSettings): Ap
     ai,
     cloud_sync: cloudSync,
     ui,
+    keybindings,
   };
 }
 

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -1,6 +1,6 @@
 import { useHotkeys } from "react-hotkeys-hook";
 import { resolveShortcutKeys } from "@/hooks/useShortcutMap";
-import { MOD } from "@/lib/shortcutRegistry";
+import { MOD, resolveIndexedKeys } from "@/lib/shortcutRegistry";
 
 export { MOD };
 
@@ -36,15 +36,16 @@ export function useGlobalShortcuts(
   useHotkeys(k("tab.next"), cb.onNextTab, HOTKEY_OPTIONS);
   useHotkeys(k("tab.prev"), cb.onPrevTab, HOTKEY_OPTIONS);
 
-  useHotkeys("ctrl+1, meta+1", () => cb.onSwitchTab(0), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+2, meta+2", () => cb.onSwitchTab(1), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+3, meta+3", () => cb.onSwitchTab(2), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+4, meta+4", () => cb.onSwitchTab(3), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+5, meta+5", () => cb.onSwitchTab(4), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+6, meta+6", () => cb.onSwitchTab(5), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+7, meta+7", () => cb.onSwitchTab(6), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+8, meta+8", () => cb.onSwitchTab(7), HOTKEY_OPTIONS);
-  useHotkeys("ctrl+9, meta+9", () => cb.onSwitchTab(-1), HOTKEY_OPTIONS);
+  const switchTabKeys = k("tab.switchTo");
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 1), () => cb.onSwitchTab(0), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 2), () => cb.onSwitchTab(1), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 3), () => cb.onSwitchTab(2), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 4), () => cb.onSwitchTab(3), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 5), () => cb.onSwitchTab(4), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 6), () => cb.onSwitchTab(5), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 7), () => cb.onSwitchTab(6), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 8), () => cb.onSwitchTab(7), HOTKEY_OPTIONS);
+  useHotkeys(resolveIndexedKeys(switchTabKeys, 9), () => cb.onSwitchTab(-1), HOTKEY_OPTIONS);
 
   useHotkeys(k("view.toggleLeftSidebar"), cb.onToggleLeftSidebar, HOTKEY_OPTIONS);
   useHotkeys(k("view.toggleRightSidebar"), cb.onToggleRightSidebar, HOTKEY_OPTIONS);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -973,6 +973,8 @@
     "keybindings": "Keyboard Shortcuts",
     "keybindingsConflict": "Already used by: {{name}}",
     "keybindingsCustom": "Custom",
+    "keybindingsIndexedHint": "Press the shortcut key and the number 1 key.",
+    "keybindingsIndexedInvalid": "The setting failed and has been reset to the default.",
     "keybindingsRecording": "Press key combination...",
     "keybindingsReset": "Reset to default",
     "keybindingsResetAll": "Reset All",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -973,6 +973,8 @@
     "keybindings": "快捷键",
     "keybindingsConflict": "已被占用: {{name}}",
     "keybindingsCustom": "自定义",
+    "keybindingsIndexedHint": "按下快捷键和数字1键",
+    "keybindingsIndexedInvalid": "设置失败，已恢复默认值。",
     "keybindingsRecording": "请按下快捷键组合...",
     "keybindingsReset": "恢复默认",
     "keybindingsResetAll": "全部重置",

--- a/src/lib/shortcutRegistry.ts
+++ b/src/lib/shortcutRegistry.ts
@@ -198,6 +198,39 @@ export function formatKeysForDisplay(keys: string): string {
     .join("+");
 }
 
+/** Format the tab index shortcut using only the configurable prefix, since the label supplies 1-9. */
+export function formatIndexedKeysForDisplay(keys: string): string {
+  const first = keys.split(",")[0].trim();
+  const prefix = first.replace(/\+(?:1-9|[1-9])$/i, "");
+  return formatKeysForDisplay(prefix || first);
+}
+
+/** Expand a tab index shortcut template into concrete key combinations for a numbered tab. */
+export function resolveIndexedKeys(keys: string, tabNumber: number): string {
+  const digit = String(tabNumber);
+  return keys
+    .split(",")
+    .map((combo) => {
+      const trimmed = combo.trim();
+      if (/(?:1-9|[1-9])$/i.test(trimmed)) {
+        return trimmed.replace(/(?:1-9|[1-9])$/i, digit);
+      }
+      if (isModifierOnlyCombo(trimmed)) {
+        return `${trimmed}+${digit}`;
+      }
+      return tabNumber === 1 ? trimmed : "";
+    })
+    .filter(Boolean)
+    .join(", ");
+}
+
+function isModifierOnlyCombo(combo: string): boolean {
+  return combo
+    .split("+")
+    .map((key) => key.trim().toLowerCase())
+    .every((key) => ["ctrl", "meta", "shift", "alt"].includes(key));
+}
+
 function formatSingleKey(key: string): string {
   const lower = key.toLowerCase();
   if (lower === "ctrl" || lower === "meta") return MOD;
@@ -239,6 +272,21 @@ export function keyEventToHotkeyString(e: KeyboardEvent): string {
     const ctrlCombo = ["ctrl", ...parts].join("+");
     const metaCombo = ["meta", ...parts].join("+");
     return `${ctrlCombo}, ${metaCombo}`;
+  }
+  return parts.join("+");
+}
+
+/** Capture a numbered-tab shortcut prefix, including a modifier key pressed on its own. */
+export function keyEventToIndexedHotkeyString(e: KeyboardEvent): string {
+  const combo = keyEventToHotkeyString(e);
+  if (combo) return combo;
+  if (!/^(Control|Meta|Alt|Shift)(Left|Right)?$/.test(e.code)) return "";
+
+  const parts: string[] = [];
+  if (e.shiftKey) parts.push("shift");
+  if (e.altKey) parts.push("alt");
+  if (e.ctrlKey || e.metaKey) {
+    return `${["ctrl", ...parts].join("+")}, ${["meta", ...parts].join("+")}`;
   }
   return parts.join("+");
 }

--- a/src/lib/shortcutRegistry.ts
+++ b/src/lib/shortcutRegistry.ts
@@ -198,11 +198,10 @@ export function formatKeysForDisplay(keys: string): string {
     .join("+");
 }
 
-/** Format the tab index shortcut using only the configurable prefix, since the label supplies 1-9. */
+/** Format the tab index shortcut as its generated range, e.g. `Ctrl+1-9`. */
 export function formatIndexedKeysForDisplay(keys: string): string {
   const first = keys.split(",")[0].trim();
-  const prefix = first.replace(/\+(?:1-9|[1-9])$/i, "");
-  return formatKeysForDisplay(prefix || first);
+  return formatKeysForDisplay(first.replace(/\+1$/i, "+1-9"));
 }
 
 /** Expand a tab index shortcut template into concrete key combinations for a numbered tab. */
@@ -222,6 +221,25 @@ export function resolveIndexedKeys(keys: string, tabNumber: number): string {
     })
     .filter(Boolean)
     .join(", ");
+}
+
+/** A numbered-tab template must be a chord whose captured terminal key is `1`. */
+export function isValidIndexedShortcutTemplate(keys: string): boolean {
+  const combos = keys
+    .split(",")
+    .map((combo) => combo.trim())
+    .filter(Boolean);
+
+  return (
+    combos.length > 0 &&
+    combos.every((combo) => {
+      const parts = combo
+        .split("+")
+        .map((key) => key.trim().toLowerCase())
+        .filter(Boolean);
+      return parts.length > 1 && parts[parts.length - 1] === "1";
+    })
+  );
 }
 
 function isModifierOnlyCombo(combo: string): boolean {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -41,6 +41,7 @@ import { TerminalTab } from "@/components/settings/TerminalTab";
 import { TransferTab } from "@/components/settings/TransferTab";
 import { TranslationTab } from "@/components/settings/TranslationTab";
 import { Button } from "@/components/ui/button";
+import { Toaster } from "@/components/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AppContext, useApp } from "@/context/AppContext";
 import { SettingsDraftContext } from "@/context/SettingsDraftContext";
@@ -572,6 +573,7 @@ export default function SettingsPage() {
               </div>
             </div>
           </div>
+          <Toaster position="top-center" offset={{ top: 48 }} />
         </AppContext.Provider>
       </SettingsDraftContext.Provider>
     </div>


### PR DESCRIPTION
Fixes the tab switching keybinding issue reported in #4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables fully customizable tab switching shortcuts. Users can set a prefix for 1–9, switching applies to the active split, and settings now validate the template with clear guidance.

- New Features
  - `tab.switchTo` is configurable; digits 1–9 are resolved at runtime with `resolveIndexedKeys`.
  - Shortcut recorder/display supports indexed prefixes and shows the prefix only; invalid templates reset to default with a hint and `sonner` toast.
  - Global and terminal handlers use the configured prefix instead of hard-coded `Ctrl/Meta + number`.

- Bug Fixes
  - Tab switching targets the active split leaf, not the global tab list.
  - Terminal reads the latest keybindings from settings to avoid stale handlers.
  - Terminal swallows custom tab-switch keystrokes so they don’t reach the shell/OS.

<sup>Written for commit f5e799ce85f1a0d0212638ca020f072331ae3e4b. Summary will update on new commits. <a href="https://cubic.dev/pr/nyakang/nyaterm/pull/13?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

