### PR TITLE
fix(zmodem): discard ZRQINIT in upload flow to avoid protocol hang

### DIFF
--- a/src-tauri/src/core/zmodem/transfer.rs
+++ b/src-tauri/src/core/zmodem/transfer.rs
@@ -311,6 +311,15 @@ impl ZmodemTransfer {
         };
         sender.set_file_options(conflict_mode.file_options());
 
+        // Discard the auto-queued ZRQINIT: the remote `rz` already sent
+        // ZRINIT proactively, so sending ZRQINIT back would confuse it.
+        // We skip directly to feeding the buffered ZRINIT and starting the
+        // first file.
+        {
+            let n = sender.drain_outgoing().len();
+            sender.advance_outgoing(n);
+        }
+
         self.state = TransferState::Sending {
             sender,
             files,
@@ -321,14 +330,12 @@ impl ZmodemTransfer {
         };
 
         let mut actions = Vec::new();
-        // 1. Drain the Sender's initial outgoing bytes (ZRQINIT).
-        actions.extend(self.drain_outgoing());
-        // 2. Feed the buffered remote ZRINIT so the Sender knows the
+        // 1. Feed the buffered remote ZRINIT so the Sender knows the
         //    receiver's capabilities.
         actions.extend(self.feed_incoming(&buffered));
-        // 3. Start the first file (prepares ZFILE frame).
+        // 2. Start the first file (prepares ZFILE frame).
         actions.extend(self.start_next_send_file());
-        // 4. Drain the ZFILE frame.
+        // 3. Drain the ZFILE frame.
         actions.extend(self.drain_outgoing());
         actions
     }

--- a/src/components/terminal/zmodemTerminalEvents.ts
+++ b/src/components/terminal/zmodemTerminalEvents.ts
@@ -127,25 +127,28 @@ export function createZmodemEventHandler(
     pendingProgress = null;
     lastProgressWriteAt = Date.now();
 
+    const fileName = payload.fileName ?? payload.file_name ?? uploadFileName;
+    const bytesTransferred = payload.bytesTransferred ?? payload.bytes_transferred ?? 0;
+    const totalSize = payload.totalSize ?? payload.total_size ?? 0;
+    const percent = totalSize > 0 ? Math.round((bytesTransferred / totalSize) * 100) : 0;
+    const t = getT();
+
     if (payload.direction === "upload") {
-      const fileName = payload.fileName ?? payload.file_name ?? uploadFileName;
       if (fileName) {
         uploadFileName = fileName;
       }
       if (!uploadStarted) {
         uploadStarted = true;
         uploadToastId = toast.message(
-          getT()("fileTransfer.uploadStarted", { name: uploadFileName || fileName }),
+          t("fileTransfer.uploadStarted", { name: uploadFileName || fileName }),
         );
       }
+      terminal.write(
+        `\r\x1b[36m[ZMODEM] ${t("zmodem.uploading", { fileName: uploadFileName || fileName, percent })}\x1b[K`,
+      );
       return;
     }
 
-    const fileName = payload.fileName ?? payload.file_name ?? "";
-    const bytesTransferred = payload.bytesTransferred ?? payload.bytes_transferred ?? 0;
-    const totalSize = payload.totalSize ?? payload.total_size ?? 0;
-    const percent = totalSize > 0 ? Math.round((bytesTransferred / totalSize) * 100) : 0;
-    const t = getT();
     terminal.write(`\r\x1b[36m[ZMODEM] ${t("zmodem.downloading", { fileName, percent })}\x1b[K`);
   };
 

--- a/src/lib/terminalZmodemUpload.ts
+++ b/src/lib/terminalZmodemUpload.ts
@@ -270,6 +270,7 @@ async function resolveUnverifiedZmodemUpload(
   duplicateStrategy: string,
 ): Promise<ConflictProbeResult> {
   if (duplicateStrategy === "skip") {
+    toast.message(i18n.t("zmodem.sftpProbeSkipped"));
     return { paths: [], probeSkipped: true, conflictMode: "skip" };
   }
 


### PR DESCRIPTION
## 修复内容

### 1. ZMODEM 上传协议卡住（根本原因）
远程 `rz` 已主动发送 `ZRINIT` 后，本地仍发送 `ZRQINIT`，导致协议握手卡在 "rz waiting to receive."。
- 修复：丢弃 `zmodem2::Sender::new()` 自动排队的 `ZRQINIT` 帧，直接喂已收到的 `ZRINIT` 并开始发 `ZFILE`

### 2. 上传进度显示到终端
之前上传只有底部 toast 提示，现在上传和下载一样会在终端中实时显示进度条 `[ZMODEM] 发送中: filename (45%)`
<img width="719" height="87" alt="图片" src="https://github.com/user-attachments/assets/300cd0da-bbdb-4a89-bef6-320a7fbd9d01" />


### 3. 补充 SFTP 探测跳过提示
当 SFTP 冲突探测不可用且策略为 `skip` 时，之前静默跳过无反馈，现在显示 toast 提示。

## 修改文件
- `src-tauri/src/core/zmodem/transfer.rs` — 丢弃 ZRQINIT 帧
- `src/components/terminal/zmodemTerminalEvents.ts` — 上传进度显示到终端
- `src/lib/terminalZmodemUpload.ts` — sftpProbeSkipped toast