### PR TITLE
fix(clipboard): keep arboard clipboard alive and enable wayland support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -1894,7 +1895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -1996,6 +1997,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -4079,6 +4086,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4819,6 +4835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5066,6 +5092,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+]
 
 [[package]]
 name = "phc"
@@ -5617,6 +5654,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -8359,6 +8405,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8761,6 +8818,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -9506,6 +9633,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -153,7 +153,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 rqrr = "0.9"
 serialport = "4"
 strip-ansi-escapes = "0.2"
-arboard = "3"
+arboard = { version = "3", features = ["wayland-data-control"] }
 opendal = { version = "0.58", default-features = false, features = [
     "executors-tokio",
     "reqwest-rustls-tls",

--- a/src-tauri/src/cmd/clipboard.rs
+++ b/src-tauri/src/cmd/clipboard.rs
@@ -4,36 +4,11 @@ use std::{
     borrow::Cow,
     fs,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, OnceLock},
+    sync::Arc,
     time::Duration,
 };
 
 const CLIPBOARD_TIMEOUT: Duration = Duration::from_millis(1000);
-
-static CLIPBOARD_STATE: OnceLock<Mutex<Option<arboard::Clipboard>>> = OnceLock::new();
-
-fn with_clipboard<F, R>(f: F) -> Result<R, String>
-where
-    F: FnOnce(&mut arboard::Clipboard) -> Result<R, arboard::Error>,
-{
-    let mutex = CLIPBOARD_STATE.get_or_init(|| Mutex::new(arboard::Clipboard::new().ok()));
-    let mut guard = mutex
-        .lock()
-        .map_err(|err| format!("failed to acquire clipboard lock: {err}"))?;
-    if guard.is_none() {
-        match arboard::Clipboard::new() {
-            Ok(clip) => {
-                *guard = Some(clip);
-            }
-            Err(err) => return Err(format!("failed to initialize clipboard: {err}")),
-        }
-    }
-    if let Some(ref mut clip) = *guard {
-        f(clip).map_err(|err| format!("clipboard operation failed: {err}"))
-    } else {
-        unreachable!()
-    }
-}
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -52,7 +27,8 @@ pub async fn read_clipboard_text() -> Option<String> {
     let result = tokio::time::timeout(
         CLIPBOARD_TIMEOUT,
         tokio::task::spawn_blocking(|| {
-            with_clipboard(|clipboard| clipboard.get_text()).ok()
+            let mut clipboard = arboard::Clipboard::new().ok()?;
+            clipboard.get_text().ok()
         }),
     )
     .await;
@@ -68,7 +44,11 @@ pub async fn write_clipboard_text(text: String) -> Result<(), String> {
     let result = tokio::time::timeout(
         CLIPBOARD_TIMEOUT,
         tokio::task::spawn_blocking(move || {
-            with_clipboard(|clipboard| clipboard.set_text(text))
+            let mut clipboard = arboard::Clipboard::new()
+                .map_err(|err| format!("failed to open clipboard: {err}"))?;
+            clipboard
+                .set_text(text)
+                .map_err(|err| format!("failed to write clipboard text: {err}"))
         }),
     )
     .await;
@@ -191,7 +171,11 @@ fn read_clipboard_image_to_temp_png() -> Result<Option<PathBuf>, String> {
 }
 
 fn read_clipboard_image_data_to_file() -> Result<Option<String>, String> {
-    let image = match with_clipboard(|clipboard| clipboard.get_image()) {
+    let mut clipboard = match arboard::Clipboard::new() {
+        Ok(clipboard) => clipboard,
+        Err(_) => return Ok(None),
+    };
+    let image = match clipboard.get_image() {
         Ok(image) => image,
         Err(_) => return Ok(None),
     };
@@ -356,7 +340,8 @@ fn is_supported_image_path(path: &Path) -> bool {
 
 #[cfg(not(target_os = "windows"))]
 fn read_clipboard_text_image_paths() -> Option<Vec<String>> {
-    let text = with_clipboard(|clipboard| clipboard.get_text()).ok()?;
+    let mut clipboard = arboard::Clipboard::new().ok()?;
+    let text = clipboard.get_text().ok()?;
     Some(parse_clipboard_text_image_paths(&text))
 }
 

--- a/src-tauri/src/cmd/clipboard.rs
+++ b/src-tauri/src/cmd/clipboard.rs
@@ -4,11 +4,36 @@ use std::{
     borrow::Cow,
     fs,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex, OnceLock},
     time::Duration,
 };
 
 const CLIPBOARD_TIMEOUT: Duration = Duration::from_millis(1000);
+
+static CLIPBOARD_STATE: OnceLock<Mutex<Option<arboard::Clipboard>>> = OnceLock::new();
+
+fn with_clipboard<F, R>(f: F) -> Result<R, String>
+where
+    F: FnOnce(&mut arboard::Clipboard) -> Result<R, arboard::Error>,
+{
+    let mutex = CLIPBOARD_STATE.get_or_init(|| Mutex::new(arboard::Clipboard::new().ok()));
+    let mut guard = mutex
+        .lock()
+        .map_err(|err| format!("failed to acquire clipboard lock: {err}"))?;
+    if guard.is_none() {
+        match arboard::Clipboard::new() {
+            Ok(clip) => {
+                *guard = Some(clip);
+            }
+            Err(err) => return Err(format!("failed to initialize clipboard: {err}")),
+        }
+    }
+    if let Some(ref mut clip) = *guard {
+        f(clip).map_err(|err| format!("clipboard operation failed: {err}"))
+    } else {
+        unreachable!()
+    }
+}
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -27,8 +52,7 @@ pub async fn read_clipboard_text() -> Option<String> {
     let result = tokio::time::timeout(
         CLIPBOARD_TIMEOUT,
         tokio::task::spawn_blocking(|| {
-            let mut clipboard = arboard::Clipboard::new().ok()?;
-            clipboard.get_text().ok()
+            with_clipboard(|clipboard| clipboard.get_text()).ok()
         }),
     )
     .await;
@@ -44,11 +68,7 @@ pub async fn write_clipboard_text(text: String) -> Result<(), String> {
     let result = tokio::time::timeout(
         CLIPBOARD_TIMEOUT,
         tokio::task::spawn_blocking(move || {
-            let mut clipboard = arboard::Clipboard::new()
-                .map_err(|err| format!("failed to open clipboard: {err}"))?;
-            clipboard
-                .set_text(text)
-                .map_err(|err| format!("failed to write clipboard text: {err}"))
+            with_clipboard(|clipboard| clipboard.set_text(text))
         }),
     )
     .await;
@@ -171,11 +191,7 @@ fn read_clipboard_image_to_temp_png() -> Result<Option<PathBuf>, String> {
 }
 
 fn read_clipboard_image_data_to_file() -> Result<Option<String>, String> {
-    let mut clipboard = match arboard::Clipboard::new() {
-        Ok(clipboard) => clipboard,
-        Err(_) => return Ok(None),
-    };
-    let image = match clipboard.get_image() {
+    let image = match with_clipboard(|clipboard| clipboard.get_image()) {
         Ok(image) => image,
         Err(_) => return Ok(None),
     };
@@ -340,8 +356,7 @@ fn is_supported_image_path(path: &Path) -> bool {
 
 #[cfg(not(target_os = "windows"))]
 fn read_clipboard_text_image_paths() -> Option<Vec<String>> {
-    let mut clipboard = arboard::Clipboard::new().ok()?;
-    let text = clipboard.get_text().ok()?;
+    let text = with_clipboard(|clipboard| clipboard.get_text()).ok()?;
     Some(parse_clipboard_text_image_paths(&text))
 }
 


### PR DESCRIPTION
# 合并说明 (Description)：

## 1. 问题背景与分析 (Problem Background & Analysis)

  在 Linux 环境下，通过右键复制文本时，剪切板无法在系统范围（如其他应用）中被成功读取，表现为 wl-paste         (Wayland) 或 xclip -o (X11) 无法获取更新，且日志中出现以下警告：

    WARN arboard::platform::linux::x11: Clipboard was dropped very quickly after writing (1ms); clipboard managers may not have seen the contents

- 所有权销毁问题：
  Linux/X11  的剪切板机制是“所有权模式”，只有当复制发生且拥有者应用保持活跃时，其他应用才能请求该数据。原先的 Rust 命令 write_clipboard_text 在调用后立即 Dropped 销毁了 arboard::Clipboard 实例，导致所有权立即失效，其他应用无法顺利粘帖。
- Wayland 隔离与同步失效：默认的 arboard 未启用 Wayland 支持，仅与 X11 交互，而现代 Linux 桌面多为  Wayland 环境。若未启用 native Wayland 剪切板读写，则无法与系统的标准 Wayland  剪切板（CLIPBOARD）直接互通，导致 wl-paste 读取失败。

## 2. 修复方案 (Solution)  
                                                                          
- 保持 Clipboard 实例常驻 (Rust 侧)：  
  在 src-tauri/src/cmd/clipboard.rs 中，通过使用全局 OnceLock<Mutex<Option<arboard::Clipboard>>>  维护一个长生命周期的剪切板实例。如此一来，当写入剪切板数据时，该实例将持续存在并持有所有权，确保其他应用能够成功获取内容。
- 启用原生 Wayland 剪切板支持 (Cargo 特性)：  
  在 src-tauri/Cargo.toml 中为 arboard 依赖项启用了 wayland-data-control 特性。这使得在 Wayland 桌面下运行时，arboard 会直接通过原生 Wayland 协议与系统剪切板进行读写（若非 Wayland  环境则会自动安全回退至 X11 后端），从而解决 wl-paste 不更新的问题。

## 3. 变更清单 (Key Changes)

- **Cargo.toml**：
  启用 arboard 的 wayland-data-control 特性：
    arboard = { version = "3", features = ["wayland-data-control"] }
- **Cargo.lock**：
  由依赖更新自动生成，引入了 wl-clipboard-rs 等 Wayland 依赖。
- **clipboard.rs**：
  - 声明全局常驻状态 static CLIPBOARD_STATE: OnceLock<Mutex<Option<arboard::Clipboard>>>。
  - 实现辅助函数 with_clipboard 以懒加载方式并安全地并发访问该剪切板实例。
  - 重构 read_clipboard_text、write_clipboard_text 等命令以配合常驻实例运行。


## 4. 测试与验证 (Verification)

- 本地在 Linux/Wayland 环境下测试：修改后复制时原先的 1ms dropped 警告消失。
- 复制内容后，wl-paste (Wayland 剪切板) 与 xclip -selection clipboard -o (X11 剪切板)均可同步并正确读取到最新复制的数据。
- 项目编译测试顺利通过，未引入任何破坏性代码或编译错误。