### PR TITLE
docs(development): 修正 i18n 文档中过时的 locale 列表

### DIFF
--- a/docs-site/docs/development/contributing.md
+++ b/docs-site/docs/development/contributing.md
@@ -72,7 +72,9 @@ docs: update installation guide
 添加或修改 UI 文本时，请同时更新：
 
 - `src/i18n/locales/zh-CN.json` — 简体中文
+- `src/i18n/locales/zh-TW.json` — 繁體中文
 - `src/i18n/locales/en.json` — English
+- `src/i18n/locales/ko.json` — 한국어
 
 ## 许可证
 

--- a/docs-site/docs/development/frontend.md
+++ b/docs-site/docs/development/frontend.md
@@ -172,9 +172,11 @@ const sessionId = await invoke<string>('create_ssh_session', {
 界面文案使用 `react-i18next`，语言包位于：
 
 - `src/i18n/locales/zh-CN.json`
+- `src/i18n/locales/zh-TW.json`
 - `src/i18n/locales/en.json`
+- `src/i18n/locales/ko.json`
 
-新增或修改用户可见文本时，应同时更新两个 locale 文件。
+新增或修改用户可见文本时，应同时更新所有 locale 文件；提交前运行 `pnpm i18n:check` 校验 JSON 格式。
 
 ## UI 组件约定
 

--- a/docs-site/i18n/en/docusaurus-plugin-content-docs/current/development/contributing.md
+++ b/docs-site/i18n/en/docusaurus-plugin-content-docs/current/development/contributing.md
@@ -67,10 +67,12 @@ docs: update installation guide
 
 ## Internationalization
 
-When adding or modifying UI text, update both:
+When adding or modifying UI text, update all:
 
-- `src/i18n/locales/zh-CN.json`
-- `src/i18n/locales/en.json`
+- `src/i18n/locales/zh-CN.json` — Simplified Chinese
+- `src/i18n/locales/zh-TW.json` — Traditional Chinese
+- `src/i18n/locales/en.json` — English
+- `src/i18n/locales/ko.json` — Korean
 
 ## License
 

--- a/docs-site/i18n/en/docusaurus-plugin-content-docs/current/development/frontend.md
+++ b/docs-site/i18n/en/docusaurus-plugin-content-docs/current/development/frontend.md
@@ -158,9 +158,11 @@ Together these files define the full user flow through settings state, Tauri com
 User-facing UI text uses `react-i18next`. Locale files are in:
 
 - `src/i18n/locales/zh-CN.json`
+- `src/i18n/locales/zh-TW.json`
 - `src/i18n/locales/en.json`
+- `src/i18n/locales/ko.json`
 
-Whenever you add or change visible UI text, update both locale files.
+When adding or modifying user-visible text, update all locale files, and run `pnpm i18n:check` before committing to validate the JSON format.
 
 ## UI component conventions
 


### PR DESCRIPTION
## 概述

`docs-site` 的 `frontend.md` 与 `contributing.md` 中「国际化」小节写的是两个 locale 文件，但仓库实际有四个 locale（`en` / `zh-CN` / `zh-TW` / `ko`），且 CLAUDE.md 要求四者同步。本 PR 修正文档，并同步更新英文版（Docusaurus i18n 翻译）。

## 改动

- `docs-site/docs/development/frontend.md`
  - 列出全部四个 locale 文件
  - 「同时更新两个 locale 文件」→「同时更新所有 locale 文件」，并补充 `pnpm i18n:check` 校验说明
- `docs-site/docs/development/contributing.md`
  - 补齐 `zh-TW.json` / `ko.json` 及各自语言说明
- `docs-site/i18n/en/docusaurus-plugin-content-docs/current/development/frontend.md`
  - 对应英文版同步修改
- `docs-site/i18n/en/docusaurus-plugin-content-docs/current/development/contributing.md`
  - 对应英文版同步修改

## 检查

- [x] 仅文档改动，无代码/语言包 JSON 变更