### PR TITLE
fix(desktop): prevent macOS panel re-entrant updates and stale snapshots

### DIFF
--- a/crates/nyaterm-desktop/src/features/connections/state/mod.rs
+++ b/crates/nyaterm-desktop/src/features/connections/state/mod.rs
@@ -242,6 +242,7 @@ impl ConnectionFeatureState {
                 NyaInputEvent::Changed(text) | NyaInputEvent::Submitted(text) => {
                     app.connection_state.set_list_search_text(text.clone());
                     app.sync_connection_keyboard_active(cx);
+                    app.defer_connection_panel_snapshot_flush(cx);
                     cx.notify();
                 }
                 NyaInputEvent::Blurred(_) => {}
@@ -1107,15 +1108,18 @@ impl ConnectionFeatureState {
             cx.subscribe(&entity, |app: &mut NyaTermApp, _, event, cx| match event {
                 NyaInputEvent::Changed(text) => {
                     app.connection_state.set_group_editor_name(text.clone());
+                    app.defer_connection_panel_snapshot_flush(cx);
                     cx.notify();
                 }
                 NyaInputEvent::Submitted(text) => {
                     app.connection_state.set_group_editor_name(text.clone());
                     app.save_connection_group_editor(cx);
+                    app.defer_connection_panel_snapshot_flush(cx);
                 }
                 NyaInputEvent::Blurred(text) => {
                     app.connection_state.set_group_editor_name(text.clone());
                     app.finish_connection_group_editor_from_blur(cx);
+                    app.defer_connection_panel_snapshot_flush(cx);
                 }
             });
         self.group_editor.field = Some(entity);

--- a/crates/nyaterm-desktop/src/features/pages/connections/flush.rs
+++ b/crates/nyaterm-desktop/src/features/pages/connections/flush.rs
@@ -37,9 +37,10 @@ impl NyaTermApp {
     ///
     /// Not called from any render. The panel used to re-enter the app from its own
     /// `render`, which made the root paint the reconciliation pump; this runs at
-    /// the boundaries that actually change something instead -- every panel
-    /// interaction (through `ConnectionPanel::with_app`) and every store reply
-    /// (through `submit_store_request`, after the whole handler body has run).
+    /// the boundaries that actually change something instead -- panel interactions,
+    /// connection-input subscriptions, and menu actions that open the group editor
+    /// (through their deferred boundary helpers), plus every store reply (through
+    /// `submit_store_request`, after the whole handler body has run).
     ///
     /// The derived model is reconciled first and unconditionally. It is memoised,
     /// so a no-op costs a key comparison, and it is what settles the search

--- a/crates/nyaterm-desktop/src/features/pages/connections/flush.rs
+++ b/crates/nyaterm-desktop/src/features/pages/connections/flush.rs
@@ -10,6 +10,20 @@ use crate::features::perf::record_gpui_perf_sample;
 use super::panel::{ConnectionChrome, ConnectionListKey, ConnectionListSnapshot};
 
 impl NyaTermApp {
+    /// Queue a snapshot rebuild after the current GPUI entity leases are released.
+    ///
+    /// Input subscriptions and panel listeners can both mutate connection state while
+    /// another entity is leased. Deferring the rebuild keeps those boundaries safe and
+    /// still publishes the snapshot before the next paint.
+    pub(in crate::features) fn defer_connection_panel_snapshot_flush(
+        &self,
+        cx: &mut Context<Self>,
+    ) {
+        self.defer_app_update(cx, |app, cx| {
+            app.flush_connection_panel_snapshot(cx);
+        });
+    }
+
     fn connection_chrome(&self) -> ConnectionChrome {
         let palette = self.theme_palette();
         ConnectionChrome {

--- a/crates/nyaterm-desktop/src/features/pages/connections/menus.rs
+++ b/crates/nyaterm-desktop/src/features/pages/connections/menus.rs
@@ -177,6 +177,7 @@ impl NyaTermApp {
                         window,
                         cx,
                     );
+                    this.defer_connection_panel_snapshot_flush(cx);
                 })),
         ];
         if total_in_group > 0 {
@@ -200,6 +201,7 @@ impl NyaTermApp {
                         window,
                         cx,
                     );
+                    this.defer_connection_panel_snapshot_flush(cx);
                 })),
             NyaMenuItem::action(t!("savedConnections.deleteFolder"))
                 .icon("icons/net/delete.svg")
@@ -304,6 +306,7 @@ impl NyaTermApp {
                 .icon("icons/fe/new-folder.svg")
                 .on_click(cx.listener(|this, _, window, cx| {
                     this.open_connection_group_editor(None, None, window, cx);
+                    this.defer_connection_panel_snapshot_flush(cx);
                 })),
             NyaMenuItem::separator(),
             NyaMenuItem::action(t!("settings.importConfig"))

--- a/crates/nyaterm-desktop/src/features/pages/connections/panel.rs
+++ b/crates/nyaterm-desktop/src/features/pages/connections/panel.rs
@@ -238,15 +238,14 @@ impl ConnectionPanel {
         cx.notify();
     }
 
-    /// The one hop from a panel interaction back to the owner.
+    /// The single entry point from a panel interaction back to authoritative app state.
     ///
-    /// Every callback in the list goes through here, which is what keeps the
-    /// authoritative state on `NyaTermApp` while the panel renders from a value.
-    /// Flushing on the way out means an interaction needs no boundary of its own:
-    /// the mutation and the rebuild are one transaction.
+    /// `cx.listener` still leases `ConnectionPanel` while the callback runs. Update
+    /// `NyaTermApp` first, then defer the snapshot flush until the current GPUI effect
+    /// cycle ends and the panel lease has been returned, avoiding re-entrant entity access.
     ///
-    /// The return value is carried back out because some handlers decide whether
-    /// to stop propagation from what the mutation reported.
+    /// The return value is passed back because some event handlers decide whether to
+    /// stop propagation based on the mutation result.
     pub(in crate::features::pages::connections) fn with_app<R: Default>(
         &self,
         cx: &mut Context<Self>,
@@ -257,7 +256,7 @@ impl ConnectionPanel {
         };
         app.update(cx, |app, cx| {
             let result = f(app, cx);
-            app.flush_connection_panel_snapshot(cx);
+            app.defer_connection_panel_snapshot_flush(cx);
             result
         })
     }

--- a/crates/nyaterm-desktop/src/features/pages/connections/panel.rs
+++ b/crates/nyaterm-desktop/src/features/pages/connections/panel.rs
@@ -292,6 +292,7 @@ mod tests {
         TestAppContext, VisualTestContext, div, px,
     };
     use nyaterm_core::{AppRuntime, Group, ProxyConfig, RuntimeMode, SavedConnection, uuid};
+    use nyaterm_ui::NyaInputEvent;
 
     use crate::entities::{OverlayStore, StartupRestoreStore, UiStoreHandles};
     use crate::features::NyaTermApp;
@@ -579,6 +580,81 @@ mod tests {
                 });
             });
         }
+    }
+
+    /// A listener updates the panel entity while the panel is still leased.
+    /// The interaction flush must wait until that lease is returned, otherwise GPUI's
+    /// re-entrant entity assertion is triggered.
+    #[test]
+    fn panel_interaction_flushes_after_its_lease_is_released() {
+        let mut cx = TestAppContext::single();
+        let (app, vcx) = hosted(&mut cx, vec![connection("a", "Alpha", None)], Vec::new());
+        let panel = vcx.update(|_, cx| app.read(cx).connection_panel.clone());
+
+        vcx.update(|_, cx| {
+            panel.update(cx, |panel, cx| {
+                panel.with_app(cx, |app, _| {
+                    app.connection_state
+                        .set_list_search_text("Alpha".to_string());
+                });
+                assert!(
+                    panel
+                        .snapshot()
+                        .expect("the hosted panel should have a snapshot")
+                        .search_is_empty,
+                    "the snapshot must remain unchanged until the panel lease is released"
+                );
+            });
+        });
+        vcx.run_until_parked();
+
+        vcx.update(|_, cx| {
+            let panel = app.read(cx).connection_panel.read(cx);
+            assert!(
+                !panel
+                    .snapshot()
+                    .expect("the hosted panel should have a snapshot")
+                    .search_is_empty,
+                "the deferred interaction flush must publish the changed search state"
+            );
+        });
+    }
+
+    /// A search subscription must publish the cached panel after the input event updates
+    /// the authoritative connection state.
+    #[test]
+    fn search_input_changes_reach_the_snapshot_after_the_subscription_runs() {
+        let mut cx = TestAppContext::single();
+        let (app, vcx) = hosted(&mut cx, vec![connection("a", "Alpha", None)], Vec::new());
+        let search_field = vcx.update(|_, cx| app.read(cx).connection_state.list_search_field());
+
+        vcx.update(|_, cx| {
+            search_field.update(cx, |_, cx| {
+                cx.emit(NyaInputEvent::Changed("Alpha".to_string()));
+            });
+            assert!(
+                app.read(cx)
+                    .connection_panel
+                    .read(cx)
+                    .snapshot()
+                    .expect("the hosted panel should have a snapshot")
+                    .search_is_empty,
+                "the snapshot must remain unchanged until the deferred flush runs"
+            );
+        });
+        vcx.run_until_parked();
+
+        vcx.update(|_, cx| {
+            assert!(
+                !app.read(cx)
+                    .connection_panel
+                    .read(cx)
+                    .snapshot()
+                    .expect("the hosted panel should have a snapshot")
+                    .search_is_empty,
+                "the search subscription must publish the changed search state"
+            );
+        });
     }
 
     /// Rows name their proxy in the detail tooltip, so a proxy edit has to reach

--- a/crates/nyaterm-desktop/src/features/pages/remote/panels.rs
+++ b/crates/nyaterm-desktop/src/features/pages/remote/panels.rs
@@ -181,9 +181,8 @@ pub(in crate::features) struct DockerSnapshot {
 pub(in crate::features) struct RemoteMonitorPanel {
     kind: RemoteMonitorKind,
     /// Weak on purpose. `NyaTermApp` owns this entity, so a strong handle back would
-    /// be a reference cycle that keeps both alive forever -- which is what
-    /// `ConnectionPanel` does today. The app always outlives the panels it owns, so
-    /// the upgrade below only fails during teardown.
+    /// be a reference cycle that keeps both alive forever. The app always outlives
+    /// the panels it owns, so the upgrade below only fails during teardown.
     app: WeakEntity<NyaTermApp>,
     /// The refresh schedule, and the only record of whether this panel is wanted.
     ///
@@ -193,8 +192,7 @@ pub(in crate::features) struct RemoteMonitorPanel {
     /// to remember to check, and it is why there is no separate `demand: bool`: the
     /// task's existence *is* the demand, so the two cannot disagree.
     clock: Option<Task<()>>,
-    /// What this panel renders from, for the kinds moved off the app. `None` for
-    /// Processes and Docker, which still delegate.
+    /// The snapshot this panel renders from.
     snapshot: Option<RemoteMonitorSnapshot>,
     /// Paints of *this entity*, so a test can tell the entity route apart from the
     /// inline views it replaced. Both register the same search-input ids, so no
@@ -204,10 +202,7 @@ pub(in crate::features) struct RemoteMonitorPanel {
 }
 
 impl RemoteMonitorPanel {
-    /// Which pane kinds render from a snapshot rather than through the app.
-    ///
-    /// Processes and Docker still delegate.
-    /// Every kind renders from a snapshot now; nothing delegates through the app.
+    /// Every pane kind renders from a snapshot rather than reading app state in `render`.
     pub(in crate::features::pages::remote) const SNAPSHOT_KINDS: [RemoteMonitorKind; 5] = [
         RemoteMonitorKind::Stats,
         RemoteMonitorKind::Gpu,
@@ -461,12 +456,12 @@ impl NyaTermApp {
 
     /// Push a fresh snapshot to every panel whose pane has moved on.
     ///
-    /// **Never called from `render`.** The boundaries are the three event drains, a
-    /// settings apply, `sync_remote_panels_after_activation` for a session switch, the
-    /// panel's own refresh clock, and `RemoteMonitorPanel::with_app` for anything the
-    /// panel initiates. GPUI runs `flush_effects` when the outermost `update` finishes,
-    /// so a mutation and the panel update it causes land in the same cycle, before any
-    /// paint.
+    /// **Never called from `render`.** The boundaries are the remote event drains, remote
+    /// input subscriptions, a settings apply, `sync_remote_panels_after_activation` for
+    /// a session switch, the panel's own refresh clock, and `RemoteMonitorPanel::with_app`
+    /// for anything the panel initiates. GPUI runs `flush_effects` when the outermost
+    /// `update` finishes, so a mutation and the panel update it causes land in the same
+    /// cycle, before any paint.
     ///
     /// Cheap when nothing changed: one `u64` compare per kind.
     pub(in crate::features) fn flush_remote_panel_snapshots(&mut self, cx: &mut Context<Self>) {
@@ -1106,6 +1101,7 @@ mod isolation_tests {
     };
     use nyaterm_core::{AiExecutionProfile, AppRuntime, RuntimeMode, uuid};
     use nyaterm_transport::{LocalSessionConfig, RemoteGpuOverview, RemoteStats, SshSessionConfig};
+    use nyaterm_ui::NyaInputEvent;
 
     use super::RemoteMonitorKind;
     use crate::entities::{OverlayStore, StartupRestoreStore, UiStoreHandles};
@@ -1380,6 +1376,62 @@ mod isolation_tests {
             (after[0], after[2]),
             (before[0], before[2]),
             "and the other two must not"
+        );
+    }
+
+    /// A remote search subscription must publish its panel snapshot after the input event.
+    #[test]
+    fn remote_search_input_reaches_its_snapshot_after_the_subscription_runs() {
+        let mut cx = TestAppContext::single();
+        let (app, vcx) = hosted(&mut cx);
+        vcx.update(|window, cx| {
+            app.update(cx, |app, cx| {
+                app.open_or_toggle_panel(NavItem::GpuMonitor, cx);
+                app.flush_remote_panel_snapshots(cx);
+            });
+            _ = window.draw(cx);
+        });
+        vcx.run_until_parked();
+
+        let field = vcx.update(|_, cx| {
+            app.read(cx)
+                .existing_text_input("remote.gpu.filter")
+                .expect("the GPU panel should own its search field")
+        });
+        let before = vcx.update(|_, cx| {
+            app.read(cx)
+                .remote_panels
+                .entity(RemoteMonitorKind::Gpu)
+                .read(cx)
+                .snapshot_revision()
+        });
+
+        vcx.update(|_, cx| {
+            field.update(cx, |_, cx| {
+                cx.emit(NyaInputEvent::Changed("py".to_string()));
+            });
+            assert_eq!(
+                app.read(cx)
+                    .remote_panels
+                    .entity(RemoteMonitorKind::Gpu)
+                    .read(cx)
+                    .snapshot_revision(),
+                before,
+                "the snapshot must remain unchanged until the deferred flush runs"
+            );
+        });
+        vcx.run_until_parked();
+
+        let after = vcx.update(|_, cx| {
+            app.read(cx)
+                .remote_panels
+                .entity(RemoteMonitorKind::Gpu)
+                .read(cx)
+                .snapshot_revision()
+        });
+        assert!(
+            after > before,
+            "the remote search subscription must publish its changed state"
         );
     }
 

--- a/crates/nyaterm-desktop/src/features/pages/remote/panels.rs
+++ b/crates/nyaterm-desktop/src/features/pages/remote/panels.rs
@@ -216,11 +216,12 @@ impl RemoteMonitorPanel {
         RemoteMonitorKind::Docker,
     ];
 
-    /// Run `f` against the app, then flush whatever snapshot it invalidated.
+    /// Run `f` against the app and queue the snapshot flush after the panel lease ends.
     ///
     /// Every panel-initiated mutation goes through here, which makes the panel its own
-    /// flush boundary: no callback has to remember a separate step. Called from event
-    /// handlers, never from render.
+    /// flush boundary: no callback has to remember a separate step. Event handlers lease
+    /// this panel while they run, so the flush is deferred until that lease is released.
+    /// This method is called from event handlers, never from render.
     pub(in crate::features::pages::remote) fn with_app<R: Default>(
         &self,
         cx: &mut Context<Self>,
@@ -231,7 +232,7 @@ impl RemoteMonitorPanel {
         };
         app.update(cx, |app, cx| {
             let result = f(app, cx);
-            app.flush_remote_panel_snapshots(cx);
+            app.defer_remote_panel_snapshot_flush(cx);
             result
         })
     }
@@ -451,6 +452,13 @@ impl RemotePanels {
 }
 
 impl NyaTermApp {
+    /// Queue a remote-panel snapshot rebuild after the current GPUI entity leases end.
+    pub(in crate::features) fn defer_remote_panel_snapshot_flush(&self, cx: &mut Context<Self>) {
+        self.defer_app_update(cx, |app, cx| {
+            app.flush_remote_panel_snapshots(cx);
+        });
+    }
+
     /// Push a fresh snapshot to every panel whose pane has moved on.
     ///
     /// **Never called from `render`.** The boundaries are the three event drains, a
@@ -1265,6 +1273,41 @@ mod isolation_tests {
             delivered,
             Some(revision),
             "the snapshot must be current before any paint"
+        );
+    }
+
+    /// A panel interaction must not flush while its own entity is leased by GPUI.
+    #[test]
+    fn a_panel_interaction_flushes_after_its_lease_is_released() {
+        let mut cx = TestAppContext::single();
+        let (app, vcx) = hosted(&mut cx);
+        let panel = vcx.update(|_, cx| {
+            app.read(cx)
+                .remote_panels
+                .entity(RemoteMonitorKind::Stats)
+                .clone()
+        });
+        let before = vcx.update(|_, cx| panel.read(cx).snapshot_revision());
+
+        vcx.update(|_, cx| {
+            panel.update(cx, |panel, cx| {
+                panel.with_app(cx, |app, _| {
+                    app.remote_ops.apply_stats(RemoteStats::default());
+                    app.remote_ops.set_stats_status("loaded stats");
+                });
+                assert_eq!(
+                    panel.snapshot_revision(),
+                    before,
+                    "the snapshot must remain unchanged until the panel lease is released"
+                );
+            });
+        });
+        vcx.run_until_parked();
+
+        let after = vcx.update(|_, cx| panel.read(cx).snapshot_revision());
+        assert!(
+            after > before,
+            "the deferred interaction flush must publish the changed stats state"
         );
     }
 

--- a/crates/nyaterm-desktop/src/features/remote/remote_runtime/docker.rs
+++ b/crates/nyaterm-desktop/src/features/remote/remote_runtime/docker.rs
@@ -577,6 +577,9 @@ impl NyaTermApp {
                         if this.apply_docker_event(event) {
                             cx.notify();
                         }
+                        // Flush boundary: a reply changed the pane, so its panel
+                        // gets the snapshot before the next paint.
+                        this.flush_remote_panel_snapshots(cx);
                     })
                     .is_err()
                 {

--- a/crates/nyaterm-desktop/src/features/remote/remote_runtime/panel_layout.rs
+++ b/crates/nyaterm-desktop/src/features/remote/remote_runtime/panel_layout.rs
@@ -28,14 +28,15 @@ impl NyaTermApp {
     /// active session, not a general activation side-effect bucket. Today that is refresh
     /// demand: a panel's clock is armed on `(visible || the header wants it) && enabled in
     /// settings && a session with an SSH config`, and the last term just changed --
-    /// switching to a non-SSH session has to drop the clocks. The snapshot flush will join
-    /// this helper, which is what keeps a future activation caller from switching sessions
-    /// while omitting either.
+    /// switching to a non-SSH session has to drop the clocks. The snapshot flush joins
+    /// this helper, which keeps every activation caller from switching sessions while
+    /// omitting either.
     pub(in crate::features) fn sync_remote_panels_after_activation(
         &mut self,
         cx: &mut Context<Self>,
     ) {
         self.sync_remote_panel_demand(cx);
+        self.defer_remote_panel_snapshot_flush(cx);
     }
 
     /// Tell the process pane which sort columns the current panel width can show.

--- a/crates/nyaterm-desktop/src/features/remote/remote_runtime/process.rs
+++ b/crates/nyaterm-desktop/src/features/remote/remote_runtime/process.rs
@@ -306,6 +306,9 @@ impl NyaTermApp {
                         if this.apply_process_event(event) {
                             cx.notify();
                         }
+                        // Flush boundary: a reply changed the pane, so its panel
+                        // gets the snapshot before the next paint.
+                        this.flush_remote_panel_snapshots(cx);
                     })
                     .is_err()
                 {

--- a/crates/nyaterm-desktop/src/features/remote/state.rs
+++ b/crates/nyaterm-desktop/src/features/remote/state.rs
@@ -701,7 +701,10 @@ impl RemoteOpsFeatureState {
     }
 
     pub(in crate::features) fn docker_menus_open(&self) -> bool {
-        self.docker.tab_menu_open || self.docker.header_menu_open
+        self.docker.tab_menu_open
+            || self.docker.header_menu_open
+            || self.docker.container_menu_id.is_some()
+            || self.docker.compose_menu_id.is_some()
     }
 
     pub(in crate::features) fn toggle_docker_container_menu(&mut self, id: String) {
@@ -2315,6 +2318,7 @@ mod tests {
         state.toggle_docker_compose_menu("compose".to_string());
         let presentation = state.docker_presentation();
         assert!(!state.docker_header_menu_open());
+        assert!(state.docker_menus_open());
         assert!(presentation.container_menu_id.is_none());
         assert_eq!(presentation.compose_menu_id.as_deref(), Some("compose"));
 

--- a/crates/nyaterm-desktop/src/features/root.rs
+++ b/crates/nyaterm-desktop/src/features/root.rs
@@ -159,10 +159,13 @@ impl NyaTermApp {
                 MouseButton::Left,
                 cx.listener(|this, _, _, cx| {
                     this.dismiss_transfer_rename_if_open(cx);
-                    let changed =
-                        this.shell.close_root_menus() || this.remote_ops.docker_menus_open();
+                    let remote_menus_open = this.remote_ops.docker_menus_open();
+                    let changed = this.shell.close_root_menus() || remote_menus_open;
                     if changed {
                         this.remote_ops.close_docker_menus();
+                        if remote_menus_open {
+                            this.defer_remote_panel_snapshot_flush(cx);
+                        }
                         cx.notify();
                     }
                 }),

--- a/crates/nyaterm-desktop/src/features/root.rs
+++ b/crates/nyaterm-desktop/src/features/root.rs
@@ -39,6 +39,24 @@ struct OverlayFlags {
 }
 
 impl NyaTermApp {
+    /// Run an app update after the current GPUI entity leases are released.
+    ///
+    /// The weak handle lets the deferred work disappear normally during application
+    /// teardown instead of keeping the root entity alive until the callback runs.
+    pub(in crate::features) fn defer_app_update(
+        &self,
+        cx: &mut Context<Self>,
+        update: impl FnOnce(&mut Self, &mut Context<Self>) + 'static,
+    ) {
+        let app = cx.entity().downgrade();
+        cx.defer(move |cx| {
+            let Some(app) = app.upgrade() else {
+                return;
+            };
+            app.update(cx, update);
+        });
+    }
+
     pub(in crate::features) fn gpui_perf_context(
         &self,
         flat_row_count: usize,

--- a/crates/nyaterm-desktop/src/features/shell/panel_stack_runtime.rs
+++ b/crates/nyaterm-desktop/src/features/shell/panel_stack_runtime.rs
@@ -826,6 +826,7 @@ impl NyaTermApp {
                         can_refresh,
                         cx.listener(|this, _, _window, cx| {
                             this.refresh_stats(cx);
+                            this.defer_remote_panel_snapshot_flush(cx);
                         }),
                     )
                     .into_any_element(),
@@ -844,6 +845,7 @@ impl NyaTermApp {
                         can_refresh,
                         cx.listener(|this, _, _window, cx| {
                             this.refresh_gpu(cx);
+                            this.defer_remote_panel_snapshot_flush(cx);
                         }),
                     )
                     .into_any_element(),
@@ -862,6 +864,7 @@ impl NyaTermApp {
                         can_refresh,
                         cx.listener(|this, _, _window, cx| {
                             this.refresh_npu(cx);
+                            this.defer_remote_panel_snapshot_flush(cx);
                         }),
                     )
                     .into_any_element(),
@@ -880,6 +883,7 @@ impl NyaTermApp {
                         can_refresh,
                         cx.listener(|this, _, _window, cx| {
                             this.refresh_processes(cx);
+                            this.defer_remote_panel_snapshot_flush(cx);
                         }),
                     )
                     .into_any_element(),
@@ -905,6 +909,7 @@ impl NyaTermApp {
                             can_refresh,
                             cx.listener(|this, _, _window, cx| {
                                 this.refresh_docker(cx);
+                                this.defer_remote_panel_snapshot_flush(cx);
                             }),
                         ))
                         .child(
@@ -919,6 +924,7 @@ impl NyaTermApp {
                                     can_prune,
                                     cx.listener(|this, _, _, cx| {
                                         this.remote_ops.toggle_docker_header_menu();
+                                        this.defer_remote_panel_snapshot_flush(cx);
                                         cx.notify();
                                     }),
                                 ))
@@ -960,6 +966,9 @@ impl NyaTermApp {
                                                         |this, _, window, cx| {
                                                             this.remote_ops.close_docker_menus();
                                                             this.prune_docker_system(window, cx);
+                                                            this.defer_remote_panel_snapshot_flush(
+                                                                cx,
+                                                            );
                                                         },
                                                     )),
                                             ),

--- a/crates/nyaterm-desktop/src/features/text_inputs.rs
+++ b/crates/nyaterm-desktop/src/features/text_inputs.rs
@@ -334,6 +334,9 @@ impl NyaTermApp {
     /// ignored rather than panicking — a field can outlive one frame of the
     /// panel that made it.
     fn on_text_input_changed(&mut self, id: SharedString, text: String, cx: &mut Context<Self>) {
+        // Remote panels render cached snapshots, so their input subscriptions need the
+        // same deferred flush boundary as panel event handlers.
+        let remote_panel_input = id.starts_with("remote.");
         if let Some(rest) = id.strip_prefix("settings.number.") {
             self.apply_settings_number_input(rest, &text, cx);
         } else if let Some(rest) = id.strip_prefix("ai.number.") {
@@ -494,6 +497,9 @@ impl NyaTermApp {
             self.apply_transfer_default_editor(text, cx);
         } else if id.as_ref() == "settings.transfer.default-permissions" {
             self.apply_transfer_file_permissions(text, cx);
+        }
+        if remote_panel_input {
+            self.defer_remote_panel_snapshot_flush(cx);
         }
     }
 


### PR DESCRIPTION
## Summary

修复 macOS 启动期间连接面板触发的 GPUI Entity 重入更新崩溃，并补齐连接面板与远程监控面板的快照刷新边界，避免界面继续显示过期状态。

## Why

macOS 上出现了以下 panic：

```text
cannot read nyaterm_desktop::features::pages::connections::panel::ConnectionPanel while it is already being updated
```

面板事件回调通过 `cx.listener` 持有当前面板 Entity 的更新租约；回调内部同步刷新面板快照时，会再次访问同一个 Entity，触发 GPUI 的重入保护。随后 panic 从 Cocoa 回调边界无法展开，进程直接中止。

Windows 当前未复现，但这是 GPUI Entity 生命周期约束问题，不是 macOS 专属逻辑。远程监控面板使用了相同的同步刷新模式，因此一并消除同类隐患。

## What changed

- 将连接面板和远程监控面板的快照刷新改为延迟到当前 Entity 租约释放之后执行。
- 增加统一的应用级 deferred update 辅助方法，保持快照实体与 `NyaTermApp` 单一权威状态模型。
- 补齐连接面板刷新边界：
  - 搜索输入订阅；
  - 分组新建、重命名等菜单操作；
  - 面板交互回调。
- 补齐远程监控面板刷新边界：
  - 进程与 Docker 事件处理；
  - 面板激活；
  - 搜索输入；
  - 统计、GPU、NPU、进程和 Docker 标题栏操作；
  - Docker 菜单切换、清理操作；
  - 根布局点击关闭菜单；
  - 远程输入路由。
- 修正 Docker 菜单状态判断，使标题栏、容器和 Compose 菜单都能正确参与关闭逻辑。
- 增加 Entity 重入和搜索快照新鲜度回归测试。

## Validation

- `cargo test -p nyaterm-desktop --profile debugging`
  - 1060 passed
  - 0 failed
  - 4 ignored
- `cargo check -p nyaterm-desktop`
- `cargo clippy -p nyaterm-desktop --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Compatibility and risk

- 不涉及持久化格式、数据库 schema、网络协议或第三方依赖。
- 不改变面板的权威状态归属，只调整快照发布时机。
- 延迟刷新仅跨过当前 GPUI effect cycle，用户可见状态仍会在同一轮交互完成后更新。
- 已经 macOS 上手动启动并验证连接面板、远程监控面板及相关菜单交互。