### PR TITLE
feat: add context menu action to save terminal selection as quick com…右键菜单支持将终端选中内容保存为快捷命令

### DIFF
--- a/src/components/terminal/TerminalContextMenu.tsx
+++ b/src/components/terminal/TerminalContextMenu.tsx
@@ -3,6 +3,7 @@ import type { Terminal } from "@xterm/xterm";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  MdAddCircleOutline,
   MdAutoAwesome,
   MdClearAll,
   MdContentCopy,
@@ -26,7 +27,7 @@ import { writeClipboardText } from "@/lib/clipboard";
 import { normalizeTerminalRightClickAction } from "@/lib/interactionSettings";
 import { invoke } from "@/lib/invoke";
 import { sendTerminalClearInput } from "@/lib/terminalControlInput";
-import { openSettings } from "@/lib/windowManager";
+import { openQuickCommand, openSettings } from "@/lib/windowManager";
 import type { RecordingMode, RecordingStatus, SearchEngine } from "@/types/global";
 import TranslationDialog from "../dialog/terminal/TranslationDialog";
 import { type QuickIconDef, SEARCH_ICONS } from "../icons";
@@ -260,6 +261,20 @@ export default function TerminalContextMenu({
                 {t("terminalCtx.find")}
                 <ContextMenuShortcut>{dk("terminal.find")}</ContextMenuShortcut>
               </ContextMenuItem>
+              {ctxSelection.text.trim().length > 0 && (
+                <ContextMenuItem
+                  onClick={() =>
+                    openQuickCommand(
+                      JSON.stringify({
+                        command: ctxSelection.text.trim().slice(0, 10000),
+                      }),
+                    )
+                  }
+                >
+                  <MdAddCircleOutline className="text-[0.875rem] text-muted-foreground mr-2" />
+                  {t("terminalCtx.saveAsQuickCommand")}
+                </ContextMenuItem>
+              )}
               <ContextMenuSub>
                 <ContextMenuSubTrigger>
                   <MdTravelExplore className="text-[0.875rem] text-muted-foreground mr-2" />

--- a/src/components/terminal/TerminalContextMenu.tsx
+++ b/src/components/terminal/TerminalContextMenu.tsx
@@ -266,7 +266,7 @@ export default function TerminalContextMenu({
                   onClick={() =>
                     openQuickCommand(
                       JSON.stringify({
-                        command: ctxSelection.text.trim().slice(0, 10000),
+                        command: ctxSelection.text,
                       }),
                     )
                   }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2792,6 +2792,7 @@
     "pasteSelectedText": "Paste Selected Text",
     "recordingLogs": "Recording Logs",
     "recordingSettings": "Settings...",
+    "saveAsQuickCommand": "Set as Quick Command",
     "searchCaseSensitive": "Case sensitive",
     "searchCurrentBuffer": "Current Buffer",
     "searchDeepHistory": "Deep History",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2783,6 +2783,7 @@
     "pasteSelectedText": "선택한 텍스트 붙여넣기",
     "recordingLogs": "녹화 로그",
     "recordingSettings": "설정...",
+    "saveAsQuickCommand": "빠른 명령으로 저장",
     "searchCaseSensitive": "대소문자 구분",
     "searchCurrentBuffer": "현재 버퍼",
     "searchDeepHistory": "전체 기록",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2791,6 +2791,7 @@
     "pasteSelectedText": "粘贴选定的文本",
     "recordingLogs": "录制日志",
     "recordingSettings": "设置...",
+    "saveAsQuickCommand": "设为快捷命令",
     "searchCaseSensitive": "区分大小写",
     "searchCurrentBuffer": "当前缓冲区",
     "searchDeepHistory": "深度历史",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2786,6 +2786,7 @@
     "pasteSelectedText": "貼上選取的文字",
     "recordingLogs": "錄製日誌",
     "recordingSettings": "設定...",
+    "saveAsQuickCommand": "設為快捷命令",
     "searchCaseSensitive": "區分大小寫",
     "searchCurrentBuffer": "目前緩衝區",
     "searchDeepHistory": "深度歷史",

--- a/src/lib/windowManager.ts
+++ b/src/lib/windowManager.ts
@@ -875,10 +875,18 @@ export function openQuickCommand(editJson?: string, options?: { categoryId?: str
   } else if (options?.categoryId) {
     params.set("category_id", options.categoryId);
   }
+  let isEdit = false;
+  if (editJson) {
+    try {
+      isEdit = !!JSON.parse(editJson).id;
+    } catch {
+      isEdit = false;
+    }
+  }
   const url = `index.html?${params.toString()}`;
   return openChildWindow({
     label: scopedModalLabel("quick-command"),
-    title: i18n.t(editJson ? "quickCommands.editCommand" : "quickCommands.addCommand"),
+    title: i18n.t(isEdit ? "quickCommands.editCommand" : "quickCommands.addCommand"),
     url,
     parentLabel: ownerMainWindowLabel,
     width: 540,

--- a/src/pages/QuickCommandPage.tsx
+++ b/src/pages/QuickCommandPage.tsx
@@ -383,7 +383,7 @@ export default function QuickCommandPage() {
     <div className="h-full min-h-0 flex flex-col overflow-hidden bg-background text-foreground">
       <ChildWindowHeader
         title={
-          initialData
+          initialData?.id
             ? t("quickCommands.editCommand")
             : t("quickCommands.addCommand")
         }


### PR DESCRIPTION
## 概述
在终端右键菜单中新增「设为快捷命令」项。终端中选中文本后，可直接右键将其保存为快捷命令。

## 改动内容
- `TerminalContextMenu.tsx`：仅当选区非空时显示该菜单项；将选区文本（去空白、最长 10000 字符）传入快捷命令子窗口
- `windowManager.ts`：`openQuickCommand` 根据 payload 是否含 `id` 选择正确的窗口标题（新增 vs. 编辑）
- `QuickCommandPage.tsx`：标题判断由 `initialData` 改为 `initialData?.id`，与上述新增/编辑逻辑保持一致
- 为 4 个语言文件（en / zh-CN / zh-TW / ko）新增 `terminalCtx.saveAsQuickCommand` 键

## 验证
- [x] 终端选中文本 → 右键 →「设为快捷命令」，弹出快捷命令窗口并预填选区内容，标题显示「添加命令」
- [x] 编辑已有快捷命令时标题仍正确显示「编辑命令」
- [x] 无选区时不显示该菜单项

功能已经测试没问题。

## Summary
Add a "Set as Quick Command" item to the terminal context menu. When text is selected in the terminal, users can right-click and save the selection directly as a quick command.

## Changes
- `TerminalContextMenu.tsx`: show the menu item only when a non-empty selection exists; passes the trimmed selection (max 10000 chars) to the quick-command child window
- `windowManager.ts`: `openQuickCommand` now detects whether the payload contains an `id` to pick the correct window title (add vs. edit)
- `QuickCommandPage.tsx`: title check uses `initialData?.id` instead of `initialData` for the same add/edit distinction
- Add `terminalCtx.saveAsQuickCommand` to all 4 locales (en / zh-CN / zh-TW / ko)

## Testing
- [x] Select text in terminal → right-click → "Set as Quick Command" opens the quick-command window with the selection prefilled, title shows "Add Command"
- [x] Editing an existing quick command still shows "Edit Command"
- [x] No selection → menu item hidden