### PR TITLE
fix(window): avoid child window loading flash

### DIFF
--- a/src/ChildWindowRouter.tsx
+++ b/src/ChildWindowRouter.tsx
@@ -1,11 +1,12 @@
 import { emit } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { lazy, Suspense, useEffect } from "react";
+import { lazy, type ReactNode, Suspense, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   isModalChildLabel,
   prepareForModalChildClose,
   setOwnerMainWindowLabel,
+  signalChildWindowReady,
 } from "./lib/windowManager";
 
 const SettingsPage = lazy(() => import("./pages/SettingsPage"));
@@ -24,6 +25,18 @@ const PAGES: Record<string, React.ComponentType> = {
   "file-preview": FilePreviewPage,
 };
 
+function ReadyContent({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      void signalChildWindowReady();
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  return children;
+}
+
 export default function ChildWindowRouter({ windowType }: { windowType: string }) {
   const { t } = useTranslation();
   const Page = PAGES[windowType];
@@ -39,8 +52,6 @@ export default function ChildWindowRouter({ windowType }: { windowType: string }
     let programmaticClose = false;
     let lastFocusEmitAt = 0;
     const pageHandlesCloseRequested = windowType === "settings";
-
-    currentWindow.show().catch(() => {});
 
     if (!pageHandlesCloseRequested) {
       currentWindow
@@ -86,21 +97,19 @@ export default function ChildWindowRouter({ windowType }: { windowType: string }
 
   if (!Page) {
     return (
-      <div className="h-screen flex items-center justify-center text-muted-foreground">
-        {t("common.unknownWindowType")}: {windowType}
-      </div>
+      <ReadyContent>
+        <div className="h-screen flex items-center justify-center text-muted-foreground">
+          {t("common.unknownWindowType")}: {windowType}
+        </div>
+      </ReadyContent>
     );
   }
 
   return (
-    <Suspense
-      fallback={
-        <div className="h-screen flex items-center justify-center text-muted-foreground">
-          {t("common.loading")}
-        </div>
-      }
-    >
-      <Page />
+    <Suspense fallback={null}>
+      <ReadyContent>
+        <Page />
+      </ReadyContent>
     </Suspense>
   );
 }

--- a/src/context/ChildAppProvider.tsx
+++ b/src/context/ChildAppProvider.tsx
@@ -19,6 +19,7 @@ import i18n from "../i18n";
 import { invoke } from "../lib/invoke";
 import { logger, setLoggerLevel } from "../lib/logger";
 import { DEFAULT_TERMINAL_FONT_SIZE } from "../lib/terminalFontSize";
+import { signalChildWindowReady } from "../lib/windowManager";
 import { AppContext } from "./AppContext";
 
 const DEFAULT_APP_SETTINGS: AppSettings = {
@@ -285,6 +286,16 @@ export function ChildAppProvider({ children }: { children: ReactNode }) {
     }
   }, [appSettings.ui?.language]);
 
+  useEffect(() => {
+    if (!settingsLoaded || !lockStateLoaded || !isLocked) return;
+
+    const timeoutId = window.setTimeout(() => {
+      void signalChildWindowReady();
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [isLocked, lockStateLoaded, settingsLoaded]);
+
   useIdleLock(
     appSettings.security.enable_screen_lock ? appSettings.security.idle_lock_minutes : 0,
     isLocked,
@@ -417,12 +428,13 @@ export function ChildAppProvider({ children }: { children: ReactNode }) {
     ],
   );
 
-  const showContent = lockStateLoaded && !isLocked;
+  const appStateReady = settingsLoaded && lockStateLoaded;
+  const showContent = appStateReady && !isLocked;
 
   return (
     <AppContext.Provider value={contextValue}>
       {showContent ? children : null}
-      {lockStateLoaded && isLocked ? (
+      {appStateReady && isLocked ? (
         <LockScreen
           hasPassword={!!appSettings.security.master_password}
           onUnlock={() => setIsLocked(false)}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,6 +8,7 @@ type LogDomain =
   | "ui.action"
   | "ui.error"
   | "tauri.invoke"
+  | "window.lifecycle"
   | "settings.persistence"
   | "terminal.input"
   | "session.lifecycle"

--- a/src/lib/windowManager.ts
+++ b/src/lib/windowManager.ts
@@ -7,6 +7,7 @@ import {
 } from "@tauri-apps/api/window";
 import i18n from "../i18n";
 import { invoke } from "./invoke";
+import { logger } from "./logger";
 import { isMacOS } from "./platform";
 
 type ChildWindowStateKey =
@@ -39,8 +40,9 @@ const MODAL_GROUP_RAISE_SUPPRESS_MS = 250;
 const MODAL_TOPMOST_PULSE_MS = 120;
 const CHILD_WINDOW_READY_EVENT = "child-window-ready";
 const CHILD_WINDOW_READY_TIMEOUT_MS = 5_000;
+const INIT_URL_ONLY_WINDOW_TYPES = new Set(["new-session", "quick-command"]);
 const registeredDestroyedHandlers = new Set<string>();
-const pendingChildWindowOpens = new Map<string, Promise<WebviewWindow>>();
+const pendingChildWindowOpens = new Map<string, PendingChildWindowOpen>();
 let ownerMainWindowLabel = MAIN_WINDOW_LABEL;
 let modalGroupRaiseInFlight = false;
 let suppressChildFocusSyncUntil = 0;
@@ -62,6 +64,11 @@ interface ChildWindowReadyPayload {
 interface ChildWindowReadyWaiter {
   promise: Promise<void>;
   cancel: () => void;
+}
+
+interface PendingChildWindowOpen {
+  url: string;
+  promise: Promise<WebviewWindow>;
 }
 
 export function isMainWindowLabel(label: string) {
@@ -135,6 +142,28 @@ function needsAlwaysOnTop(label: string) {
 
 function childWindowKind(opts: ChildWindowOptions) {
   return opts.kind ?? "modal";
+}
+
+function childWindowTypeFromUrl(url: string) {
+  try {
+    const query = url.includes("?") ? url.slice(url.indexOf("?") + 1) : "";
+    return new URLSearchParams(query).get("window") ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function shouldWarnPendingOpenConflict(existingUrl: string, requestedUrl: string) {
+  const existingWindowType = childWindowTypeFromUrl(existingUrl);
+  const requestedWindowType = childWindowTypeFromUrl(requestedUrl);
+  return {
+    existingWindowType,
+    requestedWindowType,
+    shouldWarn:
+      existingWindowType === requestedWindowType &&
+      existingWindowType !== undefined &&
+      INIT_URL_ONLY_WINDOW_TYPES.has(existingWindowType),
+  };
 }
 
 async function getMainWindow() {
@@ -315,8 +344,23 @@ async function createChildWindowReadyWaiter(label: string): Promise<ChildWindowR
         settle();
       }
     });
-    timeoutId = window.setTimeout(settle, CHILD_WINDOW_READY_TIMEOUT_MS);
-  } catch {
+    timeoutId = window.setTimeout(() => {
+      logger.warn({
+        domain: "window.lifecycle",
+        event: "child_ready_timeout",
+        message: "Child window did not signal ready before timeout",
+        data: { label },
+      });
+      settle();
+    }, CHILD_WINDOW_READY_TIMEOUT_MS);
+  } catch (error) {
+    logger.warn({
+      domain: "window.lifecycle",
+      event: "child_ready_listener_failed",
+      message: "Failed to listen for child window ready event",
+      data: { label },
+      error,
+    });
     settle();
   }
 
@@ -378,13 +422,31 @@ async function openChildWindowInternal(opts: ChildWindowOptions) {
 export function openChildWindow(opts: ChildWindowOptions): Promise<WebviewWindow> {
   const pending = pendingChildWindowOpens.get(opts.label);
   if (pending) {
-    return pending.then((win) => revealChildWindow(win, opts, childWindowKind(opts) === "modal"));
+    if (pending.url !== opts.url) {
+      const { existingWindowType, requestedWindowType, shouldWarn } = shouldWarnPendingOpenConflict(
+        pending.url,
+        opts.url,
+      );
+      if (shouldWarn) {
+        logger.warn({
+          domain: "window.lifecycle",
+          event: "child_window_open_conflict",
+          message: "Ignored child window open request while the same label is already opening",
+          data: {
+            label: opts.label,
+            existingWindowType,
+            requestedWindowType,
+          },
+        });
+      }
+    }
+    return pending.promise;
   }
 
   const operation = openChildWindowInternal(opts);
-  pendingChildWindowOpens.set(opts.label, operation);
+  pendingChildWindowOpens.set(opts.label, { url: opts.url, promise: operation });
   const clearPending = () => {
-    if (pendingChildWindowOpens.get(opts.label) === operation) {
+    if (pendingChildWindowOpens.get(opts.label)?.promise === operation) {
       pendingChildWindowOpens.delete(opts.label);
     }
   };

--- a/src/lib/windowManager.ts
+++ b/src/lib/windowManager.ts
@@ -1,4 +1,4 @@
-import { emit } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
   getCurrentWindow,
@@ -37,7 +37,10 @@ const AUTO_UPLOAD_OWNER_SEPARATOR = "--";
 const MODAL_CHILD_BASE_LABELS = new Set(["settings", "new-session", "quick-command"]);
 const MODAL_GROUP_RAISE_SUPPRESS_MS = 250;
 const MODAL_TOPMOST_PULSE_MS = 120;
+const CHILD_WINDOW_READY_EVENT = "child-window-ready";
+const CHILD_WINDOW_READY_TIMEOUT_MS = 5_000;
 const registeredDestroyedHandlers = new Set<string>();
+const pendingChildWindowOpens = new Map<string, Promise<WebviewWindow>>();
 let ownerMainWindowLabel = MAIN_WINDOW_LABEL;
 let modalGroupRaiseInFlight = false;
 let suppressChildFocusSyncUntil = 0;
@@ -50,6 +53,15 @@ interface ModalGroupRaiseOptions {
   excludedLabel?: string;
   requestAttention?: boolean;
   reason?: ModalGroupRaiseReason;
+}
+
+interface ChildWindowReadyPayload {
+  label: string;
+}
+
+interface ChildWindowReadyWaiter {
+  promise: Promise<void>;
+  cancel: () => void;
 }
 
 export function isMainWindowLabel(label: string) {
@@ -68,6 +80,10 @@ export function getOwnerMainWindowLabel() {
 
 export function isPrimaryMainWindow() {
   return ownerMainWindowLabel === MAIN_WINDOW_LABEL;
+}
+
+export function signalChildWindowReady() {
+  return emit(CHILD_WINDOW_READY_EVENT, { label: getCurrentWindow().label });
 }
 
 function scopedModalLabel(baseLabel: string, ownerLabel = ownerMainWindowLabel) {
@@ -274,42 +290,41 @@ export async function bounceTopModalWindow() {
   await raiseModalChildWindowGroup({ requestAttention: true, reason: "backdrop" });
 }
 
-export async function openChildWindow(opts: ChildWindowOptions) {
-  const kind = childWindowKind(opts);
-  const isModal = kind === "modal";
-  const existing = await WebviewWindow.getByLabel(opts.label);
-  if (existing) {
-    await existing.setTitle(opts.title).catch(() => {});
-    await existing.setAlwaysOnTop(needsAlwaysOnTop(opts.label)).catch(() => {});
-    await existing.show().catch(() => {});
-    await existing.setFocus().catch(() => {});
-    emit("child-window-opened", { label: opts.label });
-    if (isModal) {
-      await syncMainWindowModalState().catch(() => {});
-    }
-    return existing;
-  }
-
-  await invoke("open_child_window", {
-    options: {
-      label: opts.label,
-      title: opts.title,
-      url: opts.url,
-      kind,
-      parentLabel: opts.parentLabel ?? ownerMainWindowLabel,
-      width: opts.width ?? 720,
-      height: opts.height ?? 560,
-      resizable: opts.resizable ?? true,
-      alwaysOnTop: needsAlwaysOnTop(opts.label),
-      stateKey: opts.stateKey,
-    },
+async function createChildWindowReadyWaiter(label: string): Promise<ChildWindowReadyWaiter> {
+  let settled = false;
+  let timeoutId: number | undefined;
+  let unlisten: (() => void) | undefined;
+  let resolveReady: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    resolveReady = resolve;
   });
 
-  const win = await WebviewWindow.getByLabel(opts.label);
-  if (!win) {
-    throw new Error(`Failed to create child window: ${opts.label}`);
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    if (timeoutId !== undefined) {
+      window.clearTimeout(timeoutId);
+    }
+    unlisten?.();
+    resolveReady();
+  };
+
+  try {
+    unlisten = await listen<ChildWindowReadyPayload>(CHILD_WINDOW_READY_EVENT, ({ payload }) => {
+      if (payload.label === label) {
+        settle();
+      }
+    });
+    timeoutId = window.setTimeout(settle, CHILD_WINDOW_READY_TIMEOUT_MS);
+  } catch {
+    settle();
   }
 
+  return { promise, cancel: settle };
+}
+
+async function revealChildWindow(win: WebviewWindow, opts: ChildWindowOptions, isModal: boolean) {
+  await win.setTitle(opts.title).catch(() => {});
   await win.setAlwaysOnTop(needsAlwaysOnTop(opts.label)).catch(() => {});
   attachChildWindowDestroyedHandler(opts.label, win);
   await win.show().catch(() => {});
@@ -319,6 +334,62 @@ export async function openChildWindow(opts: ChildWindowOptions) {
     await syncMainWindowModalState().catch(() => {});
   }
   return win;
+}
+
+async function openChildWindowInternal(opts: ChildWindowOptions) {
+  const kind = childWindowKind(opts);
+  const isModal = kind === "modal";
+  const existing = await WebviewWindow.getByLabel(opts.label);
+  if (existing) {
+    return revealChildWindow(existing, opts, isModal);
+  }
+
+  const readyWaiter = await createChildWindowReadyWaiter(opts.label);
+  try {
+    await invoke("open_child_window", {
+      options: {
+        label: opts.label,
+        title: opts.title,
+        url: opts.url,
+        kind,
+        parentLabel: opts.parentLabel ?? ownerMainWindowLabel,
+        width: opts.width ?? 720,
+        height: opts.height ?? 560,
+        resizable: opts.resizable ?? true,
+        alwaysOnTop: needsAlwaysOnTop(opts.label),
+        stateKey: opts.stateKey,
+      },
+    });
+
+    const win = await WebviewWindow.getByLabel(opts.label);
+    if (!win) {
+      throw new Error(`Failed to create child window: ${opts.label}`);
+    }
+
+    attachChildWindowDestroyedHandler(opts.label, win);
+    await readyWaiter.promise;
+    return revealChildWindow(win, opts, isModal);
+  } catch (error) {
+    readyWaiter.cancel();
+    throw error;
+  }
+}
+
+export function openChildWindow(opts: ChildWindowOptions): Promise<WebviewWindow> {
+  const pending = pendingChildWindowOpens.get(opts.label);
+  if (pending) {
+    return pending.then((win) => revealChildWindow(win, opts, childWindowKind(opts) === "modal"));
+  }
+
+  const operation = openChildWindowInternal(opts);
+  pendingChildWindowOpens.set(opts.label, operation);
+  const clearPending = () => {
+    if (pendingChildWindowOpens.get(opts.label) === operation) {
+      pendingChildWindowOpens.delete(opts.label);
+    }
+  };
+  operation.then(clearPending, clearPending);
+  return operation;
 }
 
 export async function openSettings(tab?: string) {


### PR DESCRIPTION
解决进入 新建连接，新建会话，设置界面，添加快捷命令 显示加载中... 情况
- 子窗口在页面、设置及锁状态准备完成前保持隐藏。
- 页面 ready 后再显示、聚焦并同步模态状态。
- 移除子窗口启动阶段的“加载中...”闪屏。
- 合并连续点击产生的重复打开请求。
- 增加 5 秒保护超时，避免异常时窗口永久隐藏。
- 保留文件读取、同步等真实异步操作的加载提示。