### PR TITLE
fix(ui): preserve serial send panel input across hide/show

### DIFF
--- a/src/components/app/AppLayout.tsx
+++ b/src/components/app/AppLayout.tsx
@@ -4,6 +4,7 @@ import {
   type ReactNode,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import FloatingPanel from "@/components/app/FloatingPanel";
@@ -195,6 +196,9 @@ export default function AppLayout({
   const backgroundImagePath = appearance.background_image_path?.trim() ?? "";
   const [backgroundDataUrl, setBackgroundDataUrl] = useState("");
   const [serialSendRunning, setSerialSendRunning] = useState(false);
+  // Latch the first time the serial send panel is shown so it stays mounted
+  // (but hidden) afterwards, preserving the user's input across hide/show cycles.
+  const serialSendEverShownRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -258,7 +262,11 @@ export default function AppLayout({
   const leftMobileOpen = hasLeftActivityItems && mobile.leftOpen;
   const rightMobileOpen = hasRightActivityItems && mobile.rightOpen;
   const serialSendVisible = bottomPanel.activePanel === "serialSend";
-  const serialSendMounted = serialSendVisible || serialSendRunning;
+  if (serialSendVisible) {
+    serialSendEverShownRef.current = true;
+  }
+  const serialSendMounted =
+    serialSendVisible || serialSendRunning || serialSendEverShownRef.current;
 
   useEffect(() => {
     const roots = [document.documentElement, document.body];


### PR DESCRIPTION
## Summary

Fixes #515

命令发送面板隐藏后再开启，原先输入的文本丢失。

## Root cause

`src/components/app/AppLayout.tsx` 中命令发送面板的挂载条件为：

```js
const serialSendMounted = serialSendVisible || serialSendRunning;
```

隐藏面板时（且没有正在进行的发送），`serialSendMounted` 变为 `false`，`<SerialSendPanel>` 组件被卸载。由于所有输入状态（`commandText`、`hexText`、`dataType`、`sendMode`、`count`、`intervalInput`、`target`、`lineEnding`）都保存在组件内部的 `useState` 中，卸载即全部丢失，再次打开时是全新的空状态。

## Fix

采用本仓库 `src/components/app/PanelStack.tsx` 已有的 "once shown, stay mounted but hidden" 模式（`overlayEverShownRef` 闭锁）：引入 `serialSendEverShownRef`，面板首次显示后保持挂载（隐藏时 `display:none` 且不占高度），从而保留用户输入。

隐藏态的 `<div>` wrapper 本身已支持该模式（此前用于"发送进行中隐藏"的场景），因此无需任何布局改动。

## Verification

- 复现路径：打开 → 输入文本 → 隐藏 → 再次打开，文本保留 ✓
- `pnpm lint` 通过（仅有一条与本次改动无关的既有 info）
- `tsc --noEmit` 通过，无错误
- `draft` 流程（命令历史 → 发送到命令面板）不受影响：面板已挂载时 draft 仍正常应用，且 `show_serial_send_panel` 会被置为 `true` 使面板可见

## Changes

- `src/components/app/AppLayout.tsx`：3 处小改动（引入 `useRef`、新增 `serialSendEverShownRef` 闭锁、扩展 `serialSendMounted` 条件），共 +9/-1 行。