### PR TITLE
fix: declare macOS local network usage

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>NyaTerm needs local network access to connect to SSH, Telnet, and network devices on your LAN.</string>
+</dict>
+</plist>

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -14,5 +14,11 @@
         "create": false
       }
     ]
+  },
+  "bundle": {
+    "macOS": {
+      "entitlements": "Entitlements.plist",
+      "infoPlist": "Info.plist"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fix macOS packaged app access to local network devices by declaring the required local network usage metadata and network client entitlement.

On newer macOS versions, packaged apps may fail to connect to LAN hosts such as SSH/Telnet devices with `No route to host (os error 65)` unless the app bundle declares local network usage and is signed with the proper network client entitlement. Dev mode and system terminal clients are unaffected because they do not run under the same packaged app identity.

## Changes

- Add `NSLocalNetworkUsageDescription` to the macOS app bundle `Info.plist`
- Add `com.apple.security.network.client` to macOS entitlements
- Wire both files through `tauri.macos.conf.json`
- Keep the fix scoped to macOS bundle configuration only

No Rust SSH/Telnet connection logic is changed.

## Verification

- `plutil -lint src-tauri/Info.plist src-tauri/Entitlements.plist`
- Built an arm64 macOS DMG with ad-hoc signing for local validation
- Verified the packaged app contains:
  - `NSLocalNetworkUsageDescription`
  - `com.apple.security.network.client`
- Manually verified the installed macOS app can connect to a LAN SSH host after local network permission is granted