### PR TITLE
[Bug]: 临时SSH链接右键菜单创建会话/拆分等选项不可用

### DIFF
--- a/src-tauri/src/cmd/session.rs
+++ b/src-tauri/src/cmd/session.rs
@@ -60,10 +60,7 @@ pub async fn create_ssh_session(
         Some(connection_id.clone()),
         Some(window.label().to_string()),
         cancel_rx,
-        startup_command.map(|command| ssh::SshStartupCommand {
-            command: command.command,
-            delay_ms: command.delay_ms,
-        }),
+        startup_command.map(startup_command_payload_to_ssh),
         Some(build_auto_recording_hook(
             app.clone(),
             recording_state.inner().clone(),
@@ -85,6 +82,7 @@ pub async fn create_temporary_ssh_session(
     recording_state: tauri::State<'_, Arc<RecordingManager>>,
     config: ssh::SshConfig,
     create_request_id: Option<String>,
+    startup_command: Option<StartupCommandPayload>,
 ) -> AppResult<String> {
     let encoding = crate::config::load_app_settings(&app)
         .map(|settings| settings.interaction.default_encoding)
@@ -103,7 +101,7 @@ pub async fn create_temporary_ssh_session(
         None,
         Some(window.label().to_string()),
         cancel_rx,
-        None,
+        startup_command.map(startup_command_payload_to_ssh),
         Some(build_auto_recording_hook(
             app.clone(),
             recording_state.inner().clone(),
@@ -112,6 +110,13 @@ pub async fn create_temporary_ssh_session(
     .await?;
     drop(guard);
     Ok(session_id)
+}
+
+fn startup_command_payload_to_ssh(command: StartupCommandPayload) -> ssh::SshStartupCommand {
+    ssh::SshStartupCommand {
+        command: command.command,
+        delay_ms: command.delay_ms,
+    }
 }
 
 fn normalize_temporary_ssh_config(mut config: ssh::SshConfig, encoding: &str) -> ssh::SshConfig {
@@ -656,7 +661,10 @@ fn default_recording_dir(app: &tauri::AppHandle) -> AppResult<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_temporary_ssh_config, resolve_telnet_connection_password_with};
+    use super::{
+        StartupCommandPayload, normalize_temporary_ssh_config,
+        resolve_telnet_connection_password_with, startup_command_payload_to_ssh,
+    };
     use crate::config::ConnectionAuth;
 
     #[test]
@@ -702,6 +710,17 @@ mod tests {
         assert!(normalized.proxy.is_none());
         assert!(normalized.proxy_jump.is_none());
         assert!(normalized.post_login.is_none());
+    }
+
+    #[test]
+    fn maps_startup_command_payload_to_ssh_command() {
+        let command = startup_command_payload_to_ssh(StartupCommandPayload {
+            command: "uptime".to_string(),
+            delay_ms: 750,
+        });
+
+        assert_eq!(command.command, "uptime");
+        assert_eq!(command.delay_ms, 750);
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1155,7 +1155,14 @@ function App() {
 
   const connectTemporaryConnection = useCallback(
     async (config: TemporaryLinkConfig) => {
-      const pending = addPendingTab(config.name, getTemporaryLinkSessionType(config));
+      const pending = addPendingTab(
+        config.name,
+        getTemporaryLinkSessionType(config),
+        undefined,
+        undefined,
+        undefined,
+        { temporaryConfig: config },
+      );
       const { tabId, createRequestId } = pending;
 
       try {
@@ -1596,7 +1603,7 @@ function App() {
 
   const createSessionForPane = useCallback(
     async (
-      pane: Pick<SessionPane, "type" | "connectionId">,
+      pane: Pick<SessionPane, "type" | "connectionId" | "temporaryConfig">,
       createRequestId?: string,
       startupCommand?: StartupCommandRequest,
     ) => {
@@ -1607,18 +1614,41 @@ function App() {
             createRequestId,
           });
         case "Telnet":
-          if (!pane.connectionId) throw new Error("Missing Telnet connection id");
-          return invoke<string>("create_telnet_session", {
-            connectionId: pane.connectionId,
-            createRequestId,
-            startupCommand: buildStartupCommandPayload(startupCommand),
-          });
+          if (pane.connectionId) {
+            return invoke<string>("create_telnet_session", {
+              connectionId: pane.connectionId,
+              createRequestId,
+              startupCommand: buildStartupCommandPayload(startupCommand),
+            });
+          }
+          if (pane.temporaryConfig) {
+            return invoke<string>("create_telnet_session", {
+              connectionId: null,
+              host: pane.temporaryConfig.host,
+              port: pane.temporaryConfig.port,
+              name: pane.temporaryConfig.name,
+              createRequestId,
+              startupCommand: null,
+            });
+          }
+          throw new Error("Missing Telnet connection id");
         case "Serial":
-          if (!pane.connectionId) throw new Error("Missing Serial connection id");
-          return invoke<string>("create_serial_session", {
-            connectionId: pane.connectionId,
-            createRequestId,
-          });
+          if (pane.connectionId) {
+            return invoke<string>("create_serial_session", {
+              connectionId: pane.connectionId,
+              createRequestId,
+            });
+          }
+          if (pane.temporaryConfig) {
+            return invoke<string>("create_serial_session", {
+              connectionId: null,
+              portName: pane.temporaryConfig.portName,
+              baudRate: pane.temporaryConfig.baudRate,
+              name: pane.temporaryConfig.name,
+              createRequestId,
+            });
+          }
+          throw new Error("Missing Serial connection id");
         case "VNC":
           if (!pane.connectionId) throw new Error("Missing VNC connection id");
           return invoke<string>("create_vnc_session", {
@@ -1632,12 +1662,21 @@ function App() {
             createRequestId,
           });
         default:
-          if (!pane.connectionId) throw new Error("Missing SSH connection id");
-          return invoke<string>("create_ssh_session", {
-            connectionId: pane.connectionId,
-            createRequestId,
-            startupCommand: buildStartupCommandPayload(startupCommand),
-          });
+          if (pane.connectionId) {
+            return invoke<string>("create_ssh_session", {
+              connectionId: pane.connectionId,
+              createRequestId,
+              startupCommand: buildStartupCommandPayload(startupCommand),
+            });
+          }
+          if (pane.temporaryConfig) {
+            const { protocol: _protocol, ...sshConfig } = pane.temporaryConfig;
+            return invoke<string>("create_temporary_ssh_session", {
+              config: sshConfig,
+              createRequestId,
+            });
+          }
+          throw new Error("Missing SSH connection id");
       }
     },
     [],
@@ -2179,6 +2218,7 @@ function App() {
           pane.connectionId,
           { customName: tab.customName, tabColor: tab.tabColor },
           { afterTabId: tab.id },
+          { temporaryConfig: pane.temporaryConfig },
         );
         const { tabId, createRequestId } = pending;
         setTerminalWindows((current) =>
@@ -2539,6 +2579,7 @@ function App() {
           pane.connectionId,
           { customName: tab.customName, tabColor: tab.tabColor },
           { afterTabId: tab.id },
+          { temporaryConfig: pane.temporaryConfig },
         );
         newTabId = pending.tabId;
         setTerminalWindows((current) =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ function upsertSecurityPrompt(current: SecurityPrompt[], prompt: SecurityPrompt)
 
 import { AI_OPEN_EVENT, type AIOpenIntent } from "./lib/aiEvents";
 import {
+  assertMatchingTemporaryConfig,
   buildPanelOpenUpdate,
   canCreateSessionFromPane,
   collectActiveNonSerialSessionIds,
@@ -278,12 +279,16 @@ async function createSessionForConnection(
       return invoke<string>("create_ssh_session", {
         connectionId: connection.id,
         createRequestId,
-        startupCommand: startupCommand ?? null,
+        startupCommand: buildStartupCommandPayload(startupCommand),
       });
   }
 }
 
-async function createTemporarySession(config: TemporaryLinkConfig, createRequestId?: string) {
+async function createTemporarySession(
+  config: TemporaryLinkConfig,
+  createRequestId?: string,
+  startupCommand?: StartupCommandRequest,
+) {
   switch (config.protocol) {
     case "telnet":
       return invoke<string>("create_telnet_session", {
@@ -292,7 +297,7 @@ async function createTemporarySession(config: TemporaryLinkConfig, createRequest
         port: config.port,
         name: config.name,
         createRequestId,
-        startupCommand: null,
+        startupCommand: buildStartupCommandPayload(startupCommand),
       });
     case "serial":
       return invoke<string>("create_serial_session", {
@@ -307,6 +312,7 @@ async function createTemporarySession(config: TemporaryLinkConfig, createRequest
       return invoke<string>("create_temporary_ssh_session", {
         config: sshConfig,
         createRequestId,
+        startupCommand: buildStartupCommandPayload(startupCommand),
       });
     }
   }
@@ -1621,14 +1627,15 @@ function App() {
               startupCommand: buildStartupCommandPayload(startupCommand),
             });
           }
-          if (pane.temporaryConfig) {
+          assertMatchingTemporaryConfig(pane);
+          if (pane.temporaryConfig?.protocol === "telnet") {
             return invoke<string>("create_telnet_session", {
               connectionId: null,
               host: pane.temporaryConfig.host,
               port: pane.temporaryConfig.port,
               name: pane.temporaryConfig.name,
               createRequestId,
-              startupCommand: null,
+              startupCommand: buildStartupCommandPayload(startupCommand),
             });
           }
           throw new Error("Missing Telnet connection id");
@@ -1639,7 +1646,8 @@ function App() {
               createRequestId,
             });
           }
-          if (pane.temporaryConfig) {
+          assertMatchingTemporaryConfig(pane);
+          if (pane.temporaryConfig?.protocol === "serial") {
             return invoke<string>("create_serial_session", {
               connectionId: null,
               portName: pane.temporaryConfig.portName,
@@ -1669,11 +1677,13 @@ function App() {
               startupCommand: buildStartupCommandPayload(startupCommand),
             });
           }
-          if (pane.temporaryConfig) {
+          assertMatchingTemporaryConfig(pane);
+          if (pane.temporaryConfig?.protocol === "ssh") {
             const { protocol: _protocol, ...sshConfig } = pane.temporaryConfig;
             return invoke<string>("create_temporary_ssh_session", {
               config: sshConfig,
               createRequestId,
+              startupCommand: buildStartupCommandPayload(startupCommand),
             });
           }
           throw new Error("Missing SSH connection id");
@@ -2302,6 +2312,7 @@ function App() {
           pane.connectionId,
           { customName: tab.customName, tabColor: tab.tabColor },
           { afterTabId: tab.id },
+          { temporaryConfig: pane.temporaryConfig },
         );
         tabId = pending.tabId;
         setTerminalWindows((current) =>

--- a/src/components/terminal/PaneWorkspace.tsx
+++ b/src/components/terminal/PaneWorkspace.tsx
@@ -195,7 +195,7 @@ function PaneNodeView({
   }
 
   const isActive = visible && tab.activePaneId === node.id;
-  const showReconnectAction = !!(node.type === "Local" || node.connectionId) && !!onReconnectPane;
+  const showReconnectAction = !!(node.type === "Local" || node.connectionId || node.temporaryConfig) && !!onReconnectPane;
   const statusTitle = isReconnectPending
     ? t("tabCtx.reconnecting")
     : t("terminal.connectionFailed");
@@ -327,6 +327,7 @@ function PaneNodeView({
           visible={visible}
           sessionType={node.type}
           connectionId={node.connectionId}
+          temporaryConfig={node.temporaryConfig}
           onReconnected={onReconnected}
           onDisconnectedCloseRequested={() => void onDisconnectedCloseRequested?.(tab.id, node.id)}
           onConnectionError={(sessionId, error) =>
@@ -350,6 +351,7 @@ function PaneXTerminal({
   visible,
   sessionType,
   connectionId,
+  temporaryConfig,
   onReconnected,
   onDisconnectedCloseRequested,
   onConnectionError,
@@ -365,6 +367,7 @@ function PaneXTerminal({
   visible: boolean;
   sessionType: TerminalSessionPane["type"];
   connectionId?: string;
+  temporaryConfig?: TerminalSessionPane["temporaryConfig"];
   onReconnected?: (oldSessionId: string, newSessionId: string) => void;
   onDisconnectedCloseRequested?: () => void;
   onConnectionError?: (sessionId: string, error: string) => void;
@@ -445,6 +448,7 @@ function PaneXTerminal({
       visible={visible}
       sessionType={sessionType}
       connectionId={connectionId}
+      temporaryConfig={temporaryConfig}
       onReconnected={onReconnected}
       onDisconnectedCloseRequested={onDisconnectedCloseRequested}
       onConnectionError={onConnectionError}

--- a/src/components/terminal/PaneWorkspace.tsx
+++ b/src/components/terminal/PaneWorkspace.tsx
@@ -6,6 +6,7 @@ import RdpPaneHost from "@/components/rdp/RdpPaneHost";
 import { Button } from "@/components/ui/button";
 import VncPaneHost from "@/components/vnc/VncPaneHost";
 import { useApp } from "@/context/AppContext";
+import { hasMatchingTemporaryConfig } from "@/lib/appWorkspace";
 import {
   getActiveGroupForSession,
   getSessionInputPeerIds,
@@ -195,7 +196,9 @@ function PaneNodeView({
   }
 
   const isActive = visible && tab.activePaneId === node.id;
-  const showReconnectAction = !!(node.type === "Local" || node.connectionId || node.temporaryConfig) && !!onReconnectPane;
+  const showReconnectAction =
+    !!(node.type === "Local" || node.connectionId || hasMatchingTemporaryConfig(node)) &&
+    !!onReconnectPane;
   const statusTitle = isReconnectPending
     ? t("tabCtx.reconnecting")
     : t("terminal.connectionFailed");

--- a/src/components/terminal/TabBar.tsx
+++ b/src/components/terminal/TabBar.tsx
@@ -30,6 +30,7 @@ import { toast } from "sonner";
 import CloseAllSessionsDialog from "@/components/dialog/terminal/CloseAllSessionsDialog";
 import TabRenameDialog from "@/components/dialog/terminal/TabRenameDialog";
 import TabStartupCommandDialog from "@/components/dialog/terminal/TabStartupCommandDialog";
+import { hasMatchingTemporaryConfig } from "@/lib/appWorkspace";
 import type { TabMouseAction } from "@/lib/interactionSettings";
 import { normalizeTabMouseAction } from "@/lib/interactionSettings";
 import { getActiveGroupForSession, isSessionPausedInGroup } from "@/lib/syncInputGroups";
@@ -162,7 +163,7 @@ function canSpawnSessionFromTab(tab: Tab): boolean {
   return (
     !!pane &&
     pane.paneKind === "terminal" &&
-    (pane.type === "Local" || !!pane.connectionId || !!pane.temporaryConfig)
+    (pane.type === "Local" || !!pane.connectionId || hasMatchingTemporaryConfig(pane))
   );
 }
 
@@ -176,7 +177,7 @@ function getTabConnection(tab: Tab, savedConnections: SavedConnection[]) {
 function isSshTab(tab: Tab, savedConnections: SavedConnection[]): boolean {
   const pane = getActivePane(tab);
   if (pane?.type !== "SSH") return false;
-  if (pane.temporaryConfig) return true;
+  if (pane.temporaryConfig?.protocol === "ssh") return true;
   const connection = getTabConnection(tab, savedConnections);
   return connection?.type === "ssh";
 }
@@ -184,7 +185,7 @@ function isSshTab(tab: Tab, savedConnections: SavedConnection[]): boolean {
 function getTabServerIp(tab: Tab, savedConnections: SavedConnection[]): string | null {
   const pane = getActivePane(tab);
   if (pane?.type !== "SSH") return null;
-  if (pane.temporaryConfig?.host) return pane.temporaryConfig.host;
+  if (pane.temporaryConfig?.protocol === "ssh") return pane.temporaryConfig.host;
   return getTabConnection(tab, savedConnections)?.host || null;
 }
 
@@ -201,7 +202,11 @@ function canMultiplexTab(tab: Tab, savedConnections: SavedConnection[]): boolean
 
 function canReconnectTab(tab: Tab): boolean {
   const pane = getActivePane(tab);
-  return !!pane && !pane.connecting && (pane.type === "Local" || !!pane.connectionId || !!pane.temporaryConfig);
+  return (
+    !!pane &&
+    !pane.connecting &&
+    (pane.type === "Local" || !!pane.connectionId || hasMatchingTemporaryConfig(pane))
+  );
 }
 
 function canDisconnectTab(tab: Tab): boolean {

--- a/src/components/terminal/TabBar.tsx
+++ b/src/components/terminal/TabBar.tsx
@@ -159,7 +159,11 @@ function compareSortOrder(left: { sort_order?: number }, right: { sort_order?: n
 
 function canSpawnSessionFromTab(tab: Tab): boolean {
   const pane = getActivePane(tab);
-  return !!pane && pane.paneKind === "terminal" && (pane.type === "Local" || !!pane.connectionId);
+  return (
+    !!pane &&
+    pane.paneKind === "terminal" &&
+    (pane.type === "Local" || !!pane.connectionId || !!pane.temporaryConfig)
+  );
 }
 
 function getTabConnection(tab: Tab, savedConnections: SavedConnection[]) {
@@ -171,12 +175,16 @@ function getTabConnection(tab: Tab, savedConnections: SavedConnection[]) {
 
 function isSshTab(tab: Tab, savedConnections: SavedConnection[]): boolean {
   const pane = getActivePane(tab);
+  if (pane?.type !== "SSH") return false;
+  if (pane.temporaryConfig) return true;
   const connection = getTabConnection(tab, savedConnections);
-  return pane?.type === "SSH" && connection?.type === "ssh";
+  return connection?.type === "ssh";
 }
 
 function getTabServerIp(tab: Tab, savedConnections: SavedConnection[]): string | null {
-  if (!isSshTab(tab, savedConnections)) return null;
+  const pane = getActivePane(tab);
+  if (pane?.type !== "SSH") return null;
+  if (pane.temporaryConfig?.host) return pane.temporaryConfig.host;
   return getTabConnection(tab, savedConnections)?.host || null;
 }
 
@@ -193,7 +201,7 @@ function canMultiplexTab(tab: Tab, savedConnections: SavedConnection[]): boolean
 
 function canReconnectTab(tab: Tab): boolean {
   const pane = getActivePane(tab);
-  return !!pane && !pane.connecting && (pane.type === "Local" || !!pane.connectionId);
+  return !!pane && !pane.connecting && (pane.type === "Local" || !!pane.connectionId || !!pane.temporaryConfig);
 }
 
 function canDisconnectTab(tab: Tab): boolean {

--- a/src/components/terminal/TabContextMenu.tsx
+++ b/src/components/terminal/TabContextMenu.tsx
@@ -23,6 +23,7 @@ import { TbArrowBarToRight, TbCircleDotFilled } from "react-icons/tb";
 import { toast } from "sonner";
 import { useApp } from "@/context/AppContext";
 import { openAIAssistant } from "@/lib/aiEvents";
+import { hasMatchingTemporaryConfig } from "@/lib/appWorkspace";
 import { getActivePane } from "@/lib/workspaceTabs";
 import type { PaneSplitDirection, Tab } from "@/types/global";
 import {
@@ -109,20 +110,28 @@ export default function TabContextMenu({
   const canSpawnSession =
     !!activePane &&
     isTerminalPane &&
-    (activePane.type === "Local" || !!activePane.connectionId || !!activePane.temporaryConfig);
+    (activePane.type === "Local" ||
+      !!activePane.connectionId ||
+      hasMatchingTemporaryConfig(activePane));
   const canReconnect =
     !!activePane &&
     !activePane.connecting &&
-    (activePane.type === "Local" || !!activePane.connectionId || !!activePane.temporaryConfig);
+    (activePane.type === "Local" ||
+      !!activePane.connectionId ||
+      hasMatchingTemporaryConfig(activePane));
   const canMultiplexSsh =
     !!activePane &&
     activePane.type === "SSH" &&
+    (!!activePane.connectionId || activePane.temporaryConfig?.protocol === "ssh") &&
     !activePane.connecting &&
     !activePane.connectError &&
     !!activePane.sessionId;
   const canDisconnect = !!activePane && !activePane.connecting && !activePane.connectError;
   const canSplit =
-    !!activePane && (activePane.type === "Local" || !!activePane.connectionId || !!activePane.temporaryConfig);
+    !!activePane &&
+    (activePane.type === "Local" ||
+      !!activePane.connectionId ||
+      hasMatchingTemporaryConfig(activePane));
   const canUseAI =
     !!activePane && isTerminalPane && !activePane.connecting && !activePane.connectError;
   const canCloseInactive = tabs.length > 1;

--- a/src/components/terminal/TabContextMenu.tsx
+++ b/src/components/terminal/TabContextMenu.tsx
@@ -107,9 +107,13 @@ export default function TabContextMenu({
   const tabIndex = tabs.findIndex((item) => item.id === tab.id);
   const isTerminalPane = activePane?.paneKind === "terminal";
   const canSpawnSession =
-    !!activePane && isTerminalPane && (activePane.type === "Local" || !!activePane.connectionId);
+    !!activePane &&
+    isTerminalPane &&
+    (activePane.type === "Local" || !!activePane.connectionId || !!activePane.temporaryConfig);
   const canReconnect =
-    !!activePane && !activePane.connecting && (activePane.type === "Local" || !!activePane.connectionId);
+    !!activePane &&
+    !activePane.connecting &&
+    (activePane.type === "Local" || !!activePane.connectionId || !!activePane.temporaryConfig);
   const canMultiplexSsh =
     !!activePane &&
     activePane.type === "SSH" &&
@@ -117,7 +121,8 @@ export default function TabContextMenu({
     !activePane.connectError &&
     !!activePane.sessionId;
   const canDisconnect = !!activePane && !activePane.connecting && !activePane.connectError;
-  const canSplit = !!activePane && (activePane.type === "Local" || !!activePane.connectionId);
+  const canSplit =
+    !!activePane && (activePane.type === "Local" || !!activePane.connectionId || !!activePane.temporaryConfig);
   const canUseAI =
     !!activePane && isTerminalPane && !activePane.connecting && !activePane.connectError;
   const canCloseInactive = tabs.length > 1;

--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -253,6 +253,7 @@ export default function XTerminal({
   visible = true,
   sessionType,
   connectionId,
+  temporaryConfig,
   onReconnected,
   onDisconnectedCloseRequested,
   onConnectionError,
@@ -351,6 +352,7 @@ export default function XTerminal({
   const gutterLineOffsetRef = useRef(0);
   const sessionTypeRef = useRef(sessionType);
   const connectionIdRef = useRef(connectionId);
+  const temporaryConfigRef = useRef(temporaryConfig);
   const onReconnectedRef = useRef(onReconnected);
   const onDisconnectedCloseRequestedRef = useRef(onDisconnectedCloseRequested);
   const onConnectionErrorRef = useRef(onConnectionError);
@@ -487,6 +489,10 @@ export default function XTerminal({
   useEffect(() => {
     connectionIdRef.current = connectionId;
   }, [connectionId]);
+
+  useEffect(() => {
+    temporaryConfigRef.current = temporaryConfig;
+  }, [temporaryConfig]);
 
   useEffect(() => {
     onReconnectedRef.current = onReconnected;
@@ -1006,10 +1012,13 @@ export default function XTerminal({
     };
 
     const canReconnectDisconnectedSession = () =>
-      sessionTypeRef.current === "Local" || !!connectionIdRef.current;
+      sessionTypeRef.current === "Local" ||
+      !!connectionIdRef.current ||
+      !!temporaryConfigRef.current;
 
     const createReconnectedSession = () => {
       const connectionId = connectionIdRef.current;
+      const temporaryConfig = temporaryConfigRef.current;
 
       switch (sessionTypeRef.current) {
         case "Local":
@@ -1017,10 +1026,42 @@ export default function XTerminal({
             connectionId: connectionId || null,
           });
         case "Telnet":
+          if (connectionId) {
+            return invoke<string>("create_telnet_session", { connectionId });
+          }
+          if (temporaryConfig) {
+            return invoke<string>("create_telnet_session", {
+              connectionId: null,
+              host: temporaryConfig.host,
+              port: temporaryConfig.port,
+              name: temporaryConfig.name,
+              startupCommand: null,
+            });
+          }
           return invoke<string>("create_telnet_session", { connectionId });
         case "Serial":
+          if (connectionId) {
+            return invoke<string>("create_serial_session", { connectionId });
+          }
+          if (temporaryConfig) {
+            return invoke<string>("create_serial_session", {
+              connectionId: null,
+              portName: temporaryConfig.portName,
+              baudRate: temporaryConfig.baudRate,
+              name: temporaryConfig.name,
+            });
+          }
           return invoke<string>("create_serial_session", { connectionId });
         default:
+          if (connectionId) {
+            return invoke<string>("create_ssh_session", { connectionId });
+          }
+          if (temporaryConfig) {
+            const { protocol: _protocol, ...sshConfig } = temporaryConfig;
+            return invoke<string>("create_temporary_ssh_session", {
+              config: sshConfig,
+            });
+          }
           return invoke<string>("create_ssh_session", { connectionId });
       }
     };

--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -1014,7 +1014,27 @@ export default function XTerminal({
     const canReconnectDisconnectedSession = () =>
       sessionTypeRef.current === "Local" ||
       !!connectionIdRef.current ||
-      !!temporaryConfigRef.current;
+      temporaryConfigMatchesSessionType();
+
+    const temporaryConfigMatchesSessionType = () => {
+      const temporaryConfig = temporaryConfigRef.current;
+      if (!temporaryConfig) return false;
+      switch (sessionTypeRef.current) {
+        case "SSH":
+          return temporaryConfig.protocol === "ssh";
+        case "Telnet":
+          return temporaryConfig.protocol === "telnet";
+        case "Serial":
+          return temporaryConfig.protocol === "serial";
+        default:
+          return false;
+      }
+    };
+
+    const assertTemporaryConfigMatchesSessionType = () => {
+      if (!temporaryConfigRef.current || temporaryConfigMatchesSessionType()) return;
+      throw new Error("Temporary session config protocol mismatch");
+    };
 
     const createReconnectedSession = () => {
       const connectionId = connectionIdRef.current;
@@ -1029,7 +1049,8 @@ export default function XTerminal({
           if (connectionId) {
             return invoke<string>("create_telnet_session", { connectionId });
           }
-          if (temporaryConfig) {
+          assertTemporaryConfigMatchesSessionType();
+          if (temporaryConfig?.protocol === "telnet") {
             return invoke<string>("create_telnet_session", {
               connectionId: null,
               host: temporaryConfig.host,
@@ -1043,7 +1064,8 @@ export default function XTerminal({
           if (connectionId) {
             return invoke<string>("create_serial_session", { connectionId });
           }
-          if (temporaryConfig) {
+          assertTemporaryConfigMatchesSessionType();
+          if (temporaryConfig?.protocol === "serial") {
             return invoke<string>("create_serial_session", {
               connectionId: null,
               portName: temporaryConfig.portName,
@@ -1056,7 +1078,8 @@ export default function XTerminal({
           if (connectionId) {
             return invoke<string>("create_ssh_session", { connectionId });
           }
-          if (temporaryConfig) {
+          assertTemporaryConfigMatchesSessionType();
+          if (temporaryConfig?.protocol === "ssh") {
             const { protocol: _protocol, ...sshConfig } = temporaryConfig;
             return invoke<string>("create_temporary_ssh_session", {
               config: sshConfig,

--- a/src/components/terminal/xterminalTypes.ts
+++ b/src/components/terminal/xterminalTypes.ts
@@ -1,4 +1,5 @@
 import type { RecordingMode, RecordingStatus, SessionType } from "@/types/global";
+import type { TemporaryLinkConfig } from "@/types/temporaryConnection";
 
 export interface SyncOverlayState {
   peerCount: number;
@@ -17,15 +18,7 @@ export interface XTerminalProps {
   visible?: boolean;
   sessionType: SessionType;
   connectionId?: string;
-  temporaryConfig?: {
-    protocol: "ssh" | "telnet" | "serial";
-    name?: string;
-    host?: string;
-    port?: number;
-    username?: string;
-    portName?: string;
-    baudRate?: number;
-  };
+  temporaryConfig?: TemporaryLinkConfig;
   onReconnected?: (oldSessionId: string, newSessionId: string) => void;
   onDisconnectedCloseRequested?: () => void;
   onConnectionError?: (sessionId: string, error: string) => void;

--- a/src/components/terminal/xterminalTypes.ts
+++ b/src/components/terminal/xterminalTypes.ts
@@ -17,6 +17,15 @@ export interface XTerminalProps {
   visible?: boolean;
   sessionType: SessionType;
   connectionId?: string;
+  temporaryConfig?: {
+    protocol: "ssh" | "telnet" | "serial";
+    name?: string;
+    host?: string;
+    port?: number;
+    username?: string;
+    portName?: string;
+    baudRate?: number;
+  };
   onReconnected?: (oldSessionId: string, newSessionId: string) => void;
   onDisconnectedCloseRequested?: () => void;
   onConnectionError?: (sessionId: string, error: string) => void;

--- a/src/lib/appWorkspace.test.ts
+++ b/src/lib/appWorkspace.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { SessionPane } from "@/types/global";
+import { canCreateSessionFromPane } from "./appWorkspace";
+
+const basePane = {
+  id: "pane-1",
+  kind: "leaf",
+  paneKind: "terminal",
+  sessionId: "session-1",
+  name: "Session",
+  connecting: false,
+} as const;
+
+function pane(overrides: Partial<SessionPane>): SessionPane {
+  return {
+    ...basePane,
+    type: "SSH",
+    ...overrides,
+  } as SessionPane;
+}
+
+describe("canCreateSessionFromPane", () => {
+  it("allows temporary panes with matching protocols", () => {
+    expect(
+      canCreateSessionFromPane(
+        pane({
+          type: "SSH",
+          temporaryConfig: {
+            protocol: "ssh",
+            name: "root@example.com:22",
+            host: "example.com",
+            port: 22,
+            username: "root",
+            auth: { type: "password", password: "secret" },
+            backspace_mode: "del",
+            x11_forwarding: false,
+            x11_display: "",
+            proxy: null,
+            proxy_jump: null,
+            post_login: null,
+          },
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      canCreateSessionFromPane(
+        pane({
+          type: "Telnet",
+          temporaryConfig: {
+            protocol: "telnet",
+            name: "telnet://example.com:23",
+            host: "example.com",
+            port: 23,
+          },
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      canCreateSessionFromPane(
+        pane({
+          type: "Serial",
+          temporaryConfig: {
+            protocol: "serial",
+            name: "COM3 @ 115200",
+            portName: "COM3",
+            baudRate: 115200,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects panes without a saved connection or matching temporary config", () => {
+    expect(canCreateSessionFromPane(pane({ type: "SSH" }))).toBe(false);
+    expect(
+      canCreateSessionFromPane(
+        pane({
+          type: "SSH",
+          temporaryConfig: {
+            protocol: "telnet",
+            name: "telnet://example.com:23",
+            host: "example.com",
+            port: 23,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still allows local panes without connection metadata", () => {
+    expect(canCreateSessionFromPane(pane({ type: "Local" }))).toBe(true);
+  });
+});

--- a/src/lib/appWorkspace.ts
+++ b/src/lib/appWorkspace.ts
@@ -36,9 +36,12 @@ export type TrayAction =
   | { type: "request_quit"; targetWindowLabel?: string | null };
 
 export function canCreateSessionFromPane(
-  pane: Pick<SessionPane, "type" | "connectionId"> | null | undefined,
-): pane is Pick<SessionPane, "type" | "connectionId"> {
-  return !!pane && (pane.type === "Local" || !!pane.connectionId);
+  pane:
+    | Pick<SessionPane, "type" | "connectionId" | "temporaryConfig">
+    | null
+    | undefined,
+): pane is Pick<SessionPane, "type" | "connectionId" | "temporaryConfig"> {
+  return !!pane && (pane.type === "Local" || !!pane.connectionId || !!pane.temporaryConfig);
 }
 
 export function hasLiveSession<T extends Pick<SessionPane, "connecting" | "connectError">>(

--- a/src/lib/appWorkspace.ts
+++ b/src/lib/appWorkspace.ts
@@ -36,12 +36,34 @@ export type TrayAction =
   | { type: "request_quit"; targetWindowLabel?: string | null };
 
 export function canCreateSessionFromPane(
-  pane:
-    | Pick<SessionPane, "type" | "connectionId" | "temporaryConfig">
-    | null
-    | undefined,
+  pane: Pick<SessionPane, "type" | "connectionId" | "temporaryConfig"> | null | undefined,
 ): pane is Pick<SessionPane, "type" | "connectionId" | "temporaryConfig"> {
-  return !!pane && (pane.type === "Local" || !!pane.connectionId || !!pane.temporaryConfig);
+  return (
+    !!pane && (pane.type === "Local" || !!pane.connectionId || hasMatchingTemporaryConfig(pane))
+  );
+}
+
+export function hasMatchingTemporaryConfig(
+  pane: Pick<SessionPane, "type" | "temporaryConfig"> | null | undefined,
+) {
+  if (!pane?.temporaryConfig) return false;
+  switch (pane.type) {
+    case "SSH":
+      return pane.temporaryConfig.protocol === "ssh";
+    case "Telnet":
+      return pane.temporaryConfig.protocol === "telnet";
+    case "Serial":
+      return pane.temporaryConfig.protocol === "serial";
+    default:
+      return false;
+  }
+}
+
+export function assertMatchingTemporaryConfig<
+  T extends Pick<SessionPane, "type" | "temporaryConfig">,
+>(pane: T) {
+  if (!pane.temporaryConfig || hasMatchingTemporaryConfig(pane)) return;
+  throw new Error("Temporary session config protocol mismatch");
 }
 
 export function hasLiveSession<T extends Pick<SessionPane, "connecting" | "connectError">>(

--- a/src/lib/temporaryLink.ts
+++ b/src/lib/temporaryLink.ts
@@ -1,34 +1,16 @@
-import type { SshConfig } from "@/types/global";
+export type {
+  TemporaryLinkConfig,
+  TemporaryLinkProtocol,
+  TemporarySerialLinkConfig,
+  TemporarySshLinkConfig,
+  TemporaryTelnetLinkConfig,
+} from "@/types/temporaryConnection";
 
-export interface TemporarySshLinkConfig extends SshConfig {
-  protocol: "ssh";
-  backspace_mode: string;
-  x11_forwarding: boolean;
-  x11_display: string;
-  proxy: null;
-  proxy_jump: null;
-  post_login: null;
-}
-
-export interface TemporaryTelnetLinkConfig {
-  protocol: "telnet";
-  name: string;
-  host: string;
-  port: number;
-}
-
-export interface TemporarySerialLinkConfig {
-  protocol: "serial";
-  name: string;
-  portName: string;
-  baudRate: number;
-}
-
-export type TemporaryLinkProtocol = TemporaryLinkConfig["protocol"];
-export type TemporaryLinkConfig =
-  | TemporarySshLinkConfig
-  | TemporaryTelnetLinkConfig
-  | TemporarySerialLinkConfig;
+import type {
+  TemporaryLinkConfig,
+  TemporaryLinkProtocol,
+  TemporarySerialLinkConfig,
+} from "@/types/temporaryConnection";
 
 export type TemporaryLinkParseResult =
   | { ok: true; config: TemporaryLinkConfig }

--- a/src/lib/workspaceTabs.test.ts
+++ b/src/lib/workspaceTabs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RestorableTab } from "@/types/global";
+import type { TemporaryLinkConfig } from "@/types/temporaryConnection";
 import {
   collectSessionPanes,
   createSessionPane,
@@ -230,5 +231,29 @@ describe("workspaceTabs remote desktop persistence", () => {
     );
 
     expect(restored).toBeNull();
+  });
+});
+
+describe("workspaceTabs temporary session metadata", () => {
+  it("keeps temporaryConfig on runtime panes without persisting it", () => {
+    const temporaryConfig: TemporaryLinkConfig = {
+      protocol: "telnet",
+      name: "telnet://example.com:23",
+      host: "example.com",
+      port: 23,
+    };
+    const pane = createSessionPane("Temporary Telnet", "Telnet", undefined, {
+      temporaryConfig,
+    });
+
+    expect(pane.temporaryConfig).toBe(temporaryConfig);
+
+    const [serialized] = serializeTabsForPersistence([createWorkspaceTab(pane, 0)]);
+    expect(JSON.stringify(serialized)).not.toContain("temporaryConfig");
+    expect(serialized.root).toMatchObject({
+      kind: "leaf",
+      session_type: "Telnet",
+    });
+    expect(serialized.root?.kind === "leaf" && serialized.root.connection_id).toBeUndefined();
   });
 });

--- a/src/lib/workspaceTabs.ts
+++ b/src/lib/workspaceTabs.ts
@@ -74,6 +74,7 @@ export function createSessionPane(
     connecting: overrides?.connecting,
     createRequestId: overrides?.createRequestId,
     connectError: overrides?.connectError,
+    temporaryConfig: overrides?.temporaryConfig,
   } as SessionPane;
 }
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -3,6 +3,7 @@ export type SessionType = "SSH" | "Local" | "Telnet" | "Serial";
 export type WorkspaceSessionType = SessionType | "RDP" | "VNC";
 export type WorkspacePaneKind = "terminal" | "remote-desktop";
 export type PersistedWorkspacePaneKind = WorkspacePaneKind | "rdp";
+export type { TemporaryLinkConfig } from "@/types/temporaryConnection";
 
 export interface AppRuntimeInfo {
   portable: boolean;
@@ -72,15 +73,7 @@ export interface WorkspacePaneBase {
   type: WorkspaceSessionType;
   connectionId?: string;
   /** Config for ad-hoc (temporary) sessions that have no saved connection. */
-  temporaryConfig?: {
-    protocol: "ssh" | "telnet" | "serial";
-    name?: string;
-    host?: string;
-    port?: number;
-    username?: string;
-    portName?: string;
-    baudRate?: number;
-  };
+  temporaryConfig?: import("@/types/temporaryConnection").TemporaryLinkConfig;
   /** True while the backend session is being established. XTerminal is not rendered yet. */
   connecting?: boolean;
   /** Backend creation request id used to cancel an in-flight session creation. */

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -71,6 +71,16 @@ export interface WorkspacePaneBase {
   name: string;
   type: WorkspaceSessionType;
   connectionId?: string;
+  /** Config for ad-hoc (temporary) sessions that have no saved connection. */
+  temporaryConfig?: {
+    protocol: "ssh" | "telnet" | "serial";
+    name?: string;
+    host?: string;
+    port?: number;
+    username?: string;
+    portName?: string;
+    baudRate?: number;
+  };
   /** True while the backend session is being established. XTerminal is not rendered yet. */
   connecting?: boolean;
   /** Backend creation request id used to cancel an in-flight session creation. */

--- a/src/types/temporaryConnection.ts
+++ b/src/types/temporaryConnection.ts
@@ -1,0 +1,32 @@
+import type { SshConfig } from "@/types/global";
+
+export interface TemporarySshLinkConfig extends SshConfig {
+  protocol: "ssh";
+  backspace_mode: string;
+  x11_forwarding: boolean;
+  x11_display: string;
+  proxy: null;
+  proxy_jump: null;
+  post_login: null;
+}
+
+export interface TemporaryTelnetLinkConfig {
+  protocol: "telnet";
+  name: string;
+  host: string;
+  port: number;
+}
+
+export interface TemporarySerialLinkConfig {
+  protocol: "serial";
+  name: string;
+  portName: string;
+  baudRate: number;
+}
+
+export type TemporaryLinkConfig =
+  | TemporarySshLinkConfig
+  | TemporaryTelnetLinkConfig
+  | TemporarySerialLinkConfig;
+
+export type TemporaryLinkProtocol = TemporaryLinkConfig["protocol"];


### PR DESCRIPTION
## 修复内容

临时连接（ssh://、telnet://、serial://）打开的会话，标签页右键菜单中以下选项为灰色不可点击：

1. 复制服务器 IP
2. 复制会话
3. 复制并执行命令
4. 重新连接会话
5. 水平拆分会话
6. 垂直拆分会话

## 根因

临时连接创建的 pane 没有 \connectionId\（因为无已保存连接），\canCreateSessionFromPane\ 等判断函数只检查了 \connectionId\，导致返回 false。

## 修改方案

在 \WorkspacePaneBase\ 新增 \	emporaryConfig\ 字段存储临时连接配置，所有判断函数补充 \	emporaryConfig\ 检查，\createSessionForPane\ 增加临时会话创建分支，确保 pane 创建/复制/拆分时传递 \	emporaryConfig\。

## 涉及文件

- \src/types/global.d.ts\ — WorkspacePaneBase 新增 temporaryConfig
- \src/lib/appWorkspace.ts\ — canCreateSessionFromPane 补充判断
- \src/lib/workspaceTabs.ts\ — createSessionPane 传播 temporaryConfig
- \src/components/terminal/TabContextMenu.tsx\ — 菜单启用条件
- \src/components/terminal/TabBar.tsx\ — 标签栏启用条件 + 复制IP
- \src/components/terminal/xterminalTypes.ts\ — XTerminalProps 新增字段
- \src/components/terminal/PaneWorkspace.tsx\ — 传递 temporaryConfig
- \src/components/terminal/XTerminal.tsx\ — 内部重连支持
- \src/App.tsx\ — createSessionForPane + 各处理器

## 验证结果

临时会话功能验证通过

<img width="501" height="885" alt="图片" src="https://github.com/user-attachments/assets/6fc30cdb-f988-484d-8a5b-e42bfe661df2" />


Closes #423