### PR TITLE
feat: add ping host context menu action for saved connections

### DIFF
--- a/src-tauri/src/cmd/session.rs
+++ b/src-tauri/src/cmd/session.rs
@@ -224,6 +224,47 @@ pub async fn create_local_session(
 }
 
 #[tauri::command]
+pub async fn create_local_command_session(
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, Arc<SessionManager>>,
+    recording_state: tauri::State<'_, Arc<RecordingManager>>,
+    shell_path: String,
+    shell_args: String,
+    name: String,
+    create_request_id: Option<String>,
+) -> AppResult<String> {
+    let pending_creation = state.begin_session_creation(create_request_id).await;
+    let (guard, _cancel_rx) = match pending_creation {
+        Some((guard, cancel_rx)) => (Some(guard), Some(cancel_rx)),
+        None => (None, None),
+    };
+    let config = Some(core::LocalSessionConfig {
+        connection_id: None,
+        shell_path,
+        shell_args,
+        working_dir: None,
+        name,
+        encoding: config::load_app_settings(&app)
+            .map(|settings| settings.interaction.default_encoding)
+            .unwrap_or_else(|_| "UTF-8".to_string()),
+    });
+    let session_id = core::create_local_session(
+        app.clone(),
+        state.inner().clone(),
+        config,
+        Some(window.label().to_string()),
+        Some(build_auto_recording_hook(
+            app.clone(),
+            recording_state.inner().clone(),
+        )),
+    )
+    .await?;
+    drop(guard);
+    Ok(session_id)
+}
+
+#[tauri::command]
 pub async fn create_telnet_session(
     app: tauri::AppHandle,
     window: tauri::WebviewWindow,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,7 @@ pub fn run() {
             cmd::session::create_temporary_ssh_session,
             cmd::session::create_multiplexed_ssh_session,
             cmd::session::create_local_session,
+            cmd::session::create_local_command_session,
             cmd::session::create_telnet_session,
             cmd::session::create_serial_session,
             cmd::rdp::create_rdp_session,

--- a/src/components/panel/saved-connections/ConnectionItem.tsx
+++ b/src/components/panel/saved-connections/ConnectionItem.tsx
@@ -1,6 +1,13 @@
 import type { TFunction } from "i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { MdContentCopy, MdDelete, MdDriveFileRenameOutline, MdEdit, MdLink } from "react-icons/md";
+import {
+  MdContentCopy,
+  MdDelete,
+  MdDriveFileRenameOutline,
+  MdEdit,
+  MdLink,
+  MdNetworkCheck,
+} from "react-icons/md";
 import { toast } from "sonner";
 import {
   ContextMenu,
@@ -9,7 +16,11 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { SavedConnection } from "@/types/global";
 import { resolveConnectionIcon } from "../../icons";
 import { useSavedConnectionsContext } from "./context";
@@ -43,18 +54,23 @@ function formatRequiredDetailValue(
   value: string | number | null | undefined,
   t: TFunction,
 ): string {
-  if (value === null || value === undefined) return t("savedConnections.notSet");
+  if (value === null || value === undefined)
+    return t("savedConnections.notSet");
   const text = String(value).trim();
   return text || t("savedConnections.notSet");
 }
 
-function formatOptionalDetailValue(value: string | number | null | undefined): string | null {
+function formatOptionalDetailValue(
+  value: string | number | null | undefined,
+): string | null {
   if (value === null || value === undefined) return null;
   const text = String(value).trim();
   return text || null;
 }
 
-function getCopyDetailValue(value: string | number | null | undefined): string | undefined {
+function getCopyDetailValue(
+  value: string | number | null | undefined,
+): string | undefined {
   if (value === null || value === undefined) return undefined;
   const text = String(value).trim();
   return text || undefined;
@@ -102,7 +118,8 @@ function getConnectionDetailRows(
   t: TFunction,
 ): ConnectionDetailRow[] {
   const description =
-    formatOptionalDetailValue(conn.description) ?? t("savedConnections.noDescription");
+    formatOptionalDetailValue(conn.description) ??
+    t("savedConnections.noDescription");
 
   switch (conn.type) {
     case "local_terminal": {
@@ -169,8 +186,10 @@ function getConnectionDetailRows(
       ];
       const parity = formatOptionalDetailValue(conn.parity);
       const stopBits = formatOptionalDetailValue(conn.stop_bits);
-      if (parity) rows.push({ label: t("savedConnections.parity"), value: parity });
-      if (stopBits) rows.push({ label: t("savedConnections.stopBits"), value: stopBits });
+      if (parity)
+        rows.push({ label: t("savedConnections.parity"), value: parity });
+      if (stopBits)
+        rows.push({ label: t("savedConnections.stopBits"), value: stopBits });
       rows.push({
         label: t("savedConnections.description"),
         value: description,
@@ -292,7 +311,11 @@ function ConnectionDetailsTooltip({
   );
 }
 
-export default function ConnectionItem({ conn, indented, depth = 0 }: ConnectionItemProps) {
+export default function ConnectionItem({
+  conn,
+  indented,
+  depth = 0,
+}: ConnectionItemProps) {
   const {
     isDragEnabled,
     isPointerDragEnabled,
@@ -304,6 +327,7 @@ export default function ConnectionItem({ conn, indented, depth = 0 }: Connection
     handleConnect,
     handleConnectOnly,
     handleConnectSelected,
+    handlePingHost,
     handleCopyConnection,
     requestMoveConnectionToGroup,
     handleConnectionSelectionStart,
@@ -326,7 +350,8 @@ export default function ConnectionItem({ conn, indented, depth = 0 }: Connection
     t,
   } = useSavedConnectionsContext();
 
-  const isTarget = dragTarget?.id === conn.id && dragTarget.type === "connection";
+  const isTarget =
+    dragTarget?.id === conn.id && dragTarget.type === "connection";
   const showBefore = isTarget && dragTarget.position === "before";
   const showAfter = isTarget && dragTarget.position === "after";
   const iconDef = resolveConnectionIcon(conn.icon);
@@ -338,7 +363,9 @@ export default function ConnectionItem({ conn, indented, depth = 0 }: Connection
       ? t("savedConnections.connectSelected")
       : t("savedConnections.connect");
   const directConnectLabel = t("savedConnections.connect");
-  const iconStyle = { color: isSelected || isKeyboardActive ? "var(--df-primary)" : iconDef.color };
+  const iconStyle = {
+    color: isSelected || isKeyboardActive ? "var(--df-primary)" : iconDef.color,
+  };
   const indentLeft = indented ? `${8 + depth * 16 + 16}px` : "0.5rem";
   const [detailsOpen, setDetailsOpen] = useState(false);
   const detailsOpenTimerRef = useRef<number | null>(null);
@@ -470,15 +497,25 @@ export default function ConnectionItem({ conn, indented, depth = 0 }: Connection
               : undefined
           }
           onDragEnter={
-            isDragEnabled ? (e) => handleDragEnterItem(e, conn.id, "connection") : undefined
+            isDragEnabled
+              ? (e) => handleDragEnterItem(e, conn.id, "connection")
+              : undefined
           }
           onDragOver={
-            isDragEnabled ? (e) => handleDragOverItem(e, conn.id, "connection") : undefined
+            isDragEnabled
+              ? (e) => handleDragOverItem(e, conn.id, "connection")
+              : undefined
           }
           onDragLeave={
-            isDragEnabled ? (e) => handleDragLeaveItem(e, conn.id, "connection") : undefined
+            isDragEnabled
+              ? (e) => handleDragLeaveItem(e, conn.id, "connection")
+              : undefined
           }
-          onDrop={isDragEnabled ? (e) => handleDropItem(e, conn.id, "connection") : undefined}
+          onDrop={
+            isDragEnabled
+              ? (e) => handleDropItem(e, conn.id, "connection")
+              : undefined
+          }
           onDragEnd={
             isDragEnabled
               ? () => {
@@ -497,13 +534,17 @@ export default function ConnectionItem({ conn, indented, depth = 0 }: Connection
           <div
             className={`group/item relative flex min-w-full w-max items-center gap-2 py-1.5 px-2 rounded cursor-pointer transition-colors df-hover ${isTarget && dragTarget.position === "inside" ? "ring-1 ring-primary/60" : ""}`}
             style={{
-              ...(indented ? { paddingLeft: `${8 + depth * 16 + 16}px` } : undefined),
+              ...(indented
+                ? { paddingLeft: `${8 + depth * 16 + 16}px` }
+                : undefined),
               backgroundColor: isSelected
                 ? "color-mix(in srgb, var(--df-primary) 10%, transparent)"
                 : isKeyboardActive
                   ? "color-mix(in srgb, var(--df-primary) 7%, transparent)"
                   : undefined,
-              boxShadow: isKeyboardActive ? "inset 0 0 0 1px var(--df-primary)" : undefined,
+              boxShadow: isKeyboardActive
+                ? "inset 0 0 0 1px var(--df-primary)"
+                : undefined,
             }}
             onMouseDown={(e) => {
               closeAndSuppressDetails();
@@ -530,7 +571,9 @@ export default function ConnectionItem({ conn, indented, depth = 0 }: Connection
                     className="shrink-0 whitespace-nowrap text-xs font-medium"
                     style={{
                       color:
-                        isSelected || isKeyboardActive ? "var(--df-primary)" : "var(--df-text)",
+                        isSelected || isKeyboardActive
+                          ? "var(--df-primary)"
+                          : "var(--df-text)",
                     }}
                   >
                     {conn.name}
@@ -621,6 +664,15 @@ export default function ConnectionItem({ conn, indented, depth = 0 }: Connection
         >
           <MdEdit className="text-[0.875rem] text-muted-foreground mr-2" />
           {t("savedConnections.edit")}
+        </ContextMenuItem>
+        <ContextMenuItem
+          onClick={() => {
+            closeAndSuppressDetails();
+            handlePingHost(conn);
+          }}
+        >
+          <MdNetworkCheck className="text-[0.875rem] text-muted-foreground mr-2" />
+          {t("savedConnections.pingHost")}
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem

--- a/src/components/panel/saved-connections/context.tsx
+++ b/src/components/panel/saved-connections/context.tsx
@@ -1,5 +1,8 @@
 import type { TFunction } from "i18next";
-import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
+import type {
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+} from "react";
 import { createContext, useContext } from "react";
 import type { NewSessionTarget } from "@/lib/windowManager";
 import type { Group, SavedConnection } from "@/types/global";
@@ -42,12 +45,25 @@ export interface SavedConnectionsContextValue {
   handleConnect: (conn: SavedConnection) => void;
   handleConnectOnly: (conn: SavedConnection) => void;
   handleConnectSelected: () => void;
+  handlePingHost: (conn: SavedConnection) => void;
   handleCopyConnection: (conn: SavedConnection) => void;
-  requestMoveConnectionToGroup: (conn: SavedConnection, groupId: string | null) => void;
+  requestMoveConnectionToGroup: (
+    conn: SavedConnection,
+    groupId: string | null,
+  ) => void;
   requestMoveSelectedConnectionsToGroup: (groupId: string | null) => void;
-  handleConnectionSelectionStart: (conn: SavedConnection, event: ReactMouseEvent) => void;
-  handleConnectionContextMenu: (conn: SavedConnection, event: ReactMouseEvent) => void;
-  registerConnectionElement: (id: string, element: HTMLDivElement | null) => void;
+  handleConnectionSelectionStart: (
+    conn: SavedConnection,
+    event: ReactMouseEvent,
+  ) => void;
+  handleConnectionContextMenu: (
+    conn: SavedConnection,
+    event: ReactMouseEvent,
+  ) => void;
+  registerConnectionElement: (
+    id: string,
+    element: HTMLDivElement | null,
+  ) => void;
   onEditConnection: (
     conn: SavedConnection,
     autoConnect?: boolean,
@@ -65,17 +81,37 @@ export interface SavedConnectionsContextValue {
   requestOpenGroupConnections: (node: GroupNode) => void;
 
   // Drag handlers
-  handleDragStart: (e: React.DragEvent, type: "connection" | "group", id: string) => void;
+  handleDragStart: (
+    e: React.DragEvent,
+    type: "connection" | "group",
+    id: string,
+  ) => void;
   handleDragEnd: () => void;
-  handleDragEnterItem: (e: React.DragEvent, id: string, type: "connection" | "group") => void;
-  handleDragOverItem: (e: React.DragEvent, id: string, type: "connection" | "group") => void;
-  handleDragLeaveItem: (e: React.DragEvent, id: string, type: "connection" | "group") => void;
+  handleDragEnterItem: (
+    e: React.DragEvent,
+    id: string,
+    type: "connection" | "group",
+  ) => void;
+  handleDragOverItem: (
+    e: React.DragEvent,
+    id: string,
+    type: "connection" | "group",
+  ) => void;
+  handleDragLeaveItem: (
+    e: React.DragEvent,
+    id: string,
+    type: "connection" | "group",
+  ) => void;
   handleDropItem: (
     e: React.DragEvent,
     id: string,
     tgtType: "connection" | "group",
   ) => Promise<void>;
-  handlePointerDragStart: (e: ReactPointerEvent, type: "connection" | "group", id: string) => void;
+  handlePointerDragStart: (
+    e: ReactPointerEvent,
+    type: "connection" | "group",
+    id: string,
+  ) => void;
   handlePointerDragMove: (e: ReactPointerEvent) => void;
   handlePointerDragEnd: (e: ReactPointerEvent) => void;
   handlePointerDragCancel: (e: ReactPointerEvent) => void;
@@ -83,7 +119,8 @@ export interface SavedConnectionsContextValue {
   t: TFunction;
 }
 
-export const SavedConnectionsContext = createContext<SavedConnectionsContextValue | null>(null);
+export const SavedConnectionsContext =
+  createContext<SavedConnectionsContextValue | null>(null);
 
 export const useSavedConnectionsContext = () => {
   const ctx = useContext(SavedConnectionsContext);

--- a/src/components/panel/saved-connections/index.tsx
+++ b/src/components/panel/saved-connections/index.tsx
@@ -1,5 +1,13 @@
-import { type ComponentProps, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ComponentProps,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
+import { emit } from "@tauri-apps/api/event";
 import { BiExport, BiImport } from "react-icons/bi";
 import {
   MdAdd,
@@ -40,7 +48,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useApp } from "@/context/AppContext";
 import { useConfigTransfer } from "@/hooks/useConfigTransfer";
 import { resolveShortcutKeys } from "@/hooks/useShortcutMap";
@@ -60,7 +72,10 @@ import {
   type SortMode,
 } from "./context";
 import GroupNodeItem from "./GroupNodeItem";
-import { MoveToGroupContextMenu, MoveToGroupDropdownMenu } from "./MoveToGroupMenu";
+import {
+  MoveToGroupContextMenu,
+  MoveToGroupDropdownMenu,
+} from "./MoveToGroupMenu";
 
 interface SavedConnectionsProps {
   onTemporarySshLink: () => void;
@@ -91,7 +106,9 @@ interface PointerSavedDragState {
 
 function shouldUsePointerSavedConnectionsDrag() {
   if (typeof navigator === "undefined") return false;
-  return /Mac/.test(navigator.platform) && /AppleWebKit/.test(navigator.userAgent);
+  return (
+    /Mac/.test(navigator.platform) && /AppleWebKit/.test(navigator.userAgent)
+  );
 }
 
 function areStringSetsEqual(left: Set<string>, right: Set<string>) {
@@ -102,7 +119,11 @@ function areStringSetsEqual(left: Set<string>, right: Set<string>) {
   return true;
 }
 
-function HeaderActionButton({ tooltip, children, ...props }: HeaderActionButtonProps) {
+function HeaderActionButton({
+  tooltip,
+  children,
+  ...props
+}: HeaderActionButtonProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -122,7 +143,17 @@ export default function SavedConnections({
   onEditConnection,
   onConnectConnection,
 }: SavedConnectionsProps) {
-  const { savedConnections, savedGroups, refreshConnections, appSettings, updateUi } = useApp();
+  const {
+    savedConnections,
+    savedGroups,
+    refreshConnections,
+    appSettings,
+    updateUi,
+    addPendingTab,
+    updateTabSession,
+    hasTab,
+    recordRecentConnection,
+  } = useApp();
   const { t } = useTranslation();
   const { handleExport, passwordAlert } = useConfigTransfer();
   const panelRootRef = useRef<HTMLDivElement | null>(null);
@@ -131,21 +162,30 @@ export default function SavedConnections({
   // Tracks in-flight connections to prevent duplicate invocations (not shown in UI)
   const connectingIdsRef = useRef<Set<string>>(new Set());
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  const [selectedConnectionIds, setSelectedConnectionIds] = useState<Set<string>>(new Set());
+  const [selectedConnectionIds, setSelectedConnectionIds] = useState<
+    Set<string>
+  >(new Set());
   const [filterText, setFilterText] = useState("");
-  const [keyboardActiveConnectionId, setKeyboardActiveConnectionId] = useState<string | null>(null);
+  const [keyboardActiveConnectionId, setKeyboardActiveConnectionId] = useState<
+    string | null
+  >(null);
   const searchExpandedBaseRef = useRef<Set<string> | null>(null);
   const searchAutoExpandedGroupIdsRef = useRef<Set<string>>(new Set());
   const previousKeywordRef = useRef("");
   const lastSelectedConnectionIdRef = useRef<string | null>(null);
   const connectionElementRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const sortMode = (appSettings.ui.saved_connections_sort_mode || "default") as SortMode;
+  const sortMode = (appSettings.ui.saved_connections_sort_mode ||
+    "default") as SortMode;
 
   // ── Dialog state ──────────────────────────────────────────────────────────
   const [deleteTargets, setDeleteTargets] = useState<SavedConnection[]>([]);
-  const [renamingConn, setRenamingConn] = useState<SavedConnection | null>(null);
+  const [renamingConn, setRenamingConn] = useState<SavedConnection | null>(
+    null,
+  );
   const [renameValue, setRenameValue] = useState("");
-  const [deleteFolderTarget, setDeleteFolderTarget] = useState<Group | null>(null);
+  const [deleteFolderTarget, setDeleteFolderTarget] = useState<Group | null>(
+    null,
+  );
   const [showClearAllDialog, setShowClearAllDialog] = useState(false);
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [openGroupTarget, setOpenGroupTarget] = useState<{
@@ -154,13 +194,18 @@ export default function SavedConnections({
   } | null>(null);
   const [folderDialogOpen, setFolderDialogOpen] = useState(false);
   const [folderDialogName, setFolderDialogName] = useState("");
-  const [folderDialogParentId, setFolderDialogParentId] = useState<string | null>(null);
+  const [folderDialogParentId, setFolderDialogParentId] = useState<
+    string | null
+  >(null);
   const [editingGroup, setEditingGroup] = useState<Group | null>(null);
 
   // ── Drag state ────────────────────────────────────────────────────────────
   const [dragTarget, _setDragTarget] = useState<DragTarget | null>(null);
   const dragTargetRef = useRef<DragTarget | null>(null);
-  const dragSourceRef = useRef<{ type: "connection" | "group"; id: string } | null>(null);
+  const dragSourceRef = useRef<{
+    type: "connection" | "group";
+    id: string;
+  } | null>(null);
   const pointerDragRef = useRef<PointerSavedDragState | null>(null);
   const connectionsRef = useRef(savedConnections);
   const groupsRef = useRef(savedGroups);
@@ -169,9 +214,13 @@ export default function SavedConnections({
 
   const keyword = filterText.trim().toLowerCase();
   const isDragEnabled = sortMode === "default";
-  const isPointerDragEnabled = isDragEnabled && shouldUsePointerSavedConnectionsDrag();
+  const isPointerDragEnabled =
+    isDragEnabled && shouldUsePointerSavedConnectionsDrag();
   const connectionById = useMemo(
-    () => new Map(savedConnections.map((connection) => [connection.id, connection])),
+    () =>
+      new Map(
+        savedConnections.map((connection) => [connection.id, connection]),
+      ),
     [savedConnections],
   );
 
@@ -187,14 +236,20 @@ export default function SavedConnections({
       : savedConnections;
 
     const sortConns = (list: SavedConnection[]) => {
-      if (sortMode === "name-asc") return [...list].sort((a, b) => naturalCompare(a.name, b.name));
-      if (sortMode === "name-desc") return [...list].sort((a, b) => naturalCompare(b.name, a.name));
-      return [...list].sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
+      if (sortMode === "name-asc")
+        return [...list].sort((a, b) => naturalCompare(a.name, b.name));
+      if (sortMode === "name-desc")
+        return [...list].sort((a, b) => naturalCompare(b.name, a.name));
+      return [...list].sort(
+        (a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0),
+      );
     };
 
     const sortGroups = (list: Group[]) => {
-      if (sortMode === "name-asc") return [...list].sort((a, b) => naturalCompare(a.name, b.name));
-      if (sortMode === "name-desc") return [...list].sort((a, b) => naturalCompare(b.name, a.name));
+      if (sortMode === "name-asc")
+        return [...list].sort((a, b) => naturalCompare(a.name, b.name));
+      if (sortMode === "name-desc")
+        return [...list].sort((a, b) => naturalCompare(b.name, a.name));
       return [...list].sort((a, b) => a.sort_order - b.sort_order);
     };
 
@@ -214,7 +269,12 @@ export default function SavedConnections({
     const map: Record<string, GroupNode> = {};
     const sortedGroups = sortGroups(savedGroups);
     for (const g of sortedGroups) {
-      map[g.id] = { group: g, children: [], connections: connByGroup[g.id] || [], totalCount: 0 };
+      map[g.id] = {
+        group: g,
+        children: [],
+        connections: connByGroup[g.id] || [],
+        totalCount: 0,
+      };
     }
 
     const roots: GroupNode[] = [];
@@ -226,7 +286,8 @@ export default function SavedConnections({
 
     const computeTotal = (node: GroupNode): number => {
       node.totalCount =
-        node.connections.length + node.children.reduce((s, c) => s + computeTotal(c), 0);
+        node.connections.length +
+        node.children.reduce((s, c) => s + computeTotal(c), 0);
       return node.totalCount;
     };
     roots.forEach(computeTotal);
@@ -236,7 +297,10 @@ export default function SavedConnections({
       return node.connections.length > 0 || node.children.length > 0;
     };
 
-    return { rootNodes: keyword ? roots.filter(prune) : roots, ungrouped: noGroup };
+    return {
+      rootNodes: keyword ? roots.filter(prune) : roots,
+      ungrouped: noGroup,
+    };
   }, [savedConnections, savedGroups, keyword, sortMode]);
 
   useEffect(() => {
@@ -244,7 +308,9 @@ export default function SavedConnections({
       appSettings.ui.saved_connections_expanded_group_ids ?? [],
     );
     setExpandedGroups((prev) => {
-      return areStringSetsEqual(prev, persistedExpandedGroups) ? prev : persistedExpandedGroups;
+      return areStringSetsEqual(prev, persistedExpandedGroups)
+        ? prev
+        : persistedExpandedGroups;
     });
   }, [appSettings.ui.saved_connections_expanded_group_ids]);
 
@@ -337,7 +403,12 @@ export default function SavedConnections({
       .filter((connection): connection is SavedConnection => !!connection);
 
     return [...orderedVisible, ...hiddenSelected];
-  }, [connectionById, selectedConnectionIds, visibleConnectionIdSet, visibleConnectionIds]);
+  }, [
+    connectionById,
+    selectedConnectionIds,
+    visibleConnectionIdSet,
+    visibleConnectionIds,
+  ]);
 
   useEffect(() => {
     if (!keyword || visibleConnectionIds.length === 0) {
@@ -346,7 +417,9 @@ export default function SavedConnections({
     }
 
     setKeyboardActiveConnectionId((currentId) =>
-      currentId && visibleConnectionIdSet.has(currentId) ? currentId : visibleConnectionIds[0],
+      currentId && visibleConnectionIdSet.has(currentId)
+        ? currentId
+        : visibleConnectionIds[0],
     );
   }, [keyword, visibleConnectionIdSet, visibleConnectionIds]);
 
@@ -358,17 +431,23 @@ export default function SavedConnections({
       ?.scrollIntoView({ block: "nearest" });
   }, [keyboardActiveConnectionId, keyword]);
 
-  const registerConnectionElement = useCallback((id: string, element: HTMLDivElement | null) => {
-    if (element) {
-      connectionElementRefs.current.set(id, element);
-    } else {
-      connectionElementRefs.current.delete(id);
-    }
-  }, []);
+  const registerConnectionElement = useCallback(
+    (id: string, element: HTMLDivElement | null) => {
+      if (element) {
+        connectionElementRefs.current.set(id, element);
+      } else {
+        connectionElementRefs.current.delete(id);
+      }
+    },
+    [],
+  );
 
   const requestDeleteConnection = useCallback(
     (conn: SavedConnection) => {
-      if (selectedConnectionIds.has(conn.id) && selectedConnections.length > 1) {
+      if (
+        selectedConnectionIds.has(conn.id) &&
+        selectedConnections.length > 1
+      ) {
         setDeleteTargets(selectedConnections);
         return;
       }
@@ -386,23 +465,35 @@ export default function SavedConnections({
   const moveConnectionsToGroup = useCallback(
     async (connections: SavedConnection[], targetGroupId: string | null) => {
       const uniqueConnections = Array.from(
-        new Map(connections.map((connection) => [connection.id, connection])).values(),
+        new Map(
+          connections.map((connection) => [connection.id, connection]),
+        ).values(),
       );
       if (uniqueConnections.length === 0) return;
 
-      const movingIds = new Set(uniqueConnections.map((connection) => connection.id));
+      const movingIds = new Set(
+        uniqueConnections.map((connection) => connection.id),
+      );
       const targetSiblings = connectionsRef.current
         .filter(
           (connection) =>
-            (connection.group_id ?? null) === targetGroupId && !movingIds.has(connection.id),
+            (connection.group_id ?? null) === targetGroupId &&
+            !movingIds.has(connection.id),
         )
-        .sort((left, right) => (left.sort_order ?? 0) - (right.sort_order ?? 0));
-      const orderedTargetConnections = [...targetSiblings, ...uniqueConnections];
+        .sort(
+          (left, right) => (left.sort_order ?? 0) - (right.sort_order ?? 0),
+        );
+      const orderedTargetConnections = [
+        ...targetSiblings,
+        ...uniqueConnections,
+      ];
 
       try {
         await Promise.all(
           uniqueConnections
-            .filter((connection) => (connection.group_id ?? null) !== targetGroupId)
+            .filter(
+              (connection) => (connection.group_id ?? null) !== targetGroupId,
+            )
             .map((connection) =>
               invoke("save_connection", {
                 connection: { ...connection, group_id: targetGroupId },
@@ -433,7 +524,11 @@ export default function SavedConnections({
           message: "Move connections to group failed",
           error,
         });
-        toast.error(t("savedConnections.moveToGroupFailed", { error: getErrorMessage(error) }));
+        toast.error(
+          t("savedConnections.moveToGroupFailed", {
+            error: getErrorMessage(error),
+          }),
+        );
       }
     },
     [refreshConnections, t],
@@ -459,14 +554,19 @@ export default function SavedConnections({
   );
 
   useEffect(() => {
-    const validIds = new Set(savedConnections.map((connection) => connection.id));
+    const validIds = new Set(
+      savedConnections.map((connection) => connection.id),
+    );
 
     setSelectedConnectionIds((prev) => {
       const next = new Set(Array.from(prev).filter((id) => validIds.has(id)));
       return next.size === prev.size ? prev : next;
     });
 
-    if (lastSelectedConnectionIdRef.current && !validIds.has(lastSelectedConnectionIdRef.current)) {
+    if (
+      lastSelectedConnectionIdRef.current &&
+      !validIds.has(lastSelectedConnectionIdRef.current)
+    ) {
       lastSelectedConnectionIdRef.current = null;
     }
   }, [savedConnections]);
@@ -487,7 +587,10 @@ export default function SavedConnections({
     persistExpandedGroups(next);
   };
 
-  const allGroupIds = useMemo(() => new Set(savedGroups.map((group) => group.id)), [savedGroups]);
+  const allGroupIds = useMemo(
+    () => new Set(savedGroups.map((group) => group.id)),
+    [savedGroups],
+  );
 
   const allGroupsExpanded = useMemo(() => {
     if (savedGroups.length === 0) return false;
@@ -516,7 +619,9 @@ export default function SavedConnections({
     }
 
     const [start, end] =
-      anchorIndex < targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
+      anchorIndex < targetIndex
+        ? [anchorIndex, targetIndex]
+        : [targetIndex, anchorIndex];
     const next = additive ? new Set(baseSelection) : new Set<string>();
 
     for (let index = start; index <= end; index += 1) {
@@ -526,7 +631,10 @@ export default function SavedConnections({
     return next;
   };
 
-  const handleConnectionSelectionStart = (conn: SavedConnection, event: React.MouseEvent) => {
+  const handleConnectionSelectionStart = (
+    conn: SavedConnection,
+    event: React.MouseEvent,
+  ) => {
     if (event.button !== 0) return;
 
     if (keyword) {
@@ -535,13 +643,21 @@ export default function SavedConnections({
 
     const additive = event.ctrlKey || event.metaKey;
     setSelectedConnectionIds((prev) => {
-      const hasRangeAnchor = event.shiftKey && !!lastSelectedConnectionIdRef.current;
-      const anchor = hasRangeAnchor ? (lastSelectedConnectionIdRef.current ?? conn.id) : conn.id;
+      const hasRangeAnchor =
+        event.shiftKey && !!lastSelectedConnectionIdRef.current;
+      const anchor = hasRangeAnchor
+        ? (lastSelectedConnectionIdRef.current ?? conn.id)
+        : conn.id;
       const baseSelection = additive ? new Set(prev) : new Set<string>();
       let next: Set<string>;
 
       if (hasRangeAnchor) {
-        next = getConnectionRangeSelection(anchor, conn.id, baseSelection, additive);
+        next = getConnectionRangeSelection(
+          anchor,
+          conn.id,
+          baseSelection,
+          additive,
+        );
       } else if (additive) {
         next = new Set(prev);
         if (next.has(conn.id)) {
@@ -558,7 +674,10 @@ export default function SavedConnections({
     });
   };
 
-  const handleConnectionContextMenu = (conn: SavedConnection, _event: React.MouseEvent) => {
+  const handleConnectionContextMenu = (
+    conn: SavedConnection,
+    _event: React.MouseEvent,
+  ) => {
     setSelectedConnectionIds((prev) => {
       if (prev.has(conn.id)) {
         return prev;
@@ -575,7 +694,9 @@ export default function SavedConnections({
     try {
       await onConnectConnection(conn);
     } catch (e) {
-      toast.error(t("savedConnections.connectionFailed", { error: getErrorMessage(e) }));
+      toast.error(
+        t("savedConnections.connectionFailed", { error: getErrorMessage(e) }),
+      );
     } finally {
       connectingIdsRef.current.delete(conn.id);
     }
@@ -605,7 +726,37 @@ export default function SavedConnections({
     openConnections([conn]);
   };
 
-  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handlePingHost = async (conn: SavedConnection) => {
+    const host = conn.host?.trim();
+    if (!host) {
+      toast.error(t("savedConnections.pingNoHost"));
+      return;
+    }
+    const tabName = `ping ${host}`;
+    const pending = addPendingTab(tabName, "Local", conn.id);
+    const { tabId, createRequestId } = pending;
+    try {
+      const sessionId = await invoke<string>("create_local_command_session", {
+        shellPath: "ping",
+        shellArgs: host,
+        name: tabName,
+        createRequestId,
+      });
+      if (!hasTab(tabId)) return;
+      updateTabSession(tabId, sessionId);
+      recordRecentConnection(conn.id);
+      requestAnimationFrame(() => {
+        void emit(`focus-terminal-${sessionId}`);
+      });
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage);
+    }
+  };
+
+  const handleSearchKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
     if (!keyword || visibleConnectionIds.length === 0) return;
     if (event.nativeEvent.isComposing || event.key === "Process") return;
 
@@ -614,13 +765,18 @@ export default function SavedConnections({
       event.stopPropagation();
 
       setKeyboardActiveConnectionId((currentId) => {
-        const currentIndex = currentId ? visibleConnectionIds.indexOf(currentId) : -1;
+        const currentIndex = currentId
+          ? visibleConnectionIds.indexOf(currentId)
+          : -1;
         if (event.key === "ArrowDown") {
-          return visibleConnectionIds[(currentIndex + 1) % visibleConnectionIds.length];
+          return visibleConnectionIds[
+            (currentIndex + 1) % visibleConnectionIds.length
+          ];
         }
 
         return visibleConnectionIds[
-          (currentIndex - 1 + visibleConnectionIds.length) % visibleConnectionIds.length
+          (currentIndex - 1 + visibleConnectionIds.length) %
+            visibleConnectionIds.length
         ];
       });
       return;
@@ -629,7 +785,8 @@ export default function SavedConnections({
     if (event.key !== "Enter") return;
 
     const activeId =
-      keyboardActiveConnectionId && visibleConnectionIdSet.has(keyboardActiveConnectionId)
+      keyboardActiveConnectionId &&
+      visibleConnectionIdSet.has(keyboardActiveConnectionId)
         ? keyboardActiveConnectionId
         : visibleConnectionIds[0];
     const activeConnection = connectionById.get(activeId);
@@ -643,7 +800,12 @@ export default function SavedConnections({
   const handleCopyConnection = async (conn: SavedConnection) => {
     try {
       await invoke("save_connection", {
-        connection: { ...conn, id: "", name: `${conn.name} (copy)`, password: undefined },
+        connection: {
+          ...conn,
+          id: "",
+          name: `${conn.name} (copy)`,
+          password: undefined,
+        },
       });
       refreshConnections();
     } catch (e) {
@@ -682,7 +844,10 @@ export default function SavedConnections({
 
       if (
         !matchesKeyEvent(
-          resolveShortcutKeys("savedConnections.copySelected", appSettings.keybindings),
+          resolveShortcutKeys(
+            "savedConnections.copySelected",
+            appSettings.keybindings,
+          ),
           event,
         )
       ) {
@@ -705,10 +870,14 @@ export default function SavedConnections({
 
     try {
       await Promise.all(
-        deleteTargets.map((connection) => invoke("delete_connection", { id: connection.id })),
+        deleteTargets.map((connection) =>
+          invoke("delete_connection", { id: connection.id }),
+        ),
       );
       setSelectedConnectionIds((prev) => {
-        const next = new Set(Array.from(prev).filter((id) => !targetIds.has(id)));
+        const next = new Set(
+          Array.from(prev).filter((id) => !targetIds.has(id)),
+        );
         return next.size === prev.size ? prev : next;
       });
       if (
@@ -758,7 +927,9 @@ export default function SavedConnections({
     if (!folderDialogName.trim()) return;
     try {
       if (editingGroup) {
-        await invoke("save_group", { group: { ...editingGroup, name: folderDialogName.trim() } });
+        await invoke("save_group", {
+          group: { ...editingGroup, name: folderDialogName.trim() },
+        });
       } else {
         await invoke("save_group", {
           group: {
@@ -808,7 +979,11 @@ export default function SavedConnections({
     while (changed) {
       changed = false;
       savedGroups.forEach((group) => {
-        if (group.parent_id && groupIds.has(group.parent_id) && !groupIds.has(group.id)) {
+        if (
+          group.parent_id &&
+          groupIds.has(group.parent_id) &&
+          !groupIds.has(group.id)
+        ) {
           groupIds.add(group.id);
           changed = true;
         }
@@ -850,8 +1025,14 @@ export default function SavedConnections({
     const customPayload = dataTransfer?.getData(SAVED_CONNECTIONS_DRAG_MIME);
     if (customPayload) {
       try {
-        const parsed = JSON.parse(customPayload) as { type: string; id: string };
-        if ((parsed.type === "connection" || parsed.type === "group") && parsed.id) {
+        const parsed = JSON.parse(customPayload) as {
+          type: string;
+          id: string;
+        };
+        if (
+          (parsed.type === "connection" || parsed.type === "group") &&
+          parsed.id
+        ) {
           const source = {
             type: parsed.type,
             id: parsed.id,
@@ -893,7 +1074,11 @@ export default function SavedConnections({
     if (source.type === targetType && source.id === targetId) {
       return false;
     }
-    if (source.type === "group" && targetType === "group" && isDescendant(targetId, source.id)) {
+    if (
+      source.type === "group" &&
+      targetType === "group" &&
+      isDescendant(targetId, source.id)
+    ) {
       return false;
     }
     if (source.type === "group" && targetType === "connection") {
@@ -951,7 +1136,9 @@ export default function SavedConnections({
   ): DragTarget | null => {
     const elements = document.elementsFromPoint(clientX, clientY);
     for (const element of elements) {
-      const target = element.closest<HTMLElement>("[data-saved-drop-type][data-saved-drop-id]");
+      const target = element.closest<HTMLElement>(
+        "[data-saved-drop-type][data-saved-drop-id]",
+      );
       if (!target) continue;
 
       const type = target.dataset.savedDropType;
@@ -962,11 +1149,18 @@ export default function SavedConnections({
       return {
         id,
         type,
-        position: computeDropPositionFromPoint(target, clientY, type, source.type),
+        position: computeDropPositionFromPoint(
+          target,
+          clientY,
+          type,
+          source.type,
+        ),
       };
     }
 
-    const background = panelRootRef.current?.querySelector<HTMLElement>("[data-saved-drop-bg]");
+    const background = panelRootRef.current?.querySelector<HTMLElement>(
+      "[data-saved-drop-bg]",
+    );
     if (!background) return null;
     const rect = background.getBoundingClientRect();
     if (
@@ -982,13 +1176,22 @@ export default function SavedConnections({
       source.type === "connection"
         ? !connectionsRef.current.find((c) => c.id === source.id)?.group_id
         : !groupsRef.current.find((g) => g.id === source.id)?.parent_id;
-    return isAtRoot ? null : { id: null, type: "background", position: "inside" };
+    return isAtRoot
+      ? null
+      : { id: null, type: "background", position: "inside" };
   };
 
-  const handleDragStart = (e: React.DragEvent, type: "connection" | "group", id: string) => {
+  const handleDragStart = (
+    e: React.DragEvent,
+    type: "connection" | "group",
+    id: string,
+  ) => {
     e.stopPropagation();
     // WebKit-based runtimes may ignore HTML5 drops unless the drag carries real data.
-    e.dataTransfer.setData(SAVED_CONNECTIONS_DRAG_MIME, JSON.stringify({ type, id }));
+    e.dataTransfer.setData(
+      SAVED_CONNECTIONS_DRAG_MIME,
+      JSON.stringify({ type, id }),
+    );
     e.dataTransfer.setData("text/plain", `${type}:${id}`);
     e.dataTransfer.effectAllowed = "move";
     dragSourceRef.current = { type, id };
@@ -1005,7 +1208,8 @@ export default function SavedConnections({
     id: string,
   ) => {
     if (!isPointerDragEnabled) return;
-    if (e.button !== 0 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+    if (e.button !== 0 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey)
+      return;
 
     pointerDragRef.current = {
       type,
@@ -1058,11 +1262,16 @@ export default function SavedConnections({
     if (!state.dragging) return;
 
     const source = { type: state.type, id: state.id } as const;
-    const target = state.dragging ? resolvePointerItemTarget(e.clientX, e.clientY, source) : null;
+    const target = state.dragging
+      ? resolvePointerItemTarget(e.clientX, e.clientY, source)
+      : null;
     setDragTarget(null);
     dragSourceRef.current = null;
 
-    if ((target?.type === "connection" || target?.type === "group") && target.id) {
+    if (
+      (target?.type === "connection" || target?.type === "group") &&
+      target.id
+    ) {
       void submitItemDrop(source, target.id, target.type, target.position);
     } else if (target?.type === "background") {
       void dropSourceToRoot(source);
@@ -1084,7 +1293,11 @@ export default function SavedConnections({
     setDragTarget(null);
   };
 
-  const updateItemDragTarget = (e: React.DragEvent, id: string, type: "connection" | "group") => {
+  const updateItemDragTarget = (
+    e: React.DragEvent,
+    id: string,
+    type: "connection" | "group",
+  ) => {
     e.preventDefault();
     e.stopPropagation();
     const source = resolveDragSource(e.dataTransfer);
@@ -1096,19 +1309,32 @@ export default function SavedConnections({
     e.dataTransfer.dropEffect = "move";
     const position = computeDropPosition(e, type, source.type);
     const prev = dragTargetRef.current;
-    if (prev?.id === id && prev.type === type && prev.position === position) return;
+    if (prev?.id === id && prev.type === type && prev.position === position)
+      return;
     setDragTarget({ id, type, position });
   };
 
-  const handleDragEnterItem = (e: React.DragEvent, id: string, type: "connection" | "group") => {
+  const handleDragEnterItem = (
+    e: React.DragEvent,
+    id: string,
+    type: "connection" | "group",
+  ) => {
     updateItemDragTarget(e, id, type);
   };
 
-  const handleDragOverItem = (e: React.DragEvent, id: string, type: "connection" | "group") => {
+  const handleDragOverItem = (
+    e: React.DragEvent,
+    id: string,
+    type: "connection" | "group",
+  ) => {
     updateItemDragTarget(e, id, type);
   };
 
-  const handleDragLeaveItem = (e: React.DragEvent, id: string, type: "connection" | "group") => {
+  const handleDragLeaveItem = (
+    e: React.DragEvent,
+    id: string,
+    type: "connection" | "group",
+  ) => {
     const related = e.relatedTarget as Node | null;
     if (related && (e.currentTarget as HTMLElement).contains(related)) return;
     const cur = dragTargetRef.current;
@@ -1136,9 +1362,14 @@ export default function SavedConnections({
               .filter((c) => c.group_id === id && c.id !== srcId)
               .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
             groupConns.push({ ...conn, group_id: id });
-            await invoke("save_connection", { connection: { ...conn, group_id: id } });
+            await invoke("save_connection", {
+              connection: { ...conn, group_id: id },
+            });
             await invoke("reorder_items", {
-              connections: groupConns.map((c, i) => ({ id: c.id, sort_order: i })),
+              connections: groupConns.map((c, i) => ({
+                id: c.id,
+                sort_order: i,
+              })),
               groups: [],
             });
             refreshConnections();
@@ -1153,7 +1384,10 @@ export default function SavedConnections({
             await invoke("save_group", { group: { ...grp, parent_id: id } });
             await invoke("reorder_items", {
               connections: [],
-              groups: groupChildren.map((g, i) => ({ id: g.id, sort_order: i })),
+              groups: groupChildren.map((g, i) => ({
+                id: g.id,
+                sort_order: i,
+              })),
             });
             refreshConnections();
           }
@@ -1166,13 +1400,21 @@ export default function SavedConnections({
           ? (connections.find((c) => c.id === id)?.group_id ?? null)
           : (groups.find((g) => g.id === id)?.parent_id ?? null);
 
-      const srcConn = srcType === "connection" ? connections.find((c) => c.id === srcId) : null;
-      const srcGrp = srcType === "group" ? groups.find((g) => g.id === srcId) : null;
+      const srcConn =
+        srcType === "connection"
+          ? connections.find((c) => c.id === srcId)
+          : null;
+      const srcGrp =
+        srcType === "group" ? groups.find((g) => g.id === srcId) : null;
 
       if (srcConn && (srcConn.group_id ?? null) !== targetParentId)
-        await invoke("save_connection", { connection: { ...srcConn, group_id: targetParentId } });
+        await invoke("save_connection", {
+          connection: { ...srcConn, group_id: targetParentId },
+        });
       if (srcGrp && (srcGrp.parent_id ?? null) !== targetParentId)
-        await invoke("save_group", { group: { ...srcGrp, parent_id: targetParentId } });
+        await invoke("save_group", {
+          group: { ...srcGrp, parent_id: targetParentId },
+        });
 
       const connsUpdates: { id: string; sort_order: number }[] = [];
       const groupsUpdates: { id: string; sort_order: number }[] = [];
@@ -1202,7 +1444,9 @@ export default function SavedConnections({
       } else {
         if (srcType === "connection" && srcConn) {
           const siblings = connections
-            .filter((c) => (c.group_id ?? null) === targetParentId && c.id !== srcId)
+            .filter(
+              (c) => (c.group_id ?? null) === targetParentId && c.id !== srcId,
+            )
             .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
           siblings.push(srcConn);
           siblings.forEach((c, i) => {
@@ -1210,7 +1454,9 @@ export default function SavedConnections({
           });
         } else if (srcType === "group" && srcGrp) {
           const siblings = groups
-            .filter((g) => (g.parent_id ?? null) === targetParentId && g.id !== srcId)
+            .filter(
+              (g) => (g.parent_id ?? null) === targetParentId && g.id !== srcId,
+            )
             .sort((a, b) => a.sort_order - b.sort_order);
           siblings.push(srcGrp);
           siblings.forEach((g, i) => {
@@ -1220,7 +1466,10 @@ export default function SavedConnections({
       }
 
       if (connsUpdates.length > 0 || groupsUpdates.length > 0)
-        await invoke("reorder_items", { connections: connsUpdates, groups: groupsUpdates });
+        await invoke("reorder_items", {
+          connections: connsUpdates,
+          groups: groupsUpdates,
+        });
       refreshConnections();
     } catch (err) {
       logger.error({
@@ -1244,7 +1493,12 @@ export default function SavedConnections({
     dragSourceRef.current = null;
     if (!source || !canDropOnItem(source, id, tgtType)) return;
 
-    await submitItemDrop(source, id, tgtType, computeDropPosition(e, tgtType, source.type));
+    await submitItemDrop(
+      source,
+      id,
+      tgtType,
+      computeDropPosition(e, tgtType, source.type),
+    );
   };
 
   const handleDragOverBg = (e: React.DragEvent) => {
@@ -1265,12 +1519,17 @@ export default function SavedConnections({
       setDragTarget({ id: null, type: "background", position: "inside" });
   };
 
-  async function dropSourceToRoot(source: { type: "connection" | "group"; id: string }) {
+  async function dropSourceToRoot(source: {
+    type: "connection" | "group";
+    id: string;
+  }) {
     try {
       if (source.type === "connection") {
         const conn = connectionsRef.current.find((c) => c.id === source.id);
         if (conn?.group_id) {
-          await invoke("save_connection", { connection: { ...conn, group_id: null } });
+          await invoke("save_connection", {
+            connection: { ...conn, group_id: null },
+          });
           const siblings = connectionsRef.current
             .filter((c) => !c.group_id && c.id !== source.id)
             .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
@@ -1318,7 +1577,11 @@ export default function SavedConnections({
   // ── Sort button helpers ───────────────────────────────────────────────────
   const cycleSortMode = () => {
     const next =
-      sortMode === "default" ? "name-asc" : sortMode === "name-asc" ? "name-desc" : "default";
+      sortMode === "default"
+        ? "name-asc"
+        : sortMode === "name-asc"
+          ? "name-desc"
+          : "default";
     updateUi({ saved_connections_sort_mode: next });
   };
   const sortTitle =
@@ -1344,6 +1607,7 @@ export default function SavedConnections({
     handleConnect,
     handleConnectOnly,
     handleConnectSelected,
+    handlePingHost,
     handleCopyConnection,
     requestMoveConnectionToGroup,
     requestMoveSelectedConnectionsToGroup,
@@ -1380,7 +1644,10 @@ export default function SavedConnections({
           title={t("panel.savedConnections")}
           actions={
             savedConnections.length > 0 ? (
-              <span className="text-[0.6875rem]" style={{ color: "var(--df-text-dimmed)" }}>
+              <span
+                className="text-[0.6875rem]"
+                style={{ color: "var(--df-text-dimmed)" }}
+              >
                 {savedConnections.length}
               </span>
             ) : null
@@ -1390,7 +1657,8 @@ export default function SavedConnections({
         <div
           className="nyaterm-wallpaper-transparent-surface flex items-center gap-1.5 px-2 py-1.5 shrink-0 border-b"
           style={{
-            borderColor: "color-mix(in srgb, var(--df-border) 40%, transparent)",
+            borderColor:
+              "color-mix(in srgb, var(--df-border) 40%, transparent)",
             backgroundColor: "var(--df-bg-section-header)",
           }}
         >
@@ -1423,13 +1691,20 @@ export default function SavedConnections({
               variant="ghost"
               size="icon-sm"
               className="shrink-0 h-6 w-6 rounded-md p-0 transition-colors hover:bg-[var(--df-bg-hover)]"
-              style={{ color: sortActive ? "var(--df-primary)" : "var(--df-text-muted)" }}
+              style={{
+                color: sortActive
+                  ? "var(--df-primary)"
+                  : "var(--df-text-muted)",
+              }}
               tooltip={sortTitle}
               onClick={cycleSortMode}
             >
               <SortIcon
                 className="text-xs"
-                style={{ transform: sortMode === "name-desc" ? "scaleY(-1)" : undefined }}
+                style={{
+                  transform:
+                    sortMode === "name-desc" ? "scaleY(-1)" : undefined,
+                }}
               />
             </HeaderActionButton>
 
@@ -1482,7 +1757,9 @@ export default function SavedConnections({
                 {savedGroups.length > 0 && (
                   <>
                     <DropdownMenuItem
-                      onClick={allGroupsExpanded ? collapseAllGroups : expandAllGroups}
+                      onClick={
+                        allGroupsExpanded ? collapseAllGroups : expandAllGroups
+                      }
                       className="cursor-pointer gap-2 py-1.5 focus:bg-[var(--df-bg-hover)]"
                     >
                       {allGroupsExpanded ? (
@@ -1554,11 +1831,14 @@ export default function SavedConnections({
               data-saved-drop-bg
               className={`flex-1 overflow-x-auto overflow-y-auto p-1.5 text-xs space-y-0.5 terminal-scroll ${dragTarget?.type === "background" ? "ring-inset ring-2 ring-primary/20" : ""}`}
               onMouseDown={(event) => {
-                if (event.button !== 0 || event.target !== event.currentTarget) return;
+                if (event.button !== 0 || event.target !== event.currentTarget)
+                  return;
                 setSelectedConnectionIds(new Set());
                 lastSelectedConnectionIdRef.current = null;
               }}
-              onDragEnter={isDragEnabled ? (e) => e.preventDefault() : undefined}
+              onDragEnter={
+                isDragEnabled ? (e) => e.preventDefault() : undefined
+              }
               onDragOver={isDragEnabled ? handleDragOverBg : undefined}
               onDrop={isDragEnabled ? handleDropBg : undefined}
             >
@@ -1585,12 +1865,17 @@ export default function SavedConnections({
                     <div
                       className="mt-1 pt-1 border-t"
                       style={{
-                        borderColor: "color-mix(in srgb, var(--df-border) 50%, transparent)",
+                        borderColor:
+                          "color-mix(in srgb, var(--df-border) 50%, transparent)",
                       }}
                     />
                   )}
                   {ungrouped.map((conn) => (
-                    <ConnectionItem key={conn.id} conn={conn} indented={false} />
+                    <ConnectionItem
+                      key={conn.id}
+                      conn={conn}
+                      indented={false}
+                    />
                   ))}
                 </>
               )}
@@ -1613,7 +1898,10 @@ export default function SavedConnections({
               />
             )}
             {selectedConnections.length > 0 && (
-              <ContextMenuItem className="text-red-400" onClick={requestDeleteSelectedConnections}>
+              <ContextMenuItem
+                className="text-red-400"
+                onClick={requestDeleteSelectedConnections}
+              >
                 <MdDelete className="text-[0.875rem] mr-2" />
                 {selectedConnections.length > 1
                   ? t("savedConnections.deleteSelected")
@@ -1640,7 +1928,9 @@ export default function SavedConnections({
         {/* Dialogs */}
         <DeleteConnectionDialog
           open={deleteTargets.length > 0}
-          connectionName={deleteTargets.length === 1 ? deleteTargets[0]?.name : undefined}
+          connectionName={
+            deleteTargets.length === 1 ? deleteTargets[0]?.name : undefined
+          }
           count={deleteTargets.length}
           onConfirm={handleDeleteConfirm}
           onCancel={() => setDeleteTargets([])}
@@ -1678,7 +1968,10 @@ export default function SavedConnections({
           onConfirm={handleConfirmOpenGroupConnections}
           onCancel={() => setOpenGroupTarget(null)}
         />
-        <ImportDialog open={showImportDialog} onClose={() => setShowImportDialog(false)} />
+        <ImportDialog
+          open={showImportDialog}
+          onClose={() => setShowImportDialog(false)}
+        />
         {passwordAlert}
       </div>
     </SavedConnectionsContext.Provider>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1573,6 +1573,8 @@
     "openAllConnections": "Open All",
     "openAllConnectionsConfirm": "Open all {{count}} connections in folder '{{name}}'?",
     "parity": "Parity",
+    "pingHost": "Ping host",
+    "pingNoHost": "This connection has no host to ping",
     "port": "Port",
     "rename": "Rename",
     "renameFolder": "Rename Folder",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1572,6 +1572,8 @@
     "openAllConnections": "모두 열기",
     "openAllConnectionsConfirm": "폴더 '{{name}}' 안의 연결 {{count}}개를 모두 열까요?",
     "parity": "패리티",
+    "pingHost": "Ping 호스트",
+    "pingNoHost": "이 연결에는 Ping할 호스트가 없습니다",
     "port": "포트",
     "rename": "이름 바꾸기",
     "renameFolder": "폴더 이름 바꾸기",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1572,6 +1572,8 @@
     "openAllConnections": "打开全部连接",
     "openAllConnectionsConfirm": "确定要打开文件夹「{{name}}」中的 {{count}} 个连接吗？",
     "parity": "校验位",
+    "pingHost": "Ping 主机",
+    "pingNoHost": "该连接没有主机地址可 Ping",
     "port": "端口",
     "rename": "重命名",
     "renameFolder": "重命名文件夹",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1570,6 +1570,8 @@
     "openAllConnections": "開啟全部連線",
     "openAllConnectionsConfirm": "確定要開啟資料夾「{{name}}」中的 {{count}} 個連線嗎？",
     "parity": "校驗位",
+    "pingHost": "Ping 主機",
+    "pingNoHost": "該連線沒有主機位址可 Ping",
     "port": "埠",
     "rename": "重新命名",
     "renameFolder": "重新命名資料夾",


### PR DESCRIPTION
## Summary

Add a **Ping host** action to the saved connections context menu. Right-clicking a saved connection now offers a "Ping host" item that opens a new local terminal running `ping <host>` and focuses it.

## Changes

- **Backend**: new Tauri command `create_local_command_session` (src-tauri/src/cmd/session.rs) that spawns an arbitrary command in a local PTY session, registered in lib.rs.
- **Frontend**: `handlePingHost` in the saved-connections panel creates a new `Local` tab running `ping <host>`, updates the active session, records the recent connection, and focuses the terminal.
- **Context menu**: "Ping host" item added in ConnectionItem.tsx (uses MdNetworkCheck icon).
- **i18n**: added pingHost / pingNoHost keys in en, zh-CN, zh-TW, ko.

## Screenshot

<img width="474" height="378" alt="图片" src="https://github.com/user-attachments/assets/76487622-0d26-495e-ad37-56255eefb6cc" />

<img width="1073" height="243" alt="图片" src="https://github.com/user-attachments/assets/7e882c78-c925-4940-aaff-de59402c0c73" />


## Notes

- Pings run locally against the connection's host address. On Windows `ping` exits after 4 probes by default; on Linux/macOS it runs until the user closes the tab (Ctrl+C).