### PR TITLE
fix(terminal): focus search input when find is triggered while bar is already open. (Fixes #349)

### DIFF
--- a/src/components/terminal/TerminalSearchBar.tsx
+++ b/src/components/terminal/TerminalSearchBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MdClose, MdKeyboardArrowDown, MdKeyboardArrowUp } from "react-icons/md";
 import type {
@@ -14,6 +14,7 @@ import {
 
 interface TerminalSearchBarProps {
   show: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
   searchQuery: string;
   searchState: TerminalSearchState;
   searchFlags: TerminalSearchFlags;
@@ -29,6 +30,7 @@ interface TerminalSearchBarProps {
 
 export default function TerminalSearchBar({
   show,
+  inputRef,
   searchQuery,
   searchState,
   searchFlags,
@@ -42,7 +44,6 @@ export default function TerminalSearchBar({
   onClose,
 }: TerminalSearchBarProps) {
   const { t } = useTranslation();
-  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!show) return;
@@ -57,7 +58,7 @@ export default function TerminalSearchBar({
       window.cancelAnimationFrame(animationFrameId);
       window.clearTimeout(timeoutId);
     };
-  }, [show]);
+  }, [show, inputRef]);
 
   const statusLabel = useMemo(
     () =>

--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -3150,9 +3150,14 @@ export default function XTerminal({
     workspacePaddingSetting: terminalSettings.show_workspace_padding,
   });
 
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+
   const doFind = useCallback(
     (selection?: string) => {
       setShowSearchBar(true);
+      // When the bar is already open the focus effect won't rerun, so focus directly.
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
       if (selection) {
         setSearchQuery(selection);
         handleSearchNext(selection);
@@ -3292,6 +3297,7 @@ export default function XTerminal({
 
         <TerminalSearchBar
           show={showSearchBar}
+          inputRef={searchInputRef}
           searchQuery={searchQuery}
           searchState={searchState}
           searchFlags={searchFlags}


### PR DESCRIPTION
## 问题

  搜索栏已通过快捷键打开后，鼠标点击终端使焦点回到终端，此时再次按查找快捷键（Ctrl+Shift+F）完全无反应，焦点仍停留在终端，不会按预期回到搜索输入栏。

  ## 原因

  查找输入框的聚焦由 `TerminalSearchBar` 中以 `[show]` 为依赖的 effect 完成，只在 `show` 从 `false` 变为 `true` 时执行。查找栏已打开时，`doFind` 再次设置 `show=true`，状态不变，effect 不会重跑，因此不会重新聚焦。

  ## 修复

  - 将查找输入框的 ref 由 `TerminalSearchBar` 内部创建改为从 `XTerminal` 传入。
  - `doFind` 中在 `setShowSearchBar(true)` 后直接 `focus()` + `select()`：查找栏未打开时 ref 为 `null`，可选链安全跳过，仍由原 effect 负责聚焦；已打开时立即聚焦并全选已有查询文本，方便直接输入替换（与浏览器/编辑器的 Find 行为一致）。

  ## 验证

  - Ctrl+Shift+F 打开查找 → 点击终端 → 再次 Ctrl+Shift+F，焦点回到查找输入框并全选已有查询文本。