### PR TITLE
  fix(editor): 内置文件编辑器选区复用终端选区颜色

### DIFF
--- a/src/context/ThemeContext.test.tsx
+++ b/src/context/ThemeContext.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import type { ThemeColors } from "@/lib/themes";
+import { applyTerminalThemeToDOM } from "./ThemeContext";
+
+describe("applyTerminalThemeToDOM", () => {
+  it("publishes the terminal selection color for shared editor surfaces", () => {
+    const selectionBackground = "#264f78";
+
+    applyTerminalThemeToDOM({
+      selectionBackground,
+    } as ThemeColors["terminal"]);
+
+    expect(document.documentElement.style.getPropertyValue("--df-terminal-selection")).toBe(
+      selectionBackground,
+    );
+  });
+});

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -68,6 +68,7 @@ export function applyTerminalThemeToDOM(colors: ThemeColors["terminal"]) {
   const root = document.documentElement.style;
   root.setProperty("--df-terminal-bg", colors.background);
   root.setProperty("--df-terminal-fg", colors.foreground);
+  root.setProperty("--df-terminal-selection", colors.selectionBackground);
 }
 
 /** Provides theme, themeName, setTheme. Syncs with appSettings.appearance.theme from backend. */

--- a/src/lib/codeMirrorFileView.test.ts
+++ b/src/lib/codeMirrorFileView.test.ts
@@ -1,0 +1,74 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { describe, expect, it } from "vitest";
+import { codeMirrorFileViewExtensions } from "./codeMirrorFileView";
+
+function findRules(fragment: string): string[] {
+  const rules: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    const owner = sheet.ownerNode as HTMLStyleElement | null;
+    // jsdom's cssText drops !important inside var() values, so read the raw
+    // rule text from the mounted style tag instead.
+    const text = owner?.textContent ?? "";
+    for (const line of text.split("\n")) {
+      if (line.includes(fragment)) {
+        rules.push(line);
+      }
+    }
+  }
+  return rules;
+}
+
+function mountEditor(): HTMLDivElement {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  new EditorView({
+    state: EditorState.create({
+      doc: "hello",
+      extensions: codeMirrorFileViewExtensions("plaintext"),
+    }),
+    parent: host,
+  });
+  return host;
+}
+
+describe("codeMirrorFileView selection styling", () => {
+  it("renders the editor selection with the terminal selection color", () => {
+    const host = mountEditor();
+
+    try {
+      const rules = findRules("cm-selectionBackground").join("\n");
+      expect(rules).toContain("var(--df-terminal-selection");
+      expect(rules).toContain("!important");
+    } finally {
+      host.remove();
+    }
+  });
+
+  it("keeps the active line highlight below the selection layer", () => {
+    const host = mountEditor();
+
+    try {
+      // CodeMirror draws its selection layer below in-flow line backgrounds,
+      // so the highlight must live on a ::before with z-index under the
+      // selection layer (-2), not on the line element itself.
+      const activeLineRules = findRules("cm-activeLine").filter(
+        (rule) => !rule.includes("cm-activeLineGutter"),
+      );
+      const beforeRule = activeLineRules.find((rule) => rule.includes(":before"));
+
+      expect(beforeRule).toBeDefined();
+      expect(beforeRule).toContain("z-index: -3");
+      expect(beforeRule).toContain("color-mix(in srgb, var(--muted) 22%, transparent)");
+
+      const lineRules = activeLineRules.filter((rule) => !rule.includes(":before"));
+      // The CodeMirror base theme also styles .cm-activeLine (#cceeff44);
+      // our theme's rule is the one that clears the element background.
+      const ownLineRule = lineRules.find((rule) => rule.includes("background-color: transparent"));
+      expect(ownLineRule).toBeDefined();
+      expect(ownLineRule).toContain("position: relative");
+    } finally {
+      host.remove();
+    }
+  });
+});

--- a/src/lib/codeMirrorFileView.ts
+++ b/src/lib/codeMirrorFileView.ts
@@ -294,7 +294,7 @@ export function codeMirrorFileViewExtensions(
         borderLeftColor: "var(--foreground)",
       },
       ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
-        backgroundColor: "color-mix(in srgb, var(--primary) 28%, transparent)",
+        backgroundColor: "var(--df-terminal-selection, var(--df-primary)) !important",
       },
       ".cm-scroller": {
         fontFamily: "var(--font-mono), 'JetBrains Mono', monospace",
@@ -318,7 +318,15 @@ export function codeMirrorFileViewExtensions(
         opacity: "0.8",
       },
       ".cm-activeLine": {
-        backgroundColor: "color-mix(in srgb, var(--muted) 22%, transparent)",
+        "&::before": {
+          content: '""',
+          position: "absolute",
+          inset: "0",
+          zIndex: "-3",
+          backgroundColor: "color-mix(in srgb, var(--muted) 22%, transparent)",
+        },
+        position: "relative",
+        backgroundColor: "transparent",
       },
       ".cm-activeLineGutter": {
         backgroundColor: "color-mix(in srgb, var(--muted) 32%, transparent)",


### PR DESCRIPTION
 ## 问题

内置文件编辑器中，选中文本时选区呈浅白色，遮挡文件内容，影响阅读；
    而终端的选区样式正常，两者不一致。

## 根因

1. CodeMirror 6 默认的聚焦选区规则（`#d7d4f0`，高特异性）覆盖了编辑器主题
       设置的选区背景色。
2. 活动行高亮（`.cm-activeLine`）绘制在选区图层之上，会冲淡光标所在行的
       选区颜色——向上选择时光标位于顶部行，因此顶部行颜色明显变浅；
       向下选择时光标在底部，顶部行不受影响，看起来正常。

## 修复

- 将终端主题的 `selectionBackground` 发布为 CSS 变量
      `--df-terminal-selection`，并用于 `.cm-selectionBackground`
      （带 `!important`），使编辑器选区与终端选区颜色完全一致。
- 将 `.cm-activeLine` 高亮移至 `::before` 伪元素并将 z-index 降为 -3
      （低于选区图层的 -2），同时清除元素自身背景，使活动行高亮不再冲淡选区。
      层次变为：活动行高亮(-3) < 选区(-2) < 文本。

## 测试

- 新增 3 个回归测试（CSS 变量发布、选区/活动行编译规则）
- 全量测试 399/399 通过；biome、tsc、vite build 均通过
