### PR TITLE
fix: improve terminal copy to clipboard

### DIFF
--- a/src-tauri/src/cmd/clipboard.rs
+++ b/src-tauri/src/cmd/clipboard.rs
@@ -40,6 +40,27 @@ pub async fn read_clipboard_text() -> Option<String> {
 }
 
 #[tauri::command]
+pub async fn write_clipboard_text(text: String) -> Result<(), String> {
+    let result = tokio::time::timeout(
+        CLIPBOARD_TIMEOUT,
+        tokio::task::spawn_blocking(move || {
+            let mut clipboard = arboard::Clipboard::new()
+                .map_err(|err| format!("failed to open clipboard: {err}"))?;
+            clipboard
+                .set_text(text)
+                .map_err(|err| format!("failed to write clipboard text: {err}"))
+        }),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(result)) => result,
+        Ok(Err(err)) => Err(format!("clipboard write task failed: {err}")),
+        Err(_) => Err("clipboard write timed out".to_string()),
+    }
+}
+
+#[tauri::command]
 pub async fn read_clipboard_path_payload() -> Result<Option<ClipboardPathPayload>, String> {
     let result = tokio::time::timeout(
         CLIPBOARD_TIMEOUT,

--- a/src-tauri/src/config/settings/interaction.rs
+++ b/src-tauri/src/config/settings/interaction.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub struct InteractionSettings {
     #[serde(default = "default_true")]
     pub copy_on_select: bool,
+    #[serde(default)]
+    pub allow_osc52_clipboard_write: bool,
     #[serde(default = "default_true")]
     pub right_click_paste: bool,
     #[serde(default = "default_true")]
@@ -69,6 +71,7 @@ impl Default for InteractionSettings {
     fn default() -> Self {
         Self {
             copy_on_select: false,
+            allow_osc52_clipboard_write: false,
             right_click_paste: false,
             command_suggestions_enabled: true,
             command_suggestion_min_chars: default_command_suggestion_min_chars(),
@@ -96,6 +99,7 @@ mod tests {
         assert_eq!(settings.tab_double_click_action, "disconnect_session");
         assert_eq!(settings.tab_middle_click_action, "rename_tab");
         assert_eq!(settings.tab_right_click_action, "none");
+        assert!(!settings.allow_osc52_clipboard_write);
         assert!(!settings.alt_as_meta);
         assert!(!settings.mac_ime_compatibility);
     }
@@ -117,6 +121,7 @@ mod tests {
         assert_eq!(settings.tab_middle_click_action, "rename_tab");
         assert_eq!(settings.tab_right_click_action, "none");
         assert_eq!(settings.duplicate_session_command_delay_ms, 1000);
+        assert!(!settings.allow_osc52_clipboard_write);
         assert!(!settings.alt_as_meta);
         assert!(!settings.mac_ime_compatibility);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ pub fn run() {
             cmd::ai::append_ai_audit,
             cmd::ai::get_ai_audit_logs,
             cmd::clipboard::read_clipboard_text,
+            cmd::clipboard::write_clipboard_text,
             cmd::clipboard::read_clipboard_path_payload,
             cmd::clipboard::upload_clipboard_image_to_ssh,
             cmd::log::append_frontend_logs,

--- a/src/components/settings/InteractionTab.tsx
+++ b/src/components/settings/InteractionTab.tsx
@@ -63,6 +63,16 @@ export function InteractionTab() {
           />
         </SettingRow>
 
+        <SettingRow
+          label={t("settings.allowOsc52ClipboardWrite")}
+          desc={t("settings.allowOsc52ClipboardWriteDesc")}
+        >
+          <SettingSwitch
+            checked={interaction.allow_osc52_clipboard_write}
+            onChange={(v) => updateInteraction({ allow_osc52_clipboard_write: v })}
+          />
+        </SettingRow>
+
         <SettingRow label={t("settings.rightClickPaste")} desc={t("settings.rightClickPasteDesc")}>
           <SettingSwitch
             checked={interaction.right_click_paste}

--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -28,6 +28,7 @@ import {
   readClipboardPathPayload,
   readClipboardText,
   uploadClipboardImageToSsh,
+  writeClipboardText,
 } from "@/lib/clipboard";
 import {
   commandStartsSuggestionSuppressingProgram,
@@ -98,6 +99,7 @@ import { createZmodemEventHandler, type ZmodemEventPayload } from "./zmodemTermi
 import "@xterm/xterm/css/xterm.css";
 
 const BACKSPACE_INPUT = "\x7f";
+const OSC52_MAX_DECODED_BYTES = 1024 * 1024;
 
 interface XTermInternalTrimSource {
   _core?: {
@@ -139,6 +141,26 @@ function buildClipboardPathPasteText(
   const paths = payload.paths.map((path) => path.trim()).filter((path) => !!path);
   if (paths.length === 0) return null;
   return paths.map(quotePastedPath).join(" ");
+}
+
+function decodeOsc52ClipboardText(data: string): string | null {
+  const separatorIndex = data.indexOf(";");
+  if (separatorIndex === -1) return null;
+
+  const payload = data.slice(separatorIndex + 1).replace(/\s/g, "");
+  if (payload === "?") return null;
+
+  let binary = "";
+  try {
+    binary = atob(payload);
+  } catch {
+    return null;
+  }
+
+  if (binary.length > OSC52_MAX_DECODED_BYTES) return null;
+
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
 }
 
 interface SessionCommandAcceptedEvent {
@@ -1104,7 +1126,7 @@ export default function XTerminal({
       if (matchesKeyEvent(resolveShortcutKeys("terminal.copy", kb), e)) {
         e.preventDefault();
         const sel = terminal.getSelection();
-        if (sel) navigator.clipboard.writeText(sel).catch(() => {});
+        if (sel) writeClipboardText(sel).catch(() => {});
         return false;
       }
       if (matchesKeyEvent(resolveShortcutKeys("terminal.paste", kb), e)) {
@@ -1196,6 +1218,18 @@ export default function XTerminal({
       }
 
       return false;
+    });
+
+    const clipboardOscDisposable = terminal.parser.registerOscHandler(52, (data) => {
+      if (!terminalAppSettingsRef.current?.interaction?.allow_osc52_clipboard_write) {
+        return true;
+      }
+
+      const text = decodeOsc52ClipboardText(data);
+      if (text === null) return true;
+
+      void writeClipboardText(text).catch(() => {});
+      return true;
     });
 
     const writeParsedDisposable = terminal.onWriteParsed(() => {
@@ -1861,7 +1895,7 @@ export default function XTerminal({
       }
       if (terminalAppSettingsRef.current?.interaction?.copy_on_select) {
         if (text) {
-          navigator.clipboard.writeText(text).catch(() => {});
+          writeClipboardText(text).catch(() => {});
         }
       }
     });
@@ -1919,6 +1953,11 @@ export default function XTerminal({
               }
             }
           }
+        }
+
+        if (terminalAppSettingsRef.current?.interaction?.copy_on_select) {
+          const sel = terminal.getSelection();
+          if (sel) writeClipboardText(sel).catch(() => {});
         }
         return;
       }
@@ -1997,6 +2036,7 @@ export default function XTerminal({
       resetCredentialAutofill();
 
       oscDisposable.dispose();
+      clipboardOscDisposable.dispose();
       writeParsedDisposable.dispose();
       dataDisposable.dispose();
       resizeDisposable.dispose();

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -262,6 +262,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   },
   interaction: {
     copy_on_select: false,
+    allow_osc52_clipboard_write: false,
     right_click_paste: false,
     command_suggestions_enabled: true,
     command_suggestion_min_chars: DEFAULT_COMMAND_SUGGESTION_MIN_CHARS,

--- a/src/context/ChildAppProvider.tsx
+++ b/src/context/ChildAppProvider.tsx
@@ -89,6 +89,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   },
   interaction: {
     copy_on_select: false,
+    allow_osc52_clipboard_write: false,
     right_click_paste: false,
     command_suggestions_enabled: true,
     command_suggestion_min_chars: DEFAULT_COMMAND_SUGGESTION_MIN_CHARS,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1248,6 +1248,8 @@
     "aliyunDriveRefreshTokenDesc": "Long-lived AliyunDrive refresh token used by OpenDAL to refresh access.",
     "aliyunDriveType": "Drive Type",
     "aliyunDriveTypeDesc": "Usually resource. Use backup when your AliyunDrive app is configured for backup drive access.",
+    "allowOsc52ClipboardWrite": "Allow OSC 52 Clipboard Writes",
+    "allowOsc52ClipboardWriteDesc": "Allow terminal output from remote apps to write to the local clipboard.",
     "altAsMeta": "Use Option as Meta/Alt",
     "altAsMetaDesc": "On macOS, send ESC + key for Option shortcuts like Option+f instead of entering special characters such as ƒ.",
     "apiKey": "API Key",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1248,6 +1248,8 @@
     "aliyunDriveRefreshTokenDesc": "OpenDAL 用于刷新访问权限的 AliyunDrive 长期 Refresh Token。",
     "aliyunDriveType": "Drive Type",
     "aliyunDriveTypeDesc": "通常填写 resource。如果你的 AliyunDrive 应用配置为备份盘访问，可填写 backup。",
+    "allowOsc52ClipboardWrite": "允许 OSC 52 写入剪贴板",
+    "allowOsc52ClipboardWriteDesc": "允许远程应用通过终端输出写入本地剪贴板。",
     "altAsMeta": "将 Option 作为 Meta/Alt 键",
     "altAsMetaDesc": "在 macOS 上，Option+f 等快捷键发送 ESC + 按键，而不是输入 ƒ 等特殊字符。",
     "apiKey": "API 密钥",

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -13,6 +13,14 @@ export async function readClipboardText(): Promise<string> {
   return text ?? "";
 }
 
+export async function writeClipboardText(text: string): Promise<void> {
+  try {
+    await invoke<void>("write_clipboard_text", { text });
+  } catch {
+    await navigator.clipboard.writeText(text);
+  }
+}
+
 export async function readClipboardPathPayload(): Promise<ClipboardPathPayload | null> {
   return invoke<ClipboardPathPayload | null>("read_clipboard_path_payload");
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1043,6 +1043,7 @@ export interface TunnelConfig {
 
 export interface InteractionSettings {
   copy_on_select: boolean;
+  allow_osc52_clipboard_write: boolean;
   right_click_paste: boolean;
   command_suggestions_enabled: boolean;
   command_suggestion_min_chars: number;


### PR DESCRIPTION
https://github.com/nyakang/nyaterm/issues/202

Root Cause: Two separate issues

1. Mouse tracking mode from tmux/helix/zellij (affects all platforms)

When tmux, helix, or zellij are running, they enable mouse tracking via ANSI escape sequences (\033[?1000h, \033[?1002h, etc.). In this mode, xterm.js forwards mouse drag events to the remote application as escape sequences instead of creating a local text selection.

The copy-on-select handler at XTerminal.tsx:1836-1846 relies on xterm.js's onSelectionChange event:

const selectionDisposable = terminal.onSelectionChange(() => {
  const text = terminal.getSelection();
  if (terminalAppSettingsRef.current?.interaction?.copy_on_select) {
    if (text) {
      navigator.clipboard.writeText(text).catch(() => {});
    }
  }
});

Since no local selection is created when mouse tracking is active, onSelectionChange never fires with text → copy-on-select silently does nothing. The user has to hold Shift while dragging to force local selection bypass in xterm.js.

2. Silent clipboard write failure on Windows/WebView2

Even when Shift+drag does create a selection, the clipboard write at line 1843:
navigator.clipboard.writeText(text).catch(() => {});
uses the browser Web Clipboard API with .catch(() => {}) silently swallowing all errors. On Windows with WebView2, navigator.clipboard.writeText() may fail because:
- WebView2 enforces stricter user-gesture requirements than macOS WebKit
- The onSelectionChange callback might not count as a direct user gesture in WebView2's security model

The app has read_clipboard_text as a native Tauri command using arboard (src-tauri/src/cmd/clipboard.rs:26), but there's no corresponding write_clipboard_text command — so there's no native fallback path.

Fix

Two things to address:

1. Add a native write_clipboard_text Tauri command in src-tauri/src/cmd/clipboard.rs using arboard, then use it in the copy-on-select path instead of navigator.clipboard.writeText(). This bypasses WebView2's clipboard restrictions.
2. Also call clipboard write in the handleTerminalMouseUp handler for the mouseup event (not just in onSelectionChange), to handle the case where selection is read after mouse release:
// in handleTerminalMouseUp, after the left-button block
if (terminalAppSettingsRef.current?.interaction?.copy_on_select) {
  const sel = terminal.getSelection();
  if (sel) writeClipboardText(sel);
}

The mouse tracking issue itself is inherent to xterm.js — there's no clean way to distinguish "user drag for selection" from "mouse event intended for app" without breaking the remote app's mouse input. Shift+drag is the intended escape hatch and should be documented.