### PR TITLE
style(file-explorer): use Lucide icons for terminal path actions

### DIFF
--- a/src/components/panel/file-explorer/FileExplorerView.tsx
+++ b/src/components/panel/file-explorer/FileExplorerView.tsx
@@ -14,6 +14,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { LuClipboardPaste, LuFolderSync } from "react-icons/lu";
 import {
   MdArrowDropDown,
   MdArrowDropUp,
@@ -25,8 +26,6 @@ import {
   MdLink,
   MdNoteAdd,
   MdRefresh,
-  MdSend,
-  MdSync,
   MdSyncLock,
   MdUpload,
 } from "react-icons/md";
@@ -192,8 +191,9 @@ function FileExplorer({
   const autoSyncCwd = !!activeConnectionId && autoSyncConnectionIds.includes(activeConnectionId);
   const favoriteDirectoriesByConnection =
     appSettings.ui.file_explorer_favorite_dirs_by_connection_id ?? {};
-  const favoriteDirectories =
-    activeConnectionId ? (favoriteDirectoriesByConnection[activeConnectionId] ?? []) : [];
+  const favoriteDirectories = activeConnectionId
+    ? (favoriteDirectoriesByConnection[activeConnectionId] ?? [])
+    : [];
   const listScrollResetKey = `${activeSessionId ?? ""}:${currentPath}`;
   const listFilterResetKey = `${fileSearchQuery}:${fileSortMode.column}:${fileSortMode.direction}`;
 
@@ -1940,7 +1940,7 @@ function FileExplorer({
               {t("fileExplorer.copyDirPath")}
             </ContextMenuItem>
             <ContextMenuItem onClick={handleSendCurrentPathToTerminal}>
-              <MdSend className="mr-2 h-4 w-4" />
+              <LuClipboardPaste className="mr-2 h-4 w-4" />
               {t("fileExplorer.sendDirPathToTerminal")}
             </ContextMenuItem>
             <ContextMenuSeparator />
@@ -1984,7 +1984,7 @@ function FileExplorer({
                     onClick={handleSyncCwd}
                     disabled={!cwdTrackingActive}
                   >
-                    <MdSync className="h-[0.875rem] w-[0.875rem]" />
+                    <LuFolderSync className="h-[0.875rem] w-[0.875rem]" />
                   </Button>
                 </span>
               </TooltipTrigger>
@@ -2034,7 +2034,7 @@ function FileExplorer({
                       }
                     }}
                   >
-                    <MdSend className="h-[0.875rem] w-[0.875rem]" />
+                    <LuClipboardPaste className="h-[0.875rem] w-[0.875rem]" />
                   </Button>
                 </span>
               </TooltipTrigger>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched File Explorer terminal path actions to Lucide icons for clearer meaning and consistency.
Replaced the “send dir path to terminal” icon with a clipboard paste icon and the “sync CWD” icon with a folder sync icon in both the context menu and toolbar.

<sup>Written for commit 06dd6b3963c7ad42accfe7e5eb1727f7be846d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/nyakang/nyaterm/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

