### PR TITLE
fix(ai): 修复 IME 输入法合成状态下回车误触发提交的问题

### DIFF
--- a/src/components/panel/ai/AIAssistantPanel.tsx
+++ b/src/components/panel/ai/AIAssistantPanel.tsx
@@ -172,6 +172,7 @@ function AIAssistantPanel({ activePane, activeConnection, intent }: AIAssistantP
   const historyCardRef = useRef<HTMLDivElement | null>(null);
   const mentionPopoverRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const isComposingRef = useRef(false);
   const streamUnlistenersRef = useRef<Map<string, UnlistenFn>>(new Map());
   const streamSessionByStreamIdRef = useRef<Map<string, string>>(new Map());
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -1911,7 +1912,14 @@ function AIAssistantPanel({ activePane, activeConnection, intent }: AIAssistantP
               placeholder={aiSettings.enabled ? t("ai.placeholder") : t("ai.goToSettingsToEnable")}
               className="max-h-32 min-h-16 resize-none overflow-y-auto text-xs terminal-scroll"
               onChange={handleInputChange}
+              onCompositionStart={() => {
+                isComposingRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                isComposingRef.current = false;
+              }}
               onKeyDown={(event) => {
+                const isComposing = isComposingRef.current || event.nativeEvent.isComposing || event.keyCode === 229;
                 if (showMentionPopover) {
                   if (event.key === "Escape") {
                     event.preventDefault();
@@ -1934,7 +1942,7 @@ function AIAssistantPanel({ activePane, activeConnection, intent }: AIAssistantP
                     );
                     return;
                   }
-                  if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+                  if (event.key === "Enter" && !isComposing) {
                     event.preventDefault();
                     const target = filteredMentionPanes[mentionIndex];
                     if (target) selectMentionPane(target);
@@ -1942,7 +1950,7 @@ function AIAssistantPanel({ activePane, activeConnection, intent }: AIAssistantP
                     return;
                   }
                 }
-                if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+                if (event.key === "Enter" && !event.shiftKey && !isComposing) {
                   event.preventDefault();
                   submit();
                 }


### PR DESCRIPTION
## 问题

在中文、日文、韩文等 IME 输入法场景下，用户在 AI 提示词输入框中输入拼音并按 Enter 确认候选词时，会误触发消息发送，导致输入被打断。

Fixes [#496](https://github.com/nyakang/nyaterm/issues/496)

## 根本原因

浏览器中 `compositionend` 与 `keydown(Enter)` 的触发顺序在不同浏览器中不一致。在 Chrome 中，`compositionend` 先于 `keydown` 触发，导致 `keydown` 处理时 `event.isComposing` 已经是 `false`，无法区分"确认候选词的回车"和"真正的提交回车"。

## 修复方案

在 [AIAssistantPanel.tsx](nyaterm/src/components/panel/ai/AIAssistantPanel.tsx:0:0-0:0) 的输入框中：

1. 新增 `isComposingRef` 手动跟踪 IME 合成状态，通过 `onCompositionStart` / `onCompositionEnd` 事件维护。
2. 在 `keydown` 处理中使用三重合成态检测：
   ```ts
   const isComposing = isComposingRef.current || event.nativeEvent.isComposing || event.keyCode === 229;
```
兼容所有浏览器及旧内核环境。 
3. 合成态下按 Enter 直接放行，不触发提交也不执行 preventDefault()，保证输入法选词正常上屏。 
4. 非合成态下按 Enter 正常提交，Shift+Enter 保留换行。