### PR TITLE
fix(terminal): reset commandRunning on OSC 133 A/B

### DIFF
--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -1428,11 +1428,13 @@ export default function XTerminal({
 
       if (data.startsWith("A")) {
         si.enabled = true;
+        si.commandRunning = false;
         return false;
       }
 
       if (data.startsWith("B")) {
         si.enabled = true;
+        si.commandRunning = false;
         resetCommandSuggestionSuppression();
         return false;
       }


### PR DESCRIPTION
## Problem

Command suggestions often do not appear on a fresh session (including the first connection, with no post-login command configured).

`canShowCommandSuggestions` returns `false` when `shellIntegration.enabled && shellIntegration.commandRunning`.

`commandRunning` was only cleared on OSC 133 `D`. If the shell integration script emits `C` without a matching `D`, the flag stays `true` and suggestions stay blocked.

## Observed sequence (local log)

On session start, OSC 133 order can look like:

    C → D;0 → A → C → B → B → …

Notably there is a `C` between `A` and `B` (before the user can type). After that `C`, `commandRunning` becomes `true`. Without resetting on `A`/`B`, it remains stuck until a later `D`.

## Fix

In the OSC 133 handler, set `commandRunning = false` when handling:

- `A` — prompt start (session is at a prompt)
- `B` — command input start (ready for user input)

This matches the protocol meaning of `A`/`B` and recovers from out-of-order or startup `C` markers.

## Changes

- OSC 133 `A`: also set `commandRunning = false`
- OSC 133 `B`: also set `commandRunning = false`
- No change to `C` / `D` behavior

## Test plan

- [x] Fresh local/SSH session, no post-login command → suggestions appear while typing at the prompt
- [x] Run `sleep 5` → suggestions suppressed while running; restored after prompt returns
- [x] `sleep 30` then Ctrl+C → suggestions work again at the next prompt
- [x] (optional) Log OSC 133: after startup `A`/`B`, `commandRunning` is `false` even if a spurious `C` appeared earlier