### PR TITLE
fix(window): prevent modal overlay from remaining after child window close

### DIFF
--- a/src/hooks/useModalChildWindows.ts
+++ b/src/hooks/useModalChildWindows.ts
@@ -1,25 +1,54 @@
 import { listen } from "@tauri-apps/api/event";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   bounceTopModalWindow,
+  getOpenModalChildWindowLabels,
   isModalChildLabel,
+  prepareForModalChildClose,
   syncMainWindowModalState,
 } from "@/lib/windowManager";
 
 export function useModalChildWindows() {
-  const [modalChildWindowCount, setModalChildWindowCount] = useState(0);
+  const [modalChildWindowLabels, setModalChildWindowLabels] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const closingLabelsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
+    const refreshOpenModalChildWindows = async () => {
+      const labels = await getOpenModalChildWindowLabels().catch(() => []);
+      setModalChildWindowLabels(
+        new Set(labels.filter((label) => !closingLabelsRef.current.has(label))),
+      );
+      await syncMainWindowModalState().catch(() => {});
+    };
+
+    void refreshOpenModalChildWindows();
+
     const unsubs = [
       listen<{ label: string }>("child-window-opened", ({ payload }) => {
         if (!isModalChildLabel(payload.label)) return;
-        setModalChildWindowCount((count) => count + 1);
-        void syncMainWindowModalState();
+        closingLabelsRef.current.delete(payload.label);
+        setModalChildWindowLabels((labels) => {
+          const nextLabels = new Set(labels);
+          nextLabels.add(payload.label);
+          return nextLabels;
+        });
+        void refreshOpenModalChildWindows();
       }),
       listen<{ label: string }>("child-window-closed", ({ payload }) => {
         if (!isModalChildLabel(payload.label)) return;
-        setModalChildWindowCount((count) => Math.max(0, count - 1));
-        void syncMainWindowModalState();
+        closingLabelsRef.current.add(payload.label);
+        setModalChildWindowLabels((labels) => {
+          const nextLabels = new Set(labels);
+          nextLabels.delete(payload.label);
+          return nextLabels;
+        });
+        void prepareForModalChildClose(payload.label);
+        window.setTimeout(() => {
+          closingLabelsRef.current.delete(payload.label);
+          void refreshOpenModalChildWindows();
+        }, 250);
       }),
     ];
 
@@ -29,6 +58,8 @@ export function useModalChildWindows() {
       });
     };
   }, []);
+
+  const modalChildWindowCount = modalChildWindowLabels.size;
 
   useEffect(() => {
     let unlistenFocusChanged: (() => void) | undefined;

--- a/src/lib/windowManager.ts
+++ b/src/lib/windowManager.ts
@@ -49,9 +49,18 @@ async function getMainWindow() {
 
 async function getOpenModalChildWindows() {
   const windows = await WebviewWindow.getAll();
-  return windows.filter(
+  const modalWindows = windows.filter(
     (window) => window.label !== MAIN_WINDOW_LABEL && isModalChildLabel(window.label),
   );
+  const visibleStates = await Promise.all(
+    modalWindows.map((window) => window.isVisible().catch(() => false)),
+  );
+  return modalWindows.filter((_, index) => visibleStates[index]);
+}
+
+export async function getOpenModalChildWindowLabels() {
+  const windows = await getOpenModalChildWindows();
+  return windows.map((window) => window.label);
 }
 
 async function setMainWindowModalBlocking(mainWindow: TauriWindow, hasModalChild: boolean) {
@@ -100,7 +109,7 @@ function attachChildWindowDestroyedHandler(label: string, win: WebviewWindow) {
     registeredDestroyedHandlers.delete(label);
     readyChildWindowLabels.delete(label);
     emit("child-window-closed", { label });
-    void syncMainWindowModalState();
+    void prepareForModalChildClose(label);
   });
 }
 
@@ -177,6 +186,7 @@ export async function openChildWindow(opts: ChildWindowOptions) {
     if (isVisible) {
       await existing.show().catch(() => {});
       await existing.setFocus().catch(() => {});
+      emit("child-window-opened", { label: opts.label });
       await syncMainWindowModalState().catch(() => {});
     } else {
       await revealChildWindow(existing, opts.label);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race condition where the modal overlay could stick after a modal child window closed. Now we track visible modal child windows by label and keep the main window’s modal state in sync on open/close.

- **Bug Fixes**
  - Track open modal child windows via a Set of labels, excluding those in a brief “closing” state to avoid stale counts.
  - Only count windows that are actually visible to prevent hidden or destroyed windows from keeping the overlay.
  - On close, call prepareForModalChildClose and refresh state after 250ms; on reveal/show, emit child-window-opened to resync.
  - Added getOpenModalChildWindowLabels and an initial refresh to align state on hook mount.

<sup>Written for commit e8e1f10c2cdf10894fd9eec11eb672f0d4d05456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/nyakang/nyaterm/pull/32?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

