### PR TITLE
fix(terminal): prevent stale macOS trackpad selection

### DIFF
--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -39,6 +39,7 @@ import { detectCredentialPromptKind } from "@/lib/credentialAutofill";
 import { invoke } from "@/lib/invoke";
 import { hexLuminance } from "@/lib/keywordHighlightPresets";
 import { logger } from "@/lib/logger";
+import { isMacOS } from "@/lib/platform";
 import { openSendCommandPanel } from "@/lib/sendCommandPanelEvents";
 import {
   buildTerminalCommandInput,
@@ -1991,6 +1992,31 @@ export default function XTerminal({
       }
     };
 
+    const handleMacReleasedMouseMove = (e: MouseEvent) => {
+      if (!isMacOS || !primaryMouseDown || e.buttons !== 0) return;
+
+      primaryMouseDown = null;
+      e.stopImmediatePropagation();
+
+      // WKWebView can miss mouseup after a trackpad tap when three-finger drag is enabled.
+      // xterm listens on document while selecting, so synthesize the release there.
+      const syntheticMouseUp = new MouseEvent("mouseup", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 0,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        screenX: e.screenX,
+        screenY: e.screenY,
+        ctrlKey: e.ctrlKey,
+        metaKey: e.metaKey,
+        altKey: e.altKey,
+        shiftKey: e.shiftKey,
+      });
+      document.dispatchEvent(syntheticMouseUp);
+    };
+
     const handleTerminalPointerCancel = () => {
       resetTerminalPointerState({ clearSelection: true });
     };
@@ -2018,6 +2044,9 @@ export default function XTerminal({
     containerRef.current.addEventListener("pointercancel", handleTerminalPointerCancel);
     containerRef.current.addEventListener("mouseleave", handleTerminalMouseLeave);
     containerRef.current.addEventListener("dragstart", handleTerminalDragStart);
+    if (isMacOS) {
+      document.addEventListener("mousemove", handleMacReleasedMouseMove, true);
+    }
     window.addEventListener("blur", handleTerminalWindowBlur);
     document.addEventListener("visibilitychange", handleTerminalVisibilityChange);
     const containerEl = containerRef.current;
@@ -2042,6 +2071,9 @@ export default function XTerminal({
       containerEl.removeEventListener("pointercancel", handleTerminalPointerCancel);
       containerEl.removeEventListener("mouseleave", handleTerminalMouseLeave);
       containerEl.removeEventListener("dragstart", handleTerminalDragStart);
+      if (isMacOS) {
+        document.removeEventListener("mousemove", handleMacReleasedMouseMove, true);
+      }
       window.removeEventListener("blur", handleTerminalWindowBlur);
       document.removeEventListener("visibilitychange", handleTerminalVisibilityChange);
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);


### PR DESCRIPTION

Fixes a macOS trackpad issue where a light tap inside the terminal could leave xterm.js in a stale drag-selection state. This is easier to trigger when macOS three-finger drag is enabled: WKWebView may deliver a `mousedown` without the matching `mouseup`, so a later `mousemove` is interpreted by xterm as an active text selection drag.

This PR adds a small macOS-only guard in the terminal component. When a plain left-button press was recorded but a later `mousemove` reports `buttons === 0`, the app treats that as a stale release state, stops the stale move from reaching xterm, and dispatches a synthetic `mouseup` so xterm can clean up its document-level selection listeners.

## Changes

- Add a macOS-only stale mouse release guard for terminal mouse movement.
- Keep the workaround scoped to `XTerminal` and only register the document listener on macOS.
- Preserve normal terminal text selection because real drag selection still reports `event.buttons !== 0`.

## Testing

- Verified on macOS with trackpad tap / three-finger drag scenario.
- `./node_modules/.bin/biome check src/components/terminal/XTerminal.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check HEAD~1 HEAD`