### PR TITLE
fix: fix the issue of failing to open directories in the downloaded file list

### DIFF
--- a/src-tauri/src/cmd/app.rs
+++ b/src-tauri/src/cmd/app.rs
@@ -260,6 +260,19 @@ fn open_folder(path: &Path) -> AppResult<()> {
         ));
     }
 
-    open::that(path)
-        .map_err(|error| AppError::Config(format!("Failed to open target directory: {error}")))
+    #[cfg(windows)]
+    {
+        std::process::Command::new("explorer")
+            .arg(path.as_os_str())
+            .spawn()
+            .map_err(|error| {
+                AppError::Config(format!("Failed to open target directory: {error}"))
+            })?;
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        open::that(path)
+            .map_err(|error| AppError::Config(format!("Failed to open target directory: {error}")))
+    }
 }


### PR DESCRIPTION
When downloading remote files to the local, if you right-click on the download list to open the target directory, an error will be reported: The requested operation requires elevation. The reason for the issue is that open::that(path) uses ShellExecuteW on Windows, which under certain system configurations can trigger a UAC (User Account Control) elevation request (OS error 740). On Windows, it is recommended to use explorer.exe to open the directory instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Open target directory” action in the downloaded file list on Windows by launching Explorer directly to avoid UAC elevation errors. Behavior on macOS/Linux is unchanged.

- **Bug Fixes**
  - On Windows, spawn `explorer` with the target path instead of calling `open::that(path)` to prevent OS error 740.
  - On non-Windows platforms, continue using `open::that(path)`.

<sup>Written for commit 86728ef155c833603da28b49b03797f07660ceee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/nyakang/nyaterm/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

