### PR TITLE
fix(ui): improve macOS title bar and popup layering

### DIFF
--- a/crates/nyaterm-app/Cargo.toml
+++ b/crates/nyaterm-app/Cargo.toml
@@ -30,3 +30,8 @@ path = "src/lib.rs"
 [[bin]]
 name = "nyaterm"
 path = "src/main.rs"
+
+
+[features]
+default = ["font-kit"]
+font-kit = ["gpui_platform/font-kit"]

--- a/crates/nyaterm-app/src/main.rs
+++ b/crates/nyaterm-app/src/main.rs
@@ -1,5 +1,7 @@
 use anyhow::Context as _;
-use gpui::{App, AppContext, Bounds, WindowBounds, WindowOptions, px, size};
+use gpui::{
+    App, AppContext, Bounds, TitlebarOptions, WindowBounds, WindowOptions, point, px, size,
+};
 use nyaterm_app::assets;
 use nyaterm_core::{AppRuntime, LOG_FILE_PREFIX, LOG_FILE_SUFFIX};
 use nyaterm_desktop::AppShell;
@@ -24,7 +26,12 @@ fn main() -> anyhow::Result<()> {
 
             cx.open_window(
                 WindowOptions {
-                    titlebar: None,
+                    titlebar: Some(TitlebarOptions {
+                        appears_transparent: true,
+                        traffic_light_position: cfg!(target_os = "macos")
+                            .then(|| point(px(9.), px(11.))),
+                        ..Default::default()
+                    }),
                     window_bounds: Some(WindowBounds::Windowed(bounds)),
                     ..Default::default()
                 },

--- a/crates/nyaterm-desktop/src/features/layout/title_bar/bar.rs
+++ b/crates/nyaterm-desktop/src/features/layout/title_bar/bar.rs
@@ -47,7 +47,7 @@ impl NyaTermApp {
                     .items_center()
                     .gap_2()
                     .px_3()
-                    .when(macos, |this| this.pl(px(70.)))
+                    .when(macos, |this| this.pl(px(78.)))
                     .window_control_area(WindowControlArea::Drag)
                     .on_mouse_down(
                         MouseButton::Left,

--- a/crates/nyaterm-desktop/src/features/root.rs
+++ b/crates/nyaterm-desktop/src/features/root.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, Instant};
 use crate::models::{MainMode, NavItem, PanelResizeSide, PanelSide};
 use gpui::{
     AnyElement, Context, Div, IntoElement, KeyDownEvent, MouseButton, MouseMoveEvent, MouseUpEvent,
-    NavigationDirection, ObjectFit, Render, SharedString, Stateful, Window, canvas, div, img,
-    prelude::*, px, rgb, rgba, svg,
+    NavigationDirection, ObjectFit, Render, SharedString, Stateful, Window, canvas, deferred, div,
+    img, prelude::*, px, rgb, rgba, svg,
 };
 
 use super::NyaTermApp;
@@ -15,6 +15,7 @@ use crate::theme::ThemePalette;
 
 const WALLPAPER_TILE_ELEMENT_LIMIT: usize = 8192;
 const WALLPAPER_TILE_MIN_SIZE: f32 = 8.;
+const SSH_AUTH_PROMPT_PRIORITY: usize = usize::MAX;
 
 /// Which overlays the root chrome should render this frame.
 ///
@@ -615,8 +616,11 @@ impl NyaTermApp {
             // modal is open, so authentication must be the topmost overlay.
             .when(ssh_auth_prompt_open, |this| {
                 this.child(
-                    full_window_input_layer("ssh-auth-prompt-input-layer")
-                        .child(self.ssh_auth_prompt_overlay(cx)),
+                    deferred(
+                        full_window_input_layer("ssh-auth-prompt-input-layer")
+                            .child(self.ssh_auth_prompt_overlay(cx)),
+                    )
+                    .with_priority(SSH_AUTH_PROMPT_PRIORITY),
                 )
             })
     }

--- a/crates/nyaterm-desktop/src/features/root.rs
+++ b/crates/nyaterm-desktop/src/features/root.rs
@@ -728,9 +728,8 @@ impl NyaTermApp {
             }))
             .child(
                 div()
-                    .mx_auto()
-                    .w_full()
-                    .max_w(px(dialog_width))
+                    .w(px(dialog_width))
+                    .max_w_full()
                     .when_some(host_key_prompt, |this, prompt| {
                         this.child(self.host_key_prompt_banner(prompt, cx))
                     })

--- a/crates/nyaterm-ui/src/root.rs
+++ b/crates/nyaterm-ui/src/root.rs
@@ -2,10 +2,19 @@
 
 use gpui::{
     AnyView, AppContext as _, Context, InteractiveElement as _, IntoElement, ParentElement as _,
-    Render, Styled as _, Window, WindowHandle, div,
+    Render, Styled as _, Window, WindowHandle, deferred, div,
 };
 
 use crate::input_focus::schedule_nya_input_blur_on_outside_pointer_down;
+
+/// The base deferred priority at the component level.
+///
+/// The drag divider on the main interface uses the default priority `0`,
+/// while Select/Popover inside components typically use `1` or `2`.
+/// The component root layer also uses `1`, so it can cover the main interface divider,
+/// while internal popups are added to the deferred queue after the parent layer and
+/// can still appear above the dialog card.
+const COMPONENT_OVERLAY_PRIORITY: usize = 1;
 
 /// NyaTerm's component root type.
 ///
@@ -35,9 +44,23 @@ impl Render for NyaRootContent {
                 schedule_nya_input_blur_on_outside_pointer_down(event.button, window, cx);
             })
             .child(self.view.clone())
-            .children(gpui_component::Root::render_sheet_layer(window, cx))
-            .children(gpui_component::Root::render_dialog_layer(window, cx))
-            .children(gpui_component::Root::render_notification_layer(window, cx))
+            // GPUI's deferred rendering occurs after normal views. The panel boundaries
+            // and drag lines in the main interface also use this mechanism,
+            // so all component layers use a unified base priority to avoid hierarchies
+            // being scattered across various popup types. The priority of internal popups
+            // continues to take effect after the parent layer.
+            .children(
+                gpui_component::Root::render_sheet_layer(window, cx)
+                    .map(|layer| deferred(layer).with_priority(COMPONENT_OVERLAY_PRIORITY)),
+            )
+            .children(
+                gpui_component::Root::render_dialog_layer(window, cx)
+                    .map(|layer| deferred(layer).with_priority(COMPONENT_OVERLAY_PRIORITY)),
+            )
+            .children(
+                gpui_component::Root::render_notification_layer(window, cx)
+                    .map(|layer| deferred(layer).with_priority(COMPONENT_OVERLAY_PRIORITY)),
+            )
     }
 }
 


### PR DESCRIPTION
## Summary

- Enable `font-kit` by default for desktop builds.
- Configure the transparent macOS title bar and traffic-light position.
- Adjust macOS title-bar spacing.
- Fix deferred overlay priority so dialogs stay above resize lines and panel boundaries.
- Improve SSH authentication and popup dialog positioning.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p nyaterm-desktop`
- Manually verified on macOS.
