### PR TITLE
feat(VNC): enhance clipboard functionality and improve rendering logic

### DIFF
--- a/src-tauri/src/config/ui.rs
+++ b/src-tauri/src/config/ui.rs
@@ -23,6 +23,10 @@ pub struct RemoteDesktopDisplayMetadata {
     pub remote_height: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scale_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub view_only: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clipboard_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -520,7 +524,9 @@ mod tests {
             "display": {
                 "remoteWidth": 1600,
                 "remoteHeight": 900,
-                "scaleMode": "actual"
+                "scaleMode": "actual",
+                "viewOnly": true,
+                "clipboardEnabled": false
             }
         });
         let pane: RestorablePaneNode =

--- a/src-tauri/src/core/vnc.rs
+++ b/src-tauri/src/core/vnc.rs
@@ -446,9 +446,9 @@ async fn run_protocol_generation(
     generation: u64,
     cancel_rx: &mut watch::Receiver<bool>,
 ) -> Result<(), (VncErrorKind, String, bool)> {
-    let address = format!("{}:{}", session.config.host, session.config.port);
+    let (host, port) = vnc_connect_target(&session.config);
     let stream = tokio::select! {
-        result = timeout(CONNECT_TIMEOUT, tokio::net::TcpStream::connect(&address)) => {
+        result = timeout(CONNECT_TIMEOUT, tokio::net::TcpStream::connect((host, port))) => {
             result.map_err(|_| (VncErrorKind::Transport, "VNC connection timed out".to_string(), true))?
                 .map_err(|error| (VncErrorKind::Transport, format!("Unable to connect to the VNC server: {error}"), true))?
         }
@@ -560,6 +560,10 @@ async fn run_protocol_generation(
             }
         }
     }
+}
+
+fn vnc_connect_target(config: &VncConnectConfig) -> (&str, u16) {
+    (config.host.as_str(), config.port)
 }
 
 fn security_policy(mode: &str, has_password: bool) -> VncSecurityPolicy {
@@ -1084,6 +1088,27 @@ mod tests {
             VncSecurityPolicy::VncAuthOnly
         );
         assert_eq!(security_policy("auto", false), VncSecurityPolicy::NoneOnly);
+    }
+
+    #[test]
+    fn connect_target_preserves_ipv6_literals_without_host_port_concatenation() {
+        let config = VncConnectConfig {
+            session_id: "vnc-test".to_string(),
+            connection_id: "connection-test".to_string(),
+            name: "IPv6 VNC".to_string(),
+            host: "::1".to_string(),
+            port: 5900,
+            password: None,
+            security_mode: "none".to_string(),
+            scale_mode: "fit".to_string(),
+            clipboard_enabled: true,
+            reconnect_enabled: false,
+            reconnect_max_attempts: 0,
+            shared: true,
+            view_only: false,
+        };
+
+        assert_eq!(vnc_connect_target(&config), ("::1", 5900));
     }
 
     #[tokio::test]

--- a/src-tauri/vendor/vnc-rs/src/codec/zrle.rs
+++ b/src-tauri/vendor/vnc-rs/src/codec/zrle.rs
@@ -100,17 +100,12 @@ mod tests {
             0b1000_0000, // packed palette
         ];
         let events = decode(zrle_payload(&decoded), rect(66, 1)).await.unwrap();
-        assert_eq!(events.len(), 2);
-        let VncEvent::RawImage(_, first) = &events[0] else {
-            panic!("expected first raw image");
-        };
-        assert_eq!(first.len(), 64 * 4);
-        assert_eq!(&first[0..4], &[1, 2, 3, 255]);
-        let VncEvent::RawImage(_, second) = &events[1] else {
-            panic!("expected second raw image");
-        };
-        assert_eq!(&second[0..4], &[40, 50, 60, 255]);
-        assert_eq!(&second[4..8], &[10, 20, 30, 255]);
+        let payload = raw_payload(&events);
+        assert_eq!(payload.len(), 66 * 4);
+        assert_eq!(&payload[0..4], &[1, 2, 3, 255]);
+        assert_eq!(&payload[63 * 4..64 * 4], &[1, 2, 3, 255]);
+        assert_eq!(&payload[64 * 4..65 * 4], &[40, 50, 60, 255]);
+        assert_eq!(&payload[65 * 4..66 * 4], &[10, 20, 30, 255]);
     }
 
     #[tokio::test]
@@ -120,16 +115,12 @@ mod tests {
             130, 10, 20, 30, 40, 50, 60, 0x81, 1, // indexed RLE, two pixels of index 1
         ];
         let events = decode(zrle_payload(&decoded), rect(66, 1)).await.unwrap();
-        assert_eq!(events.len(), 2);
-        let VncEvent::RawImage(_, first) = &events[0] else {
-            panic!("expected first raw image");
-        };
-        assert_eq!(first.len(), 64 * 4);
-        assert!(first.chunks_exact(4).all(|pixel| pixel == [7, 8, 9, 255]));
-        let VncEvent::RawImage(_, second) = &events[1] else {
-            panic!("expected second raw image");
-        };
-        assert_eq!(second, &[40, 50, 60, 255, 40, 50, 60, 255]);
+        let payload = raw_payload(&events);
+        assert_eq!(payload.len(), 66 * 4);
+        assert!(payload[..64 * 4]
+            .chunks_exact(4)
+            .all(|pixel| pixel == [7, 8, 9, 255]));
+        assert_eq!(&payload[64 * 4..66 * 4], &[40, 50, 60, 255, 40, 50, 60, 255]);
     }
 
     #[tokio::test]
@@ -269,7 +260,7 @@ impl Decoder {
         let mut reader = ZlibReader::new(decompressor, &zlib_data);
 
         let bpp = format.bits_per_pixel as usize / 8;
-        checked_buffer_size(rect, bpp, &self.limits)?;
+        let rect_bytes = checked_buffer_size(rect, bpp, &self.limits)?;
         let pixel_mask = ((format.red_max as u32) << format.red_shift)
             | ((format.green_max as u32) << format.green_shift)
             | ((format.blue_max as u32) << format.blue_shift);
@@ -295,6 +286,7 @@ impl Decoder {
                 (bpp, false)
             };
         let mut palette = Vec::with_capacity(128 * bpp);
+        let mut rect_pixels = vec![0_u8; rect_bytes];
 
         let mut y = 0;
         while y < rect.height {
@@ -443,14 +435,70 @@ impl Decoder {
                 if pixels.len() != tile_bytes {
                     return Err(VncError::InvalidImageData);
                 }
-                output_func(VncEvent::RawImage(tile_rect, pixels)).await?;
+                copy_tile_to_rect(&mut rect_pixels, rect, &tile_rect, &pixels, bpp)?;
                 x += width;
             }
             y += height;
         }
 
         self.decompressor = Some(reader.into_inner()?);
+        output_func(VncEvent::RawImage(*rect, rect_pixels)).await?;
 
         Ok(())
     }
+}
+
+fn copy_tile_to_rect(
+    rect_pixels: &mut [u8],
+    rect: &Rect,
+    tile_rect: &Rect,
+    tile_pixels: &[u8],
+    bpp: usize,
+) -> Result<(), VncError> {
+    let tile_row_bytes = usize::from(tile_rect.width)
+        .checked_mul(bpp)
+        .ok_or(VncError::IntegerOverflow("ZRLE tile row bytes"))?;
+    let rect_row_bytes = usize::from(rect.width)
+        .checked_mul(bpp)
+        .ok_or(VncError::IntegerOverflow("ZRLE rect row bytes"))?;
+    let x_offset = usize::from(
+        tile_rect
+            .x
+            .checked_sub(rect.x)
+            .ok_or(VncError::InvalidImageData)?,
+    )
+    .checked_mul(bpp)
+    .ok_or(VncError::IntegerOverflow("ZRLE tile x offset"))?;
+    let y_offset = usize::from(
+        tile_rect
+            .y
+            .checked_sub(rect.y)
+            .ok_or(VncError::InvalidImageData)?,
+    );
+
+    for row in 0..usize::from(tile_rect.height) {
+        let src_start = row
+            .checked_mul(tile_row_bytes)
+            .ok_or(VncError::IntegerOverflow("ZRLE tile source row"))?;
+        let src_end = src_start
+            .checked_add(tile_row_bytes)
+            .ok_or(VncError::IntegerOverflow("ZRLE tile source end"))?;
+        let dst_start = y_offset
+            .checked_add(row)
+            .and_then(|y| y.checked_mul(rect_row_bytes))
+            .and_then(|start| start.checked_add(x_offset))
+            .ok_or(VncError::IntegerOverflow("ZRLE rect destination row"))?;
+        let dst_end = dst_start
+            .checked_add(tile_row_bytes)
+            .ok_or(VncError::IntegerOverflow("ZRLE rect destination end"))?;
+        let src = tile_pixels
+            .get(src_start..src_end)
+            .ok_or(VncError::InvalidImageData)?;
+        let dst = rect_pixels
+            .get_mut(dst_start..dst_end)
+            .ok_or(VncError::InvalidImageData)?;
+        dst.copy_from_slice(src);
+    }
+
+    Ok(())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,6 +183,7 @@ function getRemoteDesktopPaneDisplay(connection: SavedConnection | null | undefi
     return {
       scaleMode: connection.display?.scale_mode ?? "fit",
       viewOnly: connection.view_only ?? false,
+      clipboardEnabled: connection.clipboard?.enabled ?? true,
     } as const;
   }
   return undefined;

--- a/src/components/rdp/RdpPaneHost.tsx
+++ b/src/components/rdp/RdpPaneHost.tsx
@@ -37,7 +37,7 @@ import {
   getRemoteDesktopContentRect,
   mapClientEventToRemoteDesktopPixel,
 } from "@/lib/remoteDesktopViewport";
-import type { RdpSessionPane } from "@/types/global";
+import type { RdpSessionPane, RemoteDesktopScaleMode } from "@/types/global";
 
 type RdpSessionState =
   | "connecting"
@@ -86,8 +86,12 @@ interface RdpPaneHostProps {
   onConnectionError?: (sessionId: string, error: string) => void;
 }
 
-function getCanvasPoint(canvas: HTMLCanvasElement, event: PointerEvent | WheelEvent) {
-  return mapClientEventToRemoteDesktopPixel(canvas, event);
+function getCanvasPoint(
+  canvas: HTMLCanvasElement,
+  event: PointerEvent | WheelEvent,
+  scaleMode: RemoteDesktopScaleMode,
+) {
+  return mapClientEventToRemoteDesktopPixel(canvas, event, scaleMode);
 }
 
 function buttonName(button: number): Extract<RdpInputEvent, { type: "mouse-button" }>["button"] {
@@ -287,14 +291,14 @@ function RdpPaneHost({
     const position = pendingCursorRef.current;
     const bitmap = remoteCursorBitmapRef.current;
     if (!cursor || !canvas || !container || !position || !bitmap) return;
-    const rect = getRemoteDesktopContentRect(canvas);
+    const rect = getRemoteDesktopContentRect(canvas, pane.display?.scaleMode ?? "fit");
     const containerRect = container.getBoundingClientRect();
     const scaleX = rect.width / Math.max(1, canvas.width);
     const scaleY = rect.height / Math.max(1, canvas.height);
     const x = rect.left - containerRect.left + position.x * scaleX - bitmap.hotspotX * scaleX;
     const y = rect.top - containerRect.top + position.y * scaleY - bitmap.hotspotY * scaleY;
     cursor.style.transform = `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0)`;
-  }, []);
+  }, [pane.display?.scaleMode]);
 
   useEffect(() => {
     const unlisten = listen<RdpPointerPayload>(`rdp-pointer-${pane.sessionId}`, (event) => {
@@ -524,12 +528,16 @@ function RdpPaneHost({
     (event: ReactPointerEvent<HTMLCanvasElement>) => {
       const canvas = canvasRef.current;
       if (!canvas) return;
-      pendingMouseMoveRef.current = getCanvasPoint(canvas, event.nativeEvent);
+      pendingMouseMoveRef.current = getCanvasPoint(
+        canvas,
+        event.nativeEvent,
+        pane.display?.scaleMode ?? "fit",
+      );
       if (mouseRafRef.current === null) {
         mouseRafRef.current = requestAnimationFrame(flushMouseMove);
       }
     },
-    [flushMouseMove],
+    [flushMouseMove, pane.display?.scaleMode],
   );
 
   const scaleStyle = useMemo(
@@ -613,7 +621,7 @@ function RdpPaneHost({
           const canvas = canvasRef.current;
           if (!canvas) return;
           event.currentTarget.setPointerCapture(event.pointerId);
-          const point = getCanvasPoint(canvas, event.nativeEvent);
+          const point = getCanvasPoint(canvas, event.nativeEvent, pane.display?.scaleMode ?? "fit");
           void sendInputBatch([
             { type: "mouse-button", button: buttonName(event.button), pressed: true, ...point },
           ]);
@@ -621,7 +629,7 @@ function RdpPaneHost({
         onPointerUp={(event) => {
           const canvas = canvasRef.current;
           if (!canvas) return;
-          const point = getCanvasPoint(canvas, event.nativeEvent);
+          const point = getCanvasPoint(canvas, event.nativeEvent, pane.display?.scaleMode ?? "fit");
           void sendInputBatch([
             { type: "mouse-button", button: buttonName(event.button), pressed: false, ...point },
           ]);
@@ -630,7 +638,7 @@ function RdpPaneHost({
           const canvas = canvasRef.current;
           if (!canvas) return;
           event.preventDefault();
-          const point = getCanvasPoint(canvas, event.nativeEvent);
+          const point = getCanvasPoint(canvas, event.nativeEvent, pane.display?.scaleMode ?? "fit");
           void sendInputBatch([
             { type: "mouse-wheel", deltaX: event.deltaX, deltaY: event.deltaY, ...point },
           ]);

--- a/src/components/remote-desktop/RemoteDesktopSurface.test.tsx
+++ b/src/components/remote-desktop/RemoteDesktopSurface.test.tsx
@@ -1,12 +1,13 @@
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { createRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RemoteDesktopFramePatch } from "@/lib/remoteDesktopFrame";
 import { RemoteDesktopSurface, type RemoteDesktopSurfaceHandle } from "./RemoteDesktopSurface";
 
-const { createRenderer, draw, dispose } = vi.hoisted(() => ({
+const { createRenderer, draw, drawMany, dispose } = vi.hoisted(() => ({
   createRenderer: vi.fn(),
   draw: vi.fn(),
+  drawMany: vi.fn(),
   dispose: vi.fn(),
 }));
 
@@ -30,20 +31,41 @@ const patch: RemoteDesktopFramePatch = {
 describe("RemoteDesktopSurface", () => {
   beforeEach(() => {
     draw.mockReset();
+    drawMany.mockReset();
     dispose.mockReset();
     createRenderer.mockReset();
-    createRenderer.mockReturnValue({ draw, dispose });
+    createRenderer.mockReturnValue({ draw, drawMany, dispose });
   });
 
-  it("draws frames imperatively without storing framebuffer data in React state", () => {
+  it("batches imperative frame draws on the next animation frame", () => {
     const ref = createRef<RemoteDesktopSurfaceHandle>();
+    let rafCallback: FrameRequestCallback | null = null;
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        rafCallback = callback;
+        return 1;
+      });
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {});
     render(<RemoteDesktopSurface ref={ref} scaleMode="fit" active visible />);
 
     act(() => ref.current?.drawFrame(patch));
     act(() => ref.current?.drawFrame({ ...patch, sequence: 2n }));
 
+    expect(requestAnimationFrame).toHaveBeenCalledOnce();
+    expect(createRenderer).not.toHaveBeenCalled();
+    expect(drawMany).not.toHaveBeenCalled();
+
+    act(() => rafCallback?.(16));
+
     expect(createRenderer).toHaveBeenCalledOnce();
-    expect(draw).toHaveBeenCalledTimes(2);
+    expect(drawMany).toHaveBeenCalledWith([patch, { ...patch, sequence: 2n }]);
+    expect(draw).not.toHaveBeenCalled();
+
+    requestAnimationFrame.mockRestore();
+    cancelAnimationFrame.mockRestore();
   });
 
   it("implements fit, actual, and stretch as local canvas presentation modes", () => {
@@ -69,13 +91,53 @@ describe("RemoteDesktopSurface", () => {
 
   it("disposes renderer resources on reset and unmount", () => {
     const ref = createRef<RemoteDesktopSurfaceHandle>();
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {});
     const view = render(<RemoteDesktopSurface ref={ref} scaleMode="fit" active visible />);
     act(() => ref.current?.drawFrame(patch));
     act(() => ref.current?.reset());
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1);
+    expect(dispose).not.toHaveBeenCalled();
+
+    let rafCallback: FrameRequestCallback | null = null;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      rafCallback = callback;
+      return 2;
+    });
+    act(() => ref.current?.drawFrame(patch));
+    act(() => rafCallback?.(16));
+    view.unmount();
     expect(dispose).toHaveBeenCalledOnce();
 
-    act(() => ref.current?.drawFrame(patch));
-    view.unmount();
-    expect(dispose).toHaveBeenCalledTimes(2);
+    vi.restoreAllMocks();
+  });
+
+  it("maps pointer coordinates with stretch presentation", () => {
+    const onPointerMove = vi.fn();
+    const view = render(
+      <RemoteDesktopSurface scaleMode="stretch" active visible onPointerMove={onPointerMove} />,
+    );
+    const canvas = view.container.querySelector("canvas");
+    if (!(canvas instanceof HTMLCanvasElement)) throw new Error("expected canvas");
+    canvas.width = 100;
+    canvas.height = 100;
+    canvas.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        top: 20,
+        width: 300,
+        height: 200,
+        right: 310,
+        bottom: 220,
+        x: 10,
+        y: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    fireEvent.pointerMove(canvas, { clientX: 160, clientY: 120 });
+
+    expect(onPointerMove).toHaveBeenCalledWith({ x: 50, y: 50 }, expect.any(PointerEvent));
   });
 });

--- a/src/components/remote-desktop/RemoteDesktopSurface.tsx
+++ b/src/components/remote-desktop/RemoteDesktopSurface.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -71,18 +72,49 @@ export const RemoteDesktopSurface = forwardRef<
   const rootRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rendererRef = useRef<RemoteDesktopRenderer | null>(null);
+  const pendingFramesRef = useRef<RemoteDesktopFramePatch[]>([]);
+  const frameRequestRef = useRef<number | null>(null);
   const style = useMemo(() => canvasStyle(scaleMode), [scaleMode]);
+
+  const cancelPendingDraw = useCallback(() => {
+    if (frameRequestRef.current !== null) {
+      window.cancelAnimationFrame(frameRequestRef.current);
+      frameRequestRef.current = null;
+    }
+    pendingFramesRef.current = [];
+  }, []);
+
+  const flushPendingFrames = useCallback(() => {
+    frameRequestRef.current = null;
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      pendingFramesRef.current = [];
+      return;
+    }
+    const frames = pendingFramesRef.current;
+    pendingFramesRef.current = [];
+    if (frames.length === 0) return;
+    rendererRef.current ??= createRemoteDesktopRenderer(canvas);
+    rendererRef.current?.drawMany(frames);
+  }, []);
+
+  const scheduleFrameDraw = useCallback(
+    (patch: RemoteDesktopFramePatch) => {
+      pendingFramesRef.current.push(patch);
+      if (frameRequestRef.current !== null) return;
+      frameRequestRef.current = window.requestAnimationFrame(flushPendingFrames);
+    },
+    [flushPendingFrames],
+  );
 
   useImperativeHandle(
     forwardedRef,
     () => ({
       drawFrame(patch) {
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        rendererRef.current ??= createRemoteDesktopRenderer(canvas);
-        rendererRef.current?.draw(patch);
+        scheduleFrameDraw(patch);
       },
       reset() {
+        cancelPendingDraw();
         rendererRef.current?.dispose();
         rendererRef.current = null;
         const canvas = canvasRef.current;
@@ -95,19 +127,20 @@ export const RemoteDesktopSurface = forwardRef<
         rootRef.current?.focus({ preventScroll: true });
       },
     }),
-    [],
+    [cancelPendingDraw, scheduleFrameDraw],
   );
 
   useEffect(() => {
     return () => {
+      cancelPendingDraw();
       rendererRef.current?.dispose();
       rendererRef.current = null;
     };
-  }, []);
+  }, [cancelPendingDraw]);
 
   const getPoint = (event: PointerEvent | WheelEvent) => {
     const canvas = canvasRef.current;
-    return canvas ? mapClientEventToRemoteDesktopPixel(canvas, event) : { x: 0, y: 0 };
+    return canvas ? mapClientEventToRemoteDesktopPixel(canvas, event, scaleMode) : { x: 0, y: 0 };
   };
 
   return (

--- a/src/components/remote-desktop/renderer.test.ts
+++ b/src/components/remote-desktop/renderer.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { Canvas2dRemoteDesktopRenderer, createRemoteDesktopRenderer } from "./renderer";
+import {
+  Canvas2dRemoteDesktopRenderer,
+  createRemoteDesktopRenderer,
+  WebGl2RemoteDesktopRenderer,
+} from "./renderer";
 
 function patch(pixelFormat: "RGBA8888" | "BGRA8888" = "RGBA8888") {
   return {
@@ -36,6 +40,29 @@ describe("remote desktop renderer", () => {
     expect(context.putImageData).toHaveBeenCalledWith(imageData, 1, 1);
   });
 
+  it("uploads a WebGL batch before issuing one draw call", () => {
+    const gl = createWebGlMock();
+    const canvas = document.createElement("canvas");
+    const first = patch();
+    const second = {
+      ...patch(),
+      sequence: 2n,
+      x: 2,
+      payload: new Uint8Array([4, 5, 6, 255]),
+    };
+    const renderer = new WebGl2RemoteDesktopRenderer(
+      canvas,
+      gl as unknown as WebGL2RenderingContext,
+    );
+
+    renderer.drawMany([first, second]);
+
+    expect(canvas.width).toBe(4);
+    expect(canvas.height).toBe(3);
+    expect(gl.texSubImage2D).toHaveBeenCalledTimes(2);
+    expect(gl.drawArrays).toHaveBeenCalledTimes(1);
+  });
+
   it("returns null when neither rendering context is available", () => {
     const canvas = document.createElement("canvas");
     vi.spyOn(canvas, "getContext").mockReturnValue(null);
@@ -43,3 +70,54 @@ describe("remote desktop renderer", () => {
     expect(createRemoteDesktopRenderer(canvas)).toBeNull();
   });
 });
+
+function createWebGlMock() {
+  return {
+    ARRAY_BUFFER: 0x8892,
+    CLAMP_TO_EDGE: 0x812f,
+    COMPILE_STATUS: 0x8b81,
+    DEPTH: 0x1801,
+    FLOAT: 0x1406,
+    FRAGMENT_SHADER: 0x8b30,
+    LINK_STATUS: 0x8b82,
+    NEAREST: 0x2600,
+    RGBA: 0x1908,
+    STATIC_DRAW: 0x88e4,
+    TEXTURE_2D: 0x0de1,
+    TEXTURE_MAG_FILTER: 0x2800,
+    TEXTURE_MIN_FILTER: 0x2801,
+    TEXTURE_WRAP_S: 0x2802,
+    TEXTURE_WRAP_T: 0x2803,
+    TRIANGLE_STRIP: 0x0005,
+    UNSIGNED_BYTE: 0x1401,
+    VERTEX_SHADER: 0x8b31,
+    attachShader: vi.fn(),
+    bindBuffer: vi.fn(),
+    bindTexture: vi.fn(),
+    bufferData: vi.fn(),
+    compileShader: vi.fn(),
+    createBuffer: vi.fn(() => ({})),
+    createProgram: vi.fn(() => ({})),
+    createShader: vi.fn(() => ({})),
+    createTexture: vi.fn(() => ({})),
+    deleteBuffer: vi.fn(),
+    deleteProgram: vi.fn(),
+    deleteShader: vi.fn(),
+    deleteTexture: vi.fn(),
+    drawArrays: vi.fn(),
+    enableVertexAttribArray: vi.fn(),
+    getAttribLocation: vi.fn(() => 0),
+    getProgramInfoLog: vi.fn(() => ""),
+    getProgramParameter: vi.fn(() => true),
+    getShaderInfoLog: vi.fn(() => ""),
+    getShaderParameter: vi.fn(() => true),
+    linkProgram: vi.fn(),
+    shaderSource: vi.fn(),
+    texImage2D: vi.fn(),
+    texParameteri: vi.fn(),
+    texSubImage2D: vi.fn(),
+    useProgram: vi.fn(),
+    vertexAttribPointer: vi.fn(),
+    viewport: vi.fn(),
+  };
+}

--- a/src/components/remote-desktop/renderer.ts
+++ b/src/components/remote-desktop/renderer.ts
@@ -2,6 +2,7 @@ import type { RemoteDesktopFramePatch } from "@/lib/remoteDesktopFrame";
 
 export interface RemoteDesktopRenderer {
   draw(patch: RemoteDesktopFramePatch): void;
+  drawMany(patches: RemoteDesktopFramePatch[]): void;
   dispose(): void;
 }
 
@@ -41,6 +42,12 @@ export class Canvas2dRemoteDesktopRenderer implements RemoteDesktopRenderer {
     const imageData = this.ctx.createImageData(patch.width, patch.height);
     copyPatchToRgba(patch, imageData.data);
     this.ctx.putImageData(imageData, patch.x, patch.y);
+  }
+
+  drawMany(patches: RemoteDesktopFramePatch[]) {
+    for (const patch of patches) {
+      this.draw(patch);
+    }
   }
 
   dispose() {}
@@ -127,18 +134,30 @@ export class WebGl2RemoteDesktopRenderer implements RemoteDesktopRenderer {
   }
 
   draw(patch: RemoteDesktopFramePatch) {
-    const resized = ensureCanvasSize(this.canvas, patch.desktopWidth, patch.desktopHeight);
+    this.drawMany([patch]);
+  }
+
+  drawMany(patches: RemoteDesktopFramePatch[]) {
+    if (patches.length === 0) return;
+    const lastPatch = patches[patches.length - 1];
+    if (!lastPatch) return;
+    const desktopWidth = lastPatch.desktopWidth;
+    const desktopHeight = lastPatch.desktopHeight;
+    const renderPatches = patches.filter(
+      (patch) => patch.desktopWidth === desktopWidth && patch.desktopHeight === desktopHeight,
+    );
+    const resized = ensureCanvasSize(this.canvas, desktopWidth, desktopHeight);
     const gl = this.gl;
     activateWebGlProgram(gl, this.program);
-    gl.viewport(0, 0, patch.desktopWidth, patch.desktopHeight);
+    gl.viewport(0, 0, desktopWidth, desktopHeight);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
     if (resized) {
       gl.texImage2D(
         gl.TEXTURE_2D,
         0,
         gl.RGBA,
-        patch.desktopWidth,
-        patch.desktopHeight,
+        desktopWidth,
+        desktopHeight,
         0,
         gl.RGBA,
         gl.UNSIGNED_BYTE,
@@ -146,25 +165,27 @@ export class WebGl2RemoteDesktopRenderer implements RemoteDesktopRenderer {
       );
     }
 
-    const rowBytes = patch.width * 4;
-    const requiredBytes = rowBytes * patch.height;
-    const canUploadDirectly = patch.pixelFormat === "RGBA8888" && patch.stride === rowBytes;
-    const patchBytes = canUploadDirectly
-      ? patch.payload.subarray(0, requiredBytes)
-      : new Uint8Array(requiredBytes);
-    if (!canUploadDirectly) copyPatchToRgba(patch, patchBytes);
+    for (const patch of renderPatches) {
+      const rowBytes = patch.width * 4;
+      const requiredBytes = rowBytes * patch.height;
+      const canUploadDirectly = patch.pixelFormat === "RGBA8888" && patch.stride === rowBytes;
+      const patchBytes = canUploadDirectly
+        ? patch.payload.subarray(0, requiredBytes)
+        : new Uint8Array(requiredBytes);
+      if (!canUploadDirectly) copyPatchToRgba(patch, patchBytes);
 
-    gl.texSubImage2D(
-      gl.TEXTURE_2D,
-      0,
-      patch.x,
-      patch.y,
-      patch.width,
-      patch.height,
-      gl.RGBA,
-      gl.UNSIGNED_BYTE,
-      patchBytes,
-    );
+      gl.texSubImage2D(
+        gl.TEXTURE_2D,
+        0,
+        patch.x,
+        patch.y,
+        patch.width,
+        patch.height,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        patchBytes,
+      );
+    }
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
   }
 

--- a/src/components/vnc/VncPaneHost.test.tsx
+++ b/src/components/vnc/VncPaneHost.test.tsx
@@ -3,14 +3,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { VncSessionPane } from "@/types/global";
 import VncPaneHost from "./VncPaneHost";
 
-const { invokeMock, listenMock, listeners } = vi.hoisted(() => ({
-  invokeMock: vi.fn(),
-  listenMock: vi.fn(),
-  listeners: new Map<string, (event: { payload: unknown }) => void>(),
-}));
+const { invokeMock, listenMock, listeners, readClipboardTextMock, writeClipboardTextMock } =
+  vi.hoisted(() => ({
+    invokeMock: vi.fn(),
+    listenMock: vi.fn(),
+    listeners: new Map<string, (event: { payload: unknown }) => void>(),
+    readClipboardTextMock: vi.fn(),
+    writeClipboardTextMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/invoke", () => ({
   invoke: invokeMock,
+}));
+
+vi.mock("@/lib/clipboard", () => ({
+  readClipboardText: readClipboardTextMock,
+  writeClipboardText: writeClipboardTextMock,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -31,6 +39,10 @@ describe("VncPaneHost", () => {
   beforeEach(() => {
     invokeMock.mockReset();
     invokeMock.mockResolvedValue(undefined);
+    readClipboardTextMock.mockReset();
+    readClipboardTextMock.mockResolvedValue("");
+    writeClipboardTextMock.mockReset();
+    writeClipboardTextMock.mockResolvedValue(undefined);
     listenMock.mockReset();
     listeners.clear();
     listenMock.mockImplementation(
@@ -126,6 +138,77 @@ describe("VncPaneHost", () => {
 
     expect(invokeMock).toHaveBeenCalledWith("vnc_reconnect", { sessionId: "vnc-session" });
     expect(onDisconnectedCloseRequested).toHaveBeenCalledOnce();
+  });
+
+  it("writes remote clipboard events to the local clipboard when enabled and focused", async () => {
+    render(
+      <VncPaneHost
+        pane={vncPane({ display: { scaleMode: "fit", clipboardEnabled: true } })}
+        active
+        visible
+      />,
+    );
+    await activate();
+    await waitFor(() => expect(listeners.has("vnc-clipboard-vnc-session")).toBe(true));
+
+    act(() => {
+      listeners.get("vnc-clipboard-vnc-session")?.({
+        payload: { sessionId: "vnc-session", text: "remote" },
+      });
+    });
+
+    expect(writeClipboardTextMock).toHaveBeenCalledWith("remote");
+  });
+
+  it("does not subscribe to remote clipboard events when clipboard is disabled", async () => {
+    render(
+      <VncPaneHost
+        pane={vncPane({ display: { scaleMode: "fit", clipboardEnabled: false } })}
+        active
+        visible
+      />,
+    );
+    await activate();
+
+    expect(listeners.has("vnc-clipboard-vnc-session")).toBe(false);
+  });
+
+  it("polls local clipboard and sends changed Latin-1 text to the VNC server", async () => {
+    readClipboardTextMock.mockResolvedValue("local");
+    render(
+      <VncPaneHost
+        pane={vncPane({ display: { scaleMode: "fit", clipboardEnabled: true } })}
+        active
+        visible
+      />,
+    );
+    await activate();
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("vnc_set_clipboard_text", {
+        sessionId: "vnc-session",
+        text: "local",
+      });
+    });
+  });
+
+  it("does not send local clipboard text for view-only panes", async () => {
+    readClipboardTextMock.mockResolvedValue("local");
+    render(
+      <VncPaneHost
+        pane={vncPane({
+          display: { scaleMode: "fit", clipboardEnabled: true, viewOnly: true },
+        })}
+        active
+        visible
+      />,
+    );
+    await activate();
+    invokeMock.mockClear();
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(invokeMock).not.toHaveBeenCalledWith("vnc_set_clipboard_text", expect.anything());
   });
 });
 

--- a/src/components/vnc/VncPaneHost.tsx
+++ b/src/components/vnc/VncPaneHost.tsx
@@ -15,6 +15,7 @@ import {
   type RemoteDesktopSurfaceHandle,
 } from "@/components/remote-desktop/RemoteDesktopSurface";
 import { Button } from "@/components/ui/button";
+import { readClipboardText, writeClipboardText } from "@/lib/clipboard";
 import { invoke } from "@/lib/invoke";
 import { decodeRemoteDesktopFramePatch } from "@/lib/remoteDesktopFrame";
 import {
@@ -40,6 +41,11 @@ interface VncStatePayload {
   state: VncSessionState;
   message?: string | null;
   errorKind?: string | null;
+}
+
+interface VncClipboardPayload {
+  sessionId: string;
+  text: string;
 }
 
 interface VncPaneHostProps {
@@ -82,6 +88,14 @@ function wheelButtonMask(event: WheelEvent) {
   return event.deltaY > 0 ? VNC_POINTER_BUTTON.wheelDown : VNC_POINTER_BUTTON.wheelUp;
 }
 
+function isVncClipboardTextAllowed(text: string) {
+  return (
+    text.length > 0 &&
+    text.length <= 1024 * 1024 &&
+    [...text].every((ch) => ch.charCodeAt(0) <= 0xff)
+  );
+}
+
 function VncPaneHost({
   pane,
   active,
@@ -96,6 +110,8 @@ function VncPaneHost({
   const pendingPointerRef = useRef<{ x: number; y: number; buttonMask: number } | null>(null);
   const pointerRafRef = useRef<number | null>(null);
   const composingRef = useRef(false);
+  const lastLocalSentRef = useRef<string | null>(null);
+  const lastRemoteReceivedRef = useRef<string | null>(null);
   const [state, setState] = useState<VncSessionState>(pane.connectError ? "failed" : "connecting");
   const [message, setMessage] = useState<string | null>(pane.connectError ?? null);
   const [desktopSize, setDesktopSize] = useState({
@@ -104,7 +120,15 @@ function VncPaneHost({
   });
 
   const viewOnly = pane.display?.viewOnly ?? false;
+  const clipboardEnabled = pane.display?.clipboardEnabled ?? true;
   const inputEnabled = !viewOnly && !pane.connecting && !pane.connectError && state === "active";
+  const clipboardBridgeEnabled =
+    clipboardEnabled &&
+    active &&
+    visible &&
+    !pane.connecting &&
+    !pane.connectError &&
+    state === "active";
 
   const sendInputBatch = useCallback(
     async (events: VncInputEvent[]) => {
@@ -150,6 +174,52 @@ function VncPaneHost({
       void unlisten.then((dispose) => dispose());
     };
   }, [onConnectionError, pane.sessionId]);
+
+  useEffect(() => {
+    if (!clipboardBridgeEnabled) return;
+    const unlisten = listen<VncClipboardPayload>(`vnc-clipboard-${pane.sessionId}`, (event) => {
+      const text = event.payload.text;
+      lastRemoteReceivedRef.current = text;
+      void writeClipboardText(text).catch(() => {});
+    });
+    return () => {
+      void unlisten.then((dispose) => dispose());
+    };
+  }, [clipboardBridgeEnabled, pane.sessionId]);
+
+  useEffect(() => {
+    if (!clipboardBridgeEnabled || viewOnly) return;
+    let disposed = false;
+    let polling = false;
+    const poll = async () => {
+      if (disposed || polling) return;
+      polling = true;
+      try {
+        const text = await readClipboardText();
+        if (
+          !disposed &&
+          text !== lastLocalSentRef.current &&
+          text !== lastRemoteReceivedRef.current &&
+          isVncClipboardTextAllowed(text)
+        ) {
+          lastLocalSentRef.current = text;
+          await invoke("vnc_set_clipboard_text", { sessionId: pane.sessionId, text }).catch(
+            () => {},
+          );
+        }
+      } catch {
+        /* clipboard access can be denied while the pane remains usable */
+      } finally {
+        polling = false;
+      }
+    };
+    void poll();
+    const interval = window.setInterval(() => void poll(), 1000);
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+    };
+  }, [clipboardBridgeEnabled, pane.sessionId, viewOnly]);
 
   useEffect(() => {
     if (!active || !visible) releaseAllKeys();

--- a/src/lib/remoteDesktopViewport.test.ts
+++ b/src/lib/remoteDesktopViewport.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRemoteDesktopContentRect,
+  mapClientEventToRemoteDesktopPixel,
+} from "./remoteDesktopViewport";
+
+function canvas(
+  desktopWidth: number,
+  desktopHeight: number,
+  rect: Pick<DOMRect, "left" | "top" | "width" | "height">,
+) {
+  const element = document.createElement("canvas");
+  element.width = desktopWidth;
+  element.height = desktopHeight;
+  element.getBoundingClientRect = () =>
+    ({
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return element;
+}
+
+describe("remoteDesktopViewport", () => {
+  it("uses an aspect-preserving content rect for fit mode", () => {
+    const element = canvas(100, 100, { left: 10, top: 20, width: 300, height: 200 });
+    expect(getRemoteDesktopContentRect(element, "fit")).toMatchObject({
+      left: 60,
+      top: 20,
+      width: 200,
+      height: 200,
+    });
+  });
+
+  it("uses the full canvas rect for actual and stretch modes", () => {
+    const element = canvas(100, 100, { left: 10, top: 20, width: 300, height: 200 });
+    expect(getRemoteDesktopContentRect(element, "actual")).toMatchObject({
+      left: 10,
+      top: 20,
+      width: 300,
+      height: 200,
+    });
+    expect(getRemoteDesktopContentRect(element, "stretch")).toMatchObject({
+      left: 10,
+      top: 20,
+      width: 300,
+      height: 200,
+    });
+  });
+
+  it("maps stretch coordinates across the full stretched canvas", () => {
+    const element = canvas(100, 100, { left: 10, top: 20, width: 300, height: 200 });
+    expect(
+      mapClientEventToRemoteDesktopPixel(element, { clientX: 160, clientY: 120 }, "stretch"),
+    ).toEqual({ x: 50, y: 50 });
+  });
+
+  it("maps fit coordinates through the centered content rect", () => {
+    const element = canvas(100, 100, { left: 10, top: 20, width: 300, height: 200 });
+    expect(
+      mapClientEventToRemoteDesktopPixel(element, { clientX: 60, clientY: 20 }, "fit"),
+    ).toEqual({ x: 0, y: 0 });
+    expect(
+      mapClientEventToRemoteDesktopPixel(element, { clientX: 260, clientY: 220 }, "fit"),
+    ).toEqual({ x: 99, y: 99 });
+  });
+});

--- a/src/lib/remoteDesktopViewport.ts
+++ b/src/lib/remoteDesktopViewport.ts
@@ -1,3 +1,5 @@
+import type { RemoteDesktopScaleMode } from "@/types/global";
+
 export interface RemoteDesktopViewportRect {
   left: number;
   top: number;
@@ -9,11 +11,18 @@ function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
 }
 
-export function getRemoteDesktopContentRect(canvas: HTMLCanvasElement): RemoteDesktopViewportRect {
+export function getRemoteDesktopContentRect(
+  canvas: HTMLCanvasElement,
+  scaleMode: RemoteDesktopScaleMode = "fit",
+): RemoteDesktopViewportRect {
   const rect = canvas.getBoundingClientRect();
   const desktopWidth = canvas.width;
   const desktopHeight = canvas.height;
   if (rect.width <= 0 || rect.height <= 0 || desktopWidth <= 0 || desktopHeight <= 0) {
+    return rect;
+  }
+
+  if (scaleMode === "stretch" || scaleMode === "actual") {
     return rect;
   }
 
@@ -52,9 +61,10 @@ export function mapClientPointToRemoteDesktopPixel(
 export function mapClientEventToRemoteDesktopPixel(
   canvas: HTMLCanvasElement,
   event: Pick<PointerEvent | WheelEvent, "clientX" | "clientY">,
+  scaleMode: RemoteDesktopScaleMode = "fit",
 ) {
   return mapClientPointToRemoteDesktopPixel(
-    getRemoteDesktopContentRect(canvas),
+    getRemoteDesktopContentRect(canvas, scaleMode),
     canvas.width,
     canvas.height,
     event.clientX,

--- a/src/lib/workspaceTabs.test.ts
+++ b/src/lib/workspaceTabs.test.ts
@@ -178,6 +178,8 @@ describe("workspaceTabs remote desktop persistence", () => {
         remoteWidth: 1366,
         remoteHeight: 768,
         scaleMode: "stretch",
+        viewOnly: true,
+        clipboardEnabled: false,
       },
     });
     const [serialized] = serializeTabsForPersistence([createWorkspaceTab(pane, 0)]);
@@ -190,6 +192,8 @@ describe("workspaceTabs remote desktop persistence", () => {
         remoteWidth: 1366,
         remoteHeight: 768,
         scaleMode: "stretch",
+        viewOnly: true,
+        clipboardEnabled: false,
       },
     });
     const restored = restoreTabFromPersistence(serialized, 0);
@@ -200,6 +204,8 @@ describe("workspaceTabs remote desktop persistence", () => {
         remoteWidth: 1366,
         remoteHeight: 768,
         scaleMode: "stretch",
+        viewOnly: true,
+        clipboardEnabled: false,
       },
     });
   });

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -92,6 +92,7 @@ export interface RemoteDesktopDisplayMetadata {
   remoteHeight?: number;
   scaleMode?: RemoteDesktopScaleMode;
   viewOnly?: boolean;
+  clipboardEnabled?: boolean;
 }
 
 /** Leaf node representing one graphical remote desktop session inside a workspace tab. */


### PR DESCRIPTION
- Added clipboard support in VNC sessions, allowing remote clipboard events to be written to the local clipboard when enabled.
- Implemented polling for local clipboard changes to send updates to the VNC server, ensuring synchronization between local and remote clipboard contents.
- Updated rendering logic in RemoteDesktopSurface to handle multiple frame patches efficiently using batch drawing.
- Enhanced tests for VNC clipboard functionality and rendering to ensure reliability and performance.
- Refactored related components to accommodate new clipboard features and improve code organization.