### PR TITLE
feat(asset): double-click asset card/row to connect

### DIFF
--- a/src-tauri/src/core/zmodem/transfer.rs
+++ b/src-tauri/src/core/zmodem/transfer.rs
@@ -311,6 +311,15 @@ impl ZmodemTransfer {
         };
         sender.set_file_options(conflict_mode.file_options());
 
+        // Discard the auto-queued ZRQINIT: the remote `rz` already sent
+        // ZRINIT proactively, so sending ZRQINIT back would confuse it.
+        // We skip directly to feeding the buffered ZRINIT and starting the
+        // first file.
+        {
+            let n = sender.drain_outgoing().len();
+            sender.advance_outgoing(n);
+        }
+
         self.state = TransferState::Sending {
             sender,
             files,
@@ -321,14 +330,12 @@ impl ZmodemTransfer {
         };
 
         let mut actions = Vec::new();
-        // 1. Drain the Sender's initial outgoing bytes (ZRQINIT).
-        actions.extend(self.drain_outgoing());
-        // 2. Feed the buffered remote ZRINIT so the Sender knows the
+        // 1. Feed the buffered remote ZRINIT so the Sender knows the
         //    receiver's capabilities.
         actions.extend(self.feed_incoming(&buffered));
-        // 3. Start the first file (prepares ZFILE frame).
+        // 2. Start the first file (prepares ZFILE frame).
         actions.extend(self.start_next_send_file());
-        // 4. Drain the ZFILE frame.
+        // 3. Drain the ZFILE frame.
         actions.extend(self.drain_outgoing());
         actions
     }

--- a/src/components/app/start-workspace/AssetCardGrid.tsx
+++ b/src/components/app/start-workspace/AssetCardGrid.tsx
@@ -33,11 +33,15 @@ export default function AssetCardGrid({
   onEditConnection,
 }: AssetCardGridProps) {
   const [columnCount, setColumnCount] = useState(1);
-  const rows = useMemo(() => chunkRecords(records, columnCount), [columnCount, records]);
-  const { containerRef, visibleItems, paddingTop, paddingBottom, onScroll } = useVirtualList(rows, {
-    itemHeight: ASSET_CARD_ROW_HEIGHT + ASSET_CARD_GAP,
-    overscan: 5,
-  });
+  const rows = useMemo(
+    () => chunkRecords(records, columnCount),
+    [columnCount, records],
+  );
+  const { containerRef, visibleItems, paddingTop, paddingBottom, onScroll } =
+    useVirtualList(rows, {
+      itemHeight: ASSET_CARD_ROW_HEIGHT + ASSET_CARD_GAP,
+      overscan: 5,
+    });
 
   useEffect(() => {
     const container = containerRef.current;
@@ -96,7 +100,10 @@ function AssetCardRow({
   onEditConnection: (connection: SavedConnection) => void;
 }) {
   const rowKey = row.map((record) => record.connection.id).join(":");
-  const spacerKeys = createSpacerKeys(rowKey || `row-${rowIndex}`, columnCount - row.length);
+  const spacerKeys = createSpacerKeys(
+    rowKey || `row-${rowIndex}`,
+    columnCount - row.length,
+  );
 
   return (
     <div
@@ -145,13 +152,17 @@ function AssetCard({
       style={{
         borderColor: "color-mix(in srgb, var(--df-border) 78%, transparent)",
         color: "var(--df-text)",
-        backgroundColor: "color-mix(in srgb, var(--df-bg-panel) 36%, transparent)",
+        backgroundColor:
+          "color-mix(in srgb, var(--df-bg-panel) 36%, transparent)",
       }}
+      onDoubleClick={() => void onConnectConnection(connection)}
     >
       <div className="flex min-w-0 items-start gap-2.5 px-3 py-2.5">
         <AssetConnectionIcon connection={connection} />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold">{connection.name}</div>
+          <div className="truncate text-sm font-semibold">
+            {connection.name}
+          </div>
           <div
             className="mt-0.5 truncate font-mono text-xs"
             style={{ color: "var(--df-text-muted)" }}
@@ -171,18 +182,31 @@ function AssetCard({
         className="grid min-h-0 flex-1 grid-cols-2 gap-x-3 gap-y-2 px-3 pb-2 text-xs"
         style={{ color: "var(--df-text-muted)" }}
       >
-        <Metric label={t("assets.cpu")} value={formatCpuSummary(asset, labels)} />
-        <Metric label={t("assets.memory")} value={formatBytes(asset?.memory_bytes, labels)} />
-        <Metric label={t("assets.storage")} value={formatDiskSummary(asset?.disks, labels)} />
+        <Metric
+          label={t("assets.cpu")}
+          value={formatCpuSummary(asset, labels)}
+        />
+        <Metric
+          label={t("assets.memory")}
+          value={formatBytes(asset?.memory_bytes, labels)}
+        />
+        <Metric
+          label={t("assets.storage")}
+          value={formatDiskSummary(asset?.disks, labels)}
+        />
         <Metric
           label={t("assets.accelerators")}
-          value={formatAccelerators(asset?.accelerators, labels, { maxItems: 1 })}
+          value={formatAccelerators(asset?.accelerators, labels, {
+            maxItems: 1,
+          })}
         />
       </div>
 
       <div
         className="flex min-h-9 shrink-0 items-center justify-end gap-1.5 border-t px-2.5"
-        style={{ borderColor: "color-mix(in srgb, var(--df-border) 70%, transparent)" }}
+        style={{
+          borderColor: "color-mix(in srgb, var(--df-border) 70%, transparent)",
+        }}
       >
         <CardActionButton
           label={t("savedConnections.connect")}
@@ -206,7 +230,10 @@ function AssetCard({
 function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <div className="truncate text-[0.625rem]" style={{ color: "var(--df-text-dimmed)" }}>
+      <div
+        className="truncate text-[0.625rem]"
+        style={{ color: "var(--df-text-dimmed)" }}
+      >
         {label}
       </div>
       <div className="truncate">{value}</div>
@@ -232,7 +259,8 @@ function CardActionButton({
       style={{
         borderColor: "color-mix(in srgb, var(--df-border) 78%, transparent)",
         color: "var(--df-text-muted)",
-        backgroundColor: "color-mix(in srgb, var(--df-bg-terminal) 42%, transparent)",
+        backgroundColor:
+          "color-mix(in srgb, var(--df-bg-terminal) 42%, transparent)",
       }}
       onClick={onClick}
     >
@@ -241,7 +269,10 @@ function CardActionButton({
   );
 }
 
-function chunkRecords(records: AssetRecord[], columnCount: number): AssetRecord[][] {
+function chunkRecords(
+  records: AssetRecord[],
+  columnCount: number,
+): AssetRecord[][] {
   const rows: AssetRecord[][] = [];
   const safeColumnCount = Math.max(1, columnCount);
   for (let index = 0; index < records.length; index += safeColumnCount) {

--- a/src/components/app/start-workspace/AssetTable.tsx
+++ b/src/components/app/start-workspace/AssetTable.tsx
@@ -1,6 +1,10 @@
 import type { TFunction } from "i18next";
 import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
-import { type PointerEvent as ReactPointerEvent, useMemo, useState } from "react";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useMemo,
+  useState,
+} from "react";
 import { MdEdit, MdLink } from "react-icons/md";
 import { useVirtualList } from "@/hooks/useVirtualList";
 import type { SavedConnection } from "@/types/global";
@@ -67,15 +71,20 @@ export default function AssetTable({
   onConnectConnection,
   onEditConnection,
 }: AssetTableProps) {
-  const [columnWidths, setColumnWidths] =
-    useState<Record<AssetTableColumnKey, number>>(DEFAULT_COLUMN_WIDTHS);
+  const [columnWidths, setColumnWidths] = useState<
+    Record<AssetTableColumnKey, number>
+  >(DEFAULT_COLUMN_WIDTHS);
   const { containerRef, visibleItems, paddingTop, paddingBottom, onScroll } =
     useVirtualList<AssetRecord>(records, {
       itemHeight: ASSET_TABLE_ROW_HEIGHT,
       overscan: 8,
     });
   const tableMinWidth = useMemo(
-    () => ASSET_TABLE_COLUMNS.reduce((total, column) => total + columnWidths[column], 0),
+    () =>
+      ASSET_TABLE_COLUMNS.reduce(
+        (total, column) => total + columnWidths[column],
+        0,
+      ),
     [columnWidths],
   );
 
@@ -91,9 +100,14 @@ export default function AssetTable({
     const minWidth = MIN_COLUMN_WIDTHS[columnKey];
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
-      const nextWidth = Math.max(minWidth, Math.round(startWidth + moveEvent.clientX - startX));
+      const nextWidth = Math.max(
+        minWidth,
+        Math.round(startWidth + moveEvent.clientX - startX),
+      );
       setColumnWidths((current) =>
-        current[columnKey] === nextWidth ? current : { ...current, [columnKey]: nextWidth },
+        current[columnKey] === nextWidth
+          ? current
+          : { ...current, [columnKey]: nextWidth },
       );
     };
 
@@ -119,7 +133,11 @@ export default function AssetTable({
       >
         <colgroup>
           {ASSET_TABLE_COLUMNS.map((column) => (
-            <col key={column} data-asset-column={column} style={{ width: columnWidths[column] }} />
+            <col
+              key={column}
+              data-asset-column={column}
+              style={{ width: columnWidths[column] }}
+            />
           ))}
         </colgroup>
         <thead className="sticky top-0 z-[2]">
@@ -144,7 +162,9 @@ export default function AssetTable({
               sortState={sortState}
               onSortChange={onSortChange}
               width={columnWidths.address}
-              onResizeStart={(event) => handleColumnResizeStart("address", event)}
+              onResizeStart={(event) =>
+                handleColumnResizeStart("address", event)
+              }
             />
             <SortableHeaderCell
               label={t("assets.cpu")}
@@ -162,7 +182,9 @@ export default function AssetTable({
               onSortChange={onSortChange}
               className="asset-col-memory"
               width={columnWidths.memory}
-              onResizeStart={(event) => handleColumnResizeStart("memory", event)}
+              onResizeStart={(event) =>
+                handleColumnResizeStart("memory", event)
+              }
             />
             <SortableHeaderCell
               label={t("assets.storage")}
@@ -171,7 +193,9 @@ export default function AssetTable({
               onSortChange={onSortChange}
               className="asset-col-storage"
               width={columnWidths.storage}
-              onResizeStart={(event) => handleColumnResizeStart("storage", event)}
+              onResizeStart={(event) =>
+                handleColumnResizeStart("storage", event)
+              }
             />
             <SortableHeaderCell
               label={t("assets.accelerators")}
@@ -180,7 +204,9 @@ export default function AssetTable({
               onSortChange={onSortChange}
               className="asset-col-accelerators"
               width={columnWidths.accelerators}
-              onResizeStart={(event) => handleColumnResizeStart("accelerators", event)}
+              onResizeStart={(event) =>
+                handleColumnResizeStart("accelerators", event)
+              }
             />
             <HeaderCell
               className="asset-col-actions sticky right-0 z-[3] text-right"
@@ -201,6 +227,7 @@ export default function AssetTable({
                 style={{
                   color: "var(--df-text)",
                 }}
+                onDoubleClick={() => void onConnectConnection(connection)}
               >
                 <BodyCell>
                   <div className="flex min-w-0 items-center gap-2.5">
@@ -219,7 +246,9 @@ export default function AssetTable({
                   </div>
                 </BodyCell>
                 <BodyCell>{formatAssetAddress(connection, labels)}</BodyCell>
-                <BodyCell className="asset-col-cpu">{formatCpuSummary(asset, labels)}</BodyCell>
+                <BodyCell className="asset-col-cpu">
+                  {formatCpuSummary(asset, labels)}
+                </BodyCell>
                 <BodyCell className="asset-col-memory">
                   {formatBytes(asset?.memory_bytes, labels)}
                 </BodyCell>
@@ -227,7 +256,9 @@ export default function AssetTable({
                   {formatDiskSummary(asset?.disks, labels)}
                 </BodyCell>
                 <BodyCell className="asset-col-accelerators">
-                  {formatAccelerators(asset?.accelerators, labels, { maxItems: 2 })}
+                  {formatAccelerators(asset?.accelerators, labels, {
+                    maxItems: 2,
+                  })}
                 </BodyCell>
                 <BodyCell className="asset-col-actions sticky right-0 text-right">
                   <div className="flex justify-end gap-1">
@@ -314,10 +345,18 @@ function SortableHeaderCell({
   onResizeStart: (event: ReactPointerEvent<HTMLSpanElement>) => void;
 }) {
   const active = sortState?.key === sortKey;
-  const SortIcon = !active ? ChevronsUpDown : sortState.direction === "asc" ? ArrowUp : ArrowDown;
+  const SortIcon = !active
+    ? ChevronsUpDown
+    : sortState.direction === "asc"
+      ? ArrowUp
+      : ArrowDown;
 
   return (
-    <HeaderCell className={className} width={width} onResizeStart={onResizeStart}>
+    <HeaderCell
+      className={className}
+      width={width}
+      onResizeStart={onResizeStart}
+    >
       <button
         type="button"
         className="flex min-w-0 cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-[var(--df-bg-hover)]"
@@ -331,7 +370,13 @@ function SortableHeaderCell({
   );
 }
 
-function BodyCell({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+function BodyCell({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
   return (
     <td
       className={`border-b px-3 py-2 align-middle ${className}`}
@@ -365,7 +410,8 @@ function ActionButton({
       style={{
         borderColor: "color-mix(in srgb, var(--df-border) 78%, transparent)",
         color: "var(--df-text-muted)",
-        backgroundColor: "color-mix(in srgb, var(--df-bg-panel) 50%, transparent)",
+        backgroundColor:
+          "color-mix(in srgb, var(--df-bg-panel) 50%, transparent)",
       }}
       onClick={onClick}
     >

--- a/src/components/terminal/zmodemTerminalEvents.ts
+++ b/src/components/terminal/zmodemTerminalEvents.ts
@@ -127,25 +127,28 @@ export function createZmodemEventHandler(
     pendingProgress = null;
     lastProgressWriteAt = Date.now();
 
+    const fileName = payload.fileName ?? payload.file_name ?? uploadFileName;
+    const bytesTransferred = payload.bytesTransferred ?? payload.bytes_transferred ?? 0;
+    const totalSize = payload.totalSize ?? payload.total_size ?? 0;
+    const percent = totalSize > 0 ? Math.round((bytesTransferred / totalSize) * 100) : 0;
+    const t = getT();
+
     if (payload.direction === "upload") {
-      const fileName = payload.fileName ?? payload.file_name ?? uploadFileName;
       if (fileName) {
         uploadFileName = fileName;
       }
       if (!uploadStarted) {
         uploadStarted = true;
         uploadToastId = toast.message(
-          getT()("fileTransfer.uploadStarted", { name: uploadFileName || fileName }),
+          t("fileTransfer.uploadStarted", { name: uploadFileName || fileName }),
         );
       }
+      terminal.write(
+        `\r\x1b[36m[ZMODEM] ${t("zmodem.uploading", { fileName: uploadFileName || fileName, percent })}\x1b[K`,
+      );
       return;
     }
 
-    const fileName = payload.fileName ?? payload.file_name ?? "";
-    const bytesTransferred = payload.bytesTransferred ?? payload.bytes_transferred ?? 0;
-    const totalSize = payload.totalSize ?? payload.total_size ?? 0;
-    const percent = totalSize > 0 ? Math.round((bytesTransferred / totalSize) * 100) : 0;
-    const t = getT();
     terminal.write(`\r\x1b[36m[ZMODEM] ${t("zmodem.downloading", { fileName, percent })}\x1b[K`);
   };
 

--- a/src/lib/terminalZmodemUpload.ts
+++ b/src/lib/terminalZmodemUpload.ts
@@ -270,6 +270,7 @@ async function resolveUnverifiedZmodemUpload(
   duplicateStrategy: string,
 ): Promise<ConflictProbeResult> {
   if (duplicateStrategy === "skip") {
+    toast.message(i18n.t("zmodem.sftpProbeSkipped"));
     return { paths: [], probeSkipped: true, conflictMode: "skip" };
   }
 


### PR DESCRIPTION
## 功能

在资产界面（卡片视图和列表视图）双击资产即可创建连接，与点击连接按钮效果一致。

## 修改文件
- src/components/app/start-workspace/AssetCardGrid.tsx -- 卡片 article 添加 onDoubleClick
- src/components/app/start-workspace/AssetTable.tsx -- 表格行 tr 添加 onDoubleClick