### PR TITLE
feat(about): add support information

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -193,9 +193,11 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Threading",
 ] }
 windows = { version = "0.61", features = [
+    "Wdk_System_SystemServices",
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_Threading",
+    "Win32_System_SystemInformation",
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_UI_Shell",

--- a/src-tauri/src/cmd/app.rs
+++ b/src-tauri/src/cmd/app.rs
@@ -113,15 +113,12 @@ pub struct AppSupportInfo {
 
 #[tauri::command]
 pub fn get_support_info(state: tauri::State<'_, crate::runtime::AppRuntime>) -> AppSupportInfo {
+    let runtime = state.info().mode;
     AppSupportInfo {
         os: operating_system_label(),
         architecture: std::env::consts::ARCH.to_string(),
-        runtime: support_runtime_label(state.portable()).to_string(),
+        runtime,
     }
-}
-
-fn support_runtime_label(portable: bool) -> &'static str {
-    if portable { "portable" } else { "installed" }
 }
 
 fn operating_system_label() -> String {
@@ -132,8 +129,7 @@ fn operating_system_label() -> String {
 
     #[cfg(target_os = "macos")]
     {
-        return command_output("sw_vers", &["-productName", "-productVersion"])
-            .unwrap_or_else(|| "macOS".to_string());
+        return macos_version_label();
     }
 
     #[cfg(target_os = "linux")]
@@ -158,20 +154,37 @@ fn operating_system_label() -> String {
 
 #[cfg(target_os = "windows")]
 fn windows_version_label() -> String {
-    use windows::Wdk::System::SystemServices::RtlGetVersion;
-    use windows::Win32::System::SystemInformation::OSVERSIONINFOW;
+    use windows::Win32::System::SystemInformation::OSVERSIONINFOEXW;
+    use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
 
-    let mut version = OSVERSIONINFOW {
-        dwOSVersionInfoSize: std::mem::size_of::<OSVERSIONINFOW>() as u32,
+    const VER_NT_WORKSTATION: u8 = 1;
+    type RtlGetVersion = unsafe extern "system" fn(*mut OSVERSIONINFOEXW) -> i32;
+
+    let mut version = OSVERSIONINFOEXW {
+        dwOSVersionInfoSize: std::mem::size_of::<OSVERSIONINFOEXW>() as u32,
         ..Default::default()
     };
 
+    let Some(rtl_get_version) = (unsafe {
+        let ntdll = GetModuleHandleA(c"ntdll.dll".as_ptr().cast());
+        if ntdll.is_null() {
+            None
+        } else {
+            GetProcAddress(ntdll, c"RtlGetVersion".as_ptr().cast())
+        }
+    }) else {
+        return "Windows".to_string();
+    };
+
+    let rtl_get_version: RtlGetVersion = unsafe { std::mem::transmute(rtl_get_version) };
+
     // RtlGetVersion queries the current Windows version in-process, avoiding a console process.
-    if unsafe { RtlGetVersion(&mut version) }.is_ok() {
+    if unsafe { rtl_get_version(&mut version) } >= 0 {
         windows_version_label_from_parts(
             version.dwMajorVersion,
             version.dwMinorVersion,
             version.dwBuildNumber,
+            version.wProductType == VER_NT_WORKSTATION,
         )
     } else {
         "Windows".to_string()
@@ -179,7 +192,16 @@ fn windows_version_label() -> String {
 }
 
 #[cfg(any(target_os = "windows", test))]
-fn windows_version_label_from_parts(major: u32, minor: u32, build: u32) -> String {
+fn windows_version_label_from_parts(
+    major: u32,
+    minor: u32,
+    build: u32,
+    workstation: bool,
+) -> String {
+    if !workstation {
+        return format!("Windows Server ({major}.{minor}.{build})");
+    }
+
     let name = match (major, minor, build) {
         (10, 0, 22_000..) => "Windows 11",
         (10, 0, _) => "Windows 10",
@@ -189,6 +211,22 @@ fn windows_version_label_from_parts(major: u32, minor: u32, build: u32) -> Strin
         _ => "Windows",
     };
     format!("{name} ({major}.{minor}.{build})")
+}
+
+#[cfg(target_os = "macos")]
+fn macos_version_label() -> String {
+    let name = command_output("sw_vers", &["-productName"]).unwrap_or_else(|| "macOS".to_string());
+    command_output("sw_vers", &["-productVersion"])
+        .map(|version| format!("{name} {version}"))
+        .unwrap_or(name)
+}
+
+#[cfg(test)]
+fn macos_version_label_from_parts(name: Option<&str>, version: Option<&str>) -> String {
+    let name = name.unwrap_or("macOS");
+    version
+        .map(|version| format!("{name} {version}"))
+        .unwrap_or_else(|| name.to_string())
 }
 
 #[cfg(target_os = "macos")]
@@ -206,24 +244,36 @@ fn command_output(program: &str, args: &[&str]) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{support_runtime_label, windows_version_label_from_parts};
-
-    #[test]
-    fn support_runtime_label_matches_installation_mode() {
-        assert_eq!(support_runtime_label(true), "portable");
-        assert_eq!(support_runtime_label(false), "installed");
-    }
+    use super::{macos_version_label_from_parts, windows_version_label_from_parts};
 
     #[test]
     fn windows_version_label_uses_native_version_parts() {
         assert_eq!(
-            windows_version_label_from_parts(10, 0, 22_631),
+            windows_version_label_from_parts(10, 0, 22_631, true),
             "Windows 11 (10.0.22631)"
         );
         assert_eq!(
-            windows_version_label_from_parts(10, 0, 19_045),
+            windows_version_label_from_parts(10, 0, 19_045, true),
             "Windows 10 (10.0.19045)"
         );
+        assert_eq!(
+            windows_version_label_from_parts(10, 0, 20_348, false),
+            "Windows Server (10.0.20348)"
+        );
+        assert_eq!(
+            windows_version_label_from_parts(10, 0, 26_100, false),
+            "Windows Server (10.0.26100)"
+        );
+    }
+
+    #[test]
+    fn macos_version_label_combines_available_parts() {
+        assert_eq!(
+            macos_version_label_from_parts(Some("macOS"), Some("14.7.1")),
+            "macOS 14.7.1"
+        );
+        assert_eq!(macos_version_label_from_parts(Some("macOS"), None), "macOS");
+        assert_eq!(macos_version_label_from_parts(None, None), "macOS");
     }
 }
 

--- a/src-tauri/src/cmd/app.rs
+++ b/src-tauri/src/cmd/app.rs
@@ -103,6 +103,130 @@ pub fn get_app_runtime_info(
     state.info()
 }
 
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppSupportInfo {
+    os: String,
+    architecture: String,
+    runtime: String,
+}
+
+#[tauri::command]
+pub fn get_support_info(state: tauri::State<'_, crate::runtime::AppRuntime>) -> AppSupportInfo {
+    AppSupportInfo {
+        os: operating_system_label(),
+        architecture: std::env::consts::ARCH.to_string(),
+        runtime: support_runtime_label(state.portable()).to_string(),
+    }
+}
+
+fn support_runtime_label(portable: bool) -> &'static str {
+    if portable { "portable" } else { "installed" }
+}
+
+fn operating_system_label() -> String {
+    #[cfg(target_os = "windows")]
+    {
+        return windows_version_label();
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return command_output("sw_vers", &["-productName", "-productVersion"])
+            .unwrap_or_else(|| "macOS".to_string());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(contents) = std::fs::read_to_string("/etc/os-release") {
+            let name = contents
+                .lines()
+                .find_map(|line| line.strip_prefix("PRETTY_NAME="))
+                .map(|value| value.trim_matches('"').to_string());
+            if let Some(name) = name {
+                return name;
+            }
+        }
+        return "Linux".to_string();
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        std::env::consts::OS.to_string()
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_version_label() -> String {
+    use windows::Wdk::System::SystemServices::RtlGetVersion;
+    use windows::Win32::System::SystemInformation::OSVERSIONINFOW;
+
+    let mut version = OSVERSIONINFOW {
+        dwOSVersionInfoSize: std::mem::size_of::<OSVERSIONINFOW>() as u32,
+        ..Default::default()
+    };
+
+    // RtlGetVersion queries the current Windows version in-process, avoiding a console process.
+    if unsafe { RtlGetVersion(&mut version) }.is_ok() {
+        windows_version_label_from_parts(
+            version.dwMajorVersion,
+            version.dwMinorVersion,
+            version.dwBuildNumber,
+        )
+    } else {
+        "Windows".to_string()
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_version_label_from_parts(major: u32, minor: u32, build: u32) -> String {
+    let name = match (major, minor, build) {
+        (10, 0, 22_000..) => "Windows 11",
+        (10, 0, _) => "Windows 10",
+        (6, 3, _) => "Windows 8.1",
+        (6, 2, _) => "Windows 8",
+        (6, 1, _) => "Windows 7",
+        _ => "Windows",
+    };
+    format!("{name} ({major}.{minor}.{build})")
+}
+
+#[cfg(target_os = "macos")]
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{support_runtime_label, windows_version_label_from_parts};
+
+    #[test]
+    fn support_runtime_label_matches_installation_mode() {
+        assert_eq!(support_runtime_label(true), "portable");
+        assert_eq!(support_runtime_label(false), "installed");
+    }
+
+    #[test]
+    fn windows_version_label_uses_native_version_parts() {
+        assert_eq!(
+            windows_version_label_from_parts(10, 0, 22_631),
+            "Windows 11 (10.0.22631)"
+        );
+        assert_eq!(
+            windows_version_label_from_parts(10, 0, 19_045),
+            "Windows 10 (10.0.19045)"
+        );
+    }
+}
+
 #[tauri::command]
 pub fn get_app_lock_state(state: tauri::State<'_, AppLockState>) -> bool {
     state.is_locked()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,7 @@ pub fn run() {
             cmd::app::open_download_dir,
             cmd::app::open_log_dir,
             cmd::app::get_app_runtime_info,
+            cmd::app::get_support_info,
             cmd::app::get_app_lock_state,
             cmd::app::set_app_lock_state,
             cmd::app::open_child_window,

--- a/src/components/dialog/app/AboutDialog.tsx
+++ b/src/components/dialog/app/AboutDialog.tsx
@@ -12,11 +12,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import pkg from "../../../../package.json";
-import NyaTermLogo from "../../NyaTermLogo";
 import { writeClipboardText } from "@/lib/clipboard";
 import { invoke } from "@/lib/invoke";
 import type { AppSupportInfo } from "@/types/global";
+import pkg from "../../../../package.json";
+import NyaTermLogo from "../../NyaTermLogo";
 
 interface AboutDialogProps {
   open: boolean;
@@ -26,31 +26,61 @@ interface AboutDialogProps {
 export default function AboutDialog({ open, onClose }: AboutDialogProps) {
   const { t } = useTranslation();
   const [appName, setAppName] = useState("NyaTerm");
-  const [appVersion, setAppVersion] = useState("0.1.0");
-  const [supportInfo, setSupportInfo] = useState<AppSupportInfo>({
-    os: "unknown",
-    architecture: "unknown",
-    runtime: "installed",
-  });
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+  const [appVersionFailed, setAppVersionFailed] = useState(false);
+  const [supportInfo, setSupportInfo] = useState<AppSupportInfo | null>(null);
+  const [supportInfoFailed, setSupportInfoFailed] = useState(false);
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
-    if (open) {
-      getName().then(setAppName).catch(console.error);
-      getVersion().then(setAppVersion).catch(console.error);
-      invoke<AppSupportInfo>("get_support_info")
-        .then(setSupportInfo)
-        .catch(() => undefined);
-      setCopied(false);
+    if (!open) {
+      return;
     }
+
+    let cancelled = false;
+    setCopied(false);
+    setAppVersion(null);
+    setAppVersionFailed(false);
+    setSupportInfo(null);
+    setSupportInfoFailed(false);
+
+    getName()
+      .then((name) => {
+        if (!cancelled) setAppName(name);
+      })
+      .catch(() => undefined);
+
+    getVersion()
+      .then((version) => {
+        if (!cancelled) setAppVersion(version);
+      })
+      .catch(() => {
+        if (!cancelled) setAppVersionFailed(true);
+      });
+
+    invoke<AppSupportInfo>("get_support_info")
+      .then((info) => {
+        if (!cancelled) setSupportInfo(info);
+      })
+      .catch(() => {
+        if (!cancelled) setSupportInfoFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [open]);
 
   const copySupportInfo = async () => {
+    if (!appVersion || !supportInfo) {
+      return;
+    }
+
     const text = [
       "NyaTerm Support Information",
       `Version: ${appVersion}`,
       `Operating System: ${supportInfo.os}`,
-      `Architecture: ${supportInfo.architecture}`,
+      `Application Architecture: ${supportInfo.architecture}`,
       `Runtime: ${supportInfo.runtime === "portable" ? t("about.portable") : t("about.installed")}`,
     ].join("\n");
     try {
@@ -63,11 +93,26 @@ export default function AboutDialog({ open, onClose }: AboutDialogProps) {
     }
   };
 
+  const supportInfoReady = Boolean(appVersion && supportInfo);
+  const versionDisplay =
+    appVersion ?? (appVersionFailed ? t("about.unknown") : t("common.loading"));
+  const osDisplay =
+    supportInfo?.os ?? (supportInfoFailed ? t("about.unknown") : t("common.loading"));
+  const architectureDisplay =
+    supportInfo?.architecture ?? (supportInfoFailed ? t("about.unknown") : t("common.loading"));
+  const runtimeDisplay = supportInfo
+    ? supportInfo.runtime === "portable"
+      ? t("about.portable")
+      : t("about.installed")
+    : supportInfoFailed
+      ? t("about.unknown")
+      : t("common.loading");
+
   const supportRows = [
-    [t("about.version"), appVersion],
-    [t("about.operatingSystem"), supportInfo.os === "unknown" ? t("about.unknown") : supportInfo.os],
-    [t("about.architecture"), supportInfo.architecture === "unknown" ? t("about.unknown") : supportInfo.architecture],
-    [t("about.runtime"), supportInfo.runtime === "portable" ? t("about.portable") : t("about.installed")],
+    [t("about.version"), versionDisplay],
+    [t("about.operatingSystem"), osDisplay],
+    [t("about.architecture"), architectureDisplay],
+    [t("about.runtime"), runtimeDisplay],
   ];
 
   return (
@@ -76,16 +121,21 @@ export default function AboutDialog({ open, onClose }: AboutDialogProps) {
         <DialogHeader className="items-center">
           <NyaTermLogo className="w-24 h-24 object-contain" />
           <DialogTitle className="text-lg">{appName}</DialogTitle>
-          <DialogDescription className="text-xs">v{appVersion}</DialogDescription>
+          <DialogDescription className="text-xs">v{versionDisplay}</DialogDescription>
         </DialogHeader>
 
         <p className="text-xs text-center px-4 leading-relaxed text-muted-foreground">
           {t("about.description")}
         </p>
 
-        <section className="w-full rounded-md border bg-muted/20 p-3" aria-labelledby="support-info-title">
+        <section
+          className="w-full rounded-md border bg-muted/20 p-3"
+          aria-labelledby="support-info-title"
+        >
           <div className="flex items-center justify-between gap-3 mb-2">
-            <h3 id="support-info-title" className="text-sm font-medium">{t("about.supportInfo")}</h3>
+            <h3 id="support-info-title" className="text-sm font-medium">
+              {t("about.supportInfo")}
+            </h3>
             <Button
               variant="ghost"
               size="sm"
@@ -93,6 +143,7 @@ export default function AboutDialog({ open, onClose }: AboutDialogProps) {
               onClick={() => void copySupportInfo()}
               title={t("about.copySupportInfo")}
               aria-label={t("about.copySupportInfo")}
+              disabled={!supportInfoReady}
             >
               {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
               {copied ? t("about.supportInfoCopiedShort") : t("about.copySupportInfo")}

--- a/src/components/dialog/app/AboutDialog.tsx
+++ b/src/components/dialog/app/AboutDialog.tsx
@@ -1,7 +1,9 @@
 import { getName, getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { Check, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,6 +14,9 @@ import {
 } from "@/components/ui/dialog";
 import pkg from "../../../../package.json";
 import NyaTermLogo from "../../NyaTermLogo";
+import { writeClipboardText } from "@/lib/clipboard";
+import { invoke } from "@/lib/invoke";
+import type { AppSupportInfo } from "@/types/global";
 
 interface AboutDialogProps {
   open: boolean;
@@ -22,17 +27,52 @@ export default function AboutDialog({ open, onClose }: AboutDialogProps) {
   const { t } = useTranslation();
   const [appName, setAppName] = useState("NyaTerm");
   const [appVersion, setAppVersion] = useState("0.1.0");
+  const [supportInfo, setSupportInfo] = useState<AppSupportInfo>({
+    os: "unknown",
+    architecture: "unknown",
+    runtime: "installed",
+  });
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (open) {
       getName().then(setAppName).catch(console.error);
       getVersion().then(setAppVersion).catch(console.error);
+      invoke<AppSupportInfo>("get_support_info")
+        .then(setSupportInfo)
+        .catch(() => undefined);
+      setCopied(false);
     }
   }, [open]);
 
+  const copySupportInfo = async () => {
+    const text = [
+      "NyaTerm Support Information",
+      `Version: ${appVersion}`,
+      `Operating System: ${supportInfo.os}`,
+      `Architecture: ${supportInfo.architecture}`,
+      `Runtime: ${supportInfo.runtime === "portable" ? t("about.portable") : t("about.installed")}`,
+    ].join("\n");
+    try {
+      await writeClipboardText(text);
+      setCopied(true);
+      toast.success(t("about.supportInfoCopied"));
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      toast.error(t("about.supportInfoCopyFailed"));
+    }
+  };
+
+  const supportRows = [
+    [t("about.version"), appVersion],
+    [t("about.operatingSystem"), supportInfo.os === "unknown" ? t("about.unknown") : supportInfo.os],
+    [t("about.architecture"), supportInfo.architecture === "unknown" ? t("about.unknown") : supportInfo.architecture],
+    [t("about.runtime"), supportInfo.runtime === "portable" ? t("about.portable") : t("about.installed")],
+  ];
+
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="w-[min(320px,calc(100vw-2rem))] sm:max-w-[320px] flex flex-col items-center p-6 gap-4">
+      <DialogContent className="w-[min(440px,calc(100vw-2rem))] sm:max-w-[440px] flex flex-col items-center p-6 gap-4">
         <DialogHeader className="items-center">
           <NyaTermLogo className="w-24 h-24 object-contain" />
           <DialogTitle className="text-lg">{appName}</DialogTitle>
@@ -42,6 +82,31 @@ export default function AboutDialog({ open, onClose }: AboutDialogProps) {
         <p className="text-xs text-center px-4 leading-relaxed text-muted-foreground">
           {t("about.description")}
         </p>
+
+        <section className="w-full rounded-md border bg-muted/20 p-3" aria-labelledby="support-info-title">
+          <div className="flex items-center justify-between gap-3 mb-2">
+            <h3 id="support-info-title" className="text-sm font-medium">{t("about.supportInfo")}</h3>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 px-2 text-xs"
+              onClick={() => void copySupportInfo()}
+              title={t("about.copySupportInfo")}
+              aria-label={t("about.copySupportInfo")}
+            >
+              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              {copied ? t("about.supportInfoCopiedShort") : t("about.copySupportInfo")}
+            </Button>
+          </div>
+          <dl className="grid grid-cols-[minmax(0,auto)_1fr] gap-x-4 gap-y-1.5 text-xs">
+            {supportRows.map(([label, value]) => (
+              <div className="contents" key={label}>
+                <dt className="text-muted-foreground">{label}</dt>
+                <dd className="min-w-0 break-words text-right font-mono">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
 
         <div className="flex gap-3 w-full pt-2">
           <Button

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,8 +1,20 @@
 {
   "about": {
+    "architecture": "Architecture",
     "close": "Close",
+    "copySupportInfo": "Copy all",
     "description": "A desktop client for SSH-centric operations and mixed terminal workflows.",
+    "installed": "Installed",
     "issues": "Issues",
+    "operatingSystem": "Operating system",
+    "portable": "Portable",
+    "runtime": "Runtime",
+    "supportInfo": "Support information",
+    "supportInfoCopied": "Support information copied",
+    "supportInfoCopiedShort": "Copied",
+    "supportInfoCopyFailed": "Failed to copy support information",
+    "unknown": "Unknown",
+    "version": "Version",
     "website": "Website"
   },
   "activeSessions": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,6 +1,6 @@
 {
   "about": {
-    "architecture": "Architecture",
+    "architecture": "Application architecture",
     "close": "Close",
     "copySupportInfo": "Copy all",
     "description": "A desktop client for SSH-centric operations and mixed terminal workflows.",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1,6 +1,6 @@
 {
   "about": {
-    "architecture": "시스템 아키텍처",
+    "architecture": "애플리케이션 아키텍처",
     "close": "닫기",
     "copySupportInfo": "전체 복사",
     "description": "SSH 중심 작업과 다양한 터미널 워크플로를 위한 데스크톱 클라이언트입니다.",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1,8 +1,20 @@
 {
   "about": {
+    "architecture": "시스템 아키텍처",
     "close": "닫기",
+    "copySupportInfo": "전체 복사",
     "description": "SSH 중심 작업과 다양한 터미널 워크플로를 위한 데스크톱 클라이언트입니다.",
+    "installed": "설치 버전",
     "issues": "이슈",
+    "operatingSystem": "운영 체제",
+    "portable": "포터블 버전",
+    "runtime": "실행 환경",
+    "supportInfo": "지원 정보",
+    "supportInfoCopied": "지원 정보가 복사되었습니다",
+    "supportInfoCopiedShort": "복사됨",
+    "supportInfoCopyFailed": "지원 정보를 복사하지 못했습니다",
+    "unknown": "알 수 없음",
+    "version": "소프트웨어 버전",
     "website": "웹사이트"
   },
   "activeSessions": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1,8 +1,20 @@
 {
   "about": {
+    "architecture": "系统架构",
     "close": "关闭",
+    "copySupportInfo": "复制全部",
     "description": "用于 SSH、串口和本地命令行工作的桌面终端客户端。",
+    "installed": "安装版",
     "issues": "问题反馈",
+    "operatingSystem": "操作系统",
+    "portable": "便携版",
+    "runtime": "运行环境",
+    "supportInfo": "支持信息",
+    "supportInfoCopied": "支持信息已复制",
+    "supportInfoCopiedShort": "已复制",
+    "supportInfoCopyFailed": "支持信息复制失败",
+    "unknown": "未知",
+    "version": "软件版本",
     "website": "官网"
   },
   "activeSessions": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1,6 +1,6 @@
 {
   "about": {
-    "architecture": "系统架构",
+    "architecture": "应用架构",
     "close": "关闭",
     "copySupportInfo": "复制全部",
     "description": "用于 SSH、串口和本地命令行工作的桌面终端客户端。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1,6 +1,6 @@
 {
   "about": {
-    "architecture": "系統架構",
+    "architecture": "應用程式架構",
     "close": "關閉",
     "copySupportInfo": "複製全部",
     "description": "用於 SSH、序列埠和本機命令列工作的桌面終端客戶端。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1,8 +1,20 @@
 {
   "about": {
+    "architecture": "系統架構",
     "close": "關閉",
+    "copySupportInfo": "複製全部",
     "description": "用於 SSH、序列埠和本機命令列工作的桌面終端客戶端。",
+    "installed": "安裝版",
     "issues": "問題回報",
+    "operatingSystem": "作業系統",
+    "portable": "便攜版",
+    "runtime": "執行環境",
+    "supportInfo": "支援資訊",
+    "supportInfoCopied": "支援資訊已複製",
+    "supportInfoCopiedShort": "已複製",
+    "supportInfoCopyFailed": "支援資訊複製失敗",
+    "unknown": "未知",
+    "version": "軟體版本",
     "website": "官方網站"
   },
   "activeSessions": {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -12,6 +12,12 @@ export interface AppRuntimeInfo {
   portableMarkerPath?: string | null;
 }
 
+export interface AppSupportInfo {
+  os: string;
+  architecture: string;
+  runtime: "portable" | "installed";
+}
+
 /** AI Agent command execution wrapper profile. */
 export type AIExecutionProfile = "auto" | "posix" | "powershell" | "cmd" | "send_only" | "disabled";
 


### PR DESCRIPTION
- 在“帮助 -> 关于”弹窗新增“支持信息”区域，显示软件版本、操作系统、系统架构、运行环境（便携版/安装版）。
- 新增“复制全部信息”按钮，复制适合粘贴到 GitHub Issue 的支持信息，并提供成功/失败提示。
- 新增 get_support_info Tauri 命令，前端通过类型化调用获取系统信息。
- Windows 系统版本查询改为原生 RtlGetVersion，不再启动 PowerShell：消除打开关于页时闪现的黑色控制台窗口。
- 系统、架构和运行环境信息立即返回，不再等待后台进程。
- 补充英文、简体中文、繁体中文、韩文的相关文案。
- 添加 Windows 版本格式化单元测试，并完成 Windows 便携版生产构建与压缩包校验。

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/31267601-b93c-46dd-976f-1c897b0e976c" />

借鉴自dbx

复制完以后结果为
NyaTerm Support Information
Version: 1.1.19
Operating System: Windows 10 (10.0.19044)
Architecture: x86_64
Runtime: Portable