### PR TITLE
fix(terminal): defer protocol wheel handling to avoid GPUI reentrancy

### DIFF
--- a/crates/nyaterm-desktop/src/features/terminal/terminal_runtime/mod.rs
+++ b/crates/nyaterm-desktop/src/features/terminal/terminal_runtime/mod.rs
@@ -5,7 +5,7 @@ mod buffer;
 mod paste;
 mod scroll;
 pub(in crate::features) use scroll::{
-    TERMINAL_USER_SCROLL_ACTIVE_WINDOW, TerminalScrollVisualState,
+    TERMINAL_USER_SCROLL_ACTIVE_WINDOW, TerminalScrollVisualState, TerminalScrollWheelStateResult,
     terminal_display_offset_from_state, terminal_local_scroll_delta_lines_from_state,
     terminal_scroll_needs_text_first_repaint, terminal_visual_scroll_active_for_state,
 };

--- a/crates/nyaterm-desktop/src/features/terminal/terminal_surface_entity/mod.rs
+++ b/crates/nyaterm-desktop/src/features/terminal/terminal_surface_entity/mod.rs
@@ -9,7 +9,7 @@ use crate::features::formatting::{
     TerminalTimestampFormatter, terminal_gutter_labels, terminal_timestamp_format_width_chars,
 };
 use crate::features::terminal::terminal_runtime::{
-    TerminalScrollVisualState, terminal_display_offset_from_state,
+    TerminalScrollVisualState, TerminalScrollWheelStateResult, terminal_display_offset_from_state,
     terminal_local_scroll_delta_lines_from_state, terminal_scroll_needs_text_first_repaint,
     terminal_visual_scroll_active_for_state,
 };
@@ -1813,16 +1813,41 @@ impl TerminalSurface {
             cx.stop_propagation();
             return;
         }
-        let result = app.update(cx, |this, cx| {
-            this.terminal_scroll_wheel_state_for_session(
-                session_id.as_str(),
-                raw_lines,
-                event.position,
-                event.modifiers,
-                cx,
-            )
-        });
 
+        // Protocol-owned wheel handling needs the surface's hit-test geometry. The
+        // current callback still holds the TerminalSurface update lease, so the
+        // parent app must not be entered until that lease is released; otherwise
+        // GPUI detects entity reentrancy at `surface.read(cx)` and panics.
+        if !raw_lines.is_finite() || raw_lines == 0.0 {
+            return;
+        }
+        let surface = cx.entity();
+        let position = event.position;
+        let modifiers = event.modifiers;
+        cx.stop_propagation();
+        cx.defer(move |cx| {
+            let result = app.update(cx, |this, cx| {
+                this.terminal_scroll_wheel_state_for_session(
+                    session_id.as_str(),
+                    raw_lines,
+                    position,
+                    modifiers,
+                    cx,
+                )
+            });
+            surface.update(cx, |surface, cx| {
+                surface.apply_scroll_wheel_result(app, session_id, result, cx);
+            });
+        });
+    }
+
+    fn apply_scroll_wheel_result(
+        &mut self,
+        app: Entity<NyaTermApp>,
+        session_id: String,
+        result: TerminalScrollWheelStateResult,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(state) = result.visual_state {
             let repaint_needed = self.scroll_visual_state_needs_repaint(&state);
             let text_updated = self.apply_scroll_visual_state(state.clone());
@@ -1832,16 +1857,17 @@ impl TerminalSurface {
                 cx.notify();
             }
             if needs_text_first_repaint {
-                app.update(cx, |this, cx| {
-                    this.notify_terminal_scroll_position_only(session_id.as_str(), cx);
+                let session_id = session_id.clone();
+                let app = app.clone();
+                cx.defer(move |cx| {
+                    app.update(cx, |this, cx| {
+                        this.notify_terminal_scroll_position_only(session_id.as_str(), cx);
+                    });
                 });
             }
         }
         if result.defer_repaint {
             Self::defer_surface_repaint(app, Some(session_id), cx);
-        }
-        if result.handled {
-            cx.stop_propagation();
         }
     }
 

--- a/crates/nyaterm-desktop/src/features/terminal/terminal_surface_entity/tests.rs
+++ b/crates/nyaterm-desktop/src/features/terminal/terminal_surface_entity/tests.rs
@@ -1,6 +1,8 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::entities::{OverlayStore, StartupRestoreStore, UiStoreHandles};
+use crate::features::NyaTermApp;
 use crate::features::terminal::terminal_surface::{
     TerminalOverviewMarker, TerminalOverviewMarkerKind,
 };
@@ -11,8 +13,10 @@ use crate::terminal::{
 };
 use gpui::prelude::*;
 use gpui::{
-    AppContext, Context, Entity, Render, TestAppContext, Window, bounds, div, point, px, size,
+    AppContext, Context, Entity, Render, ScrollDelta, ScrollWheelEvent, TestAppContext, Window,
+    bounds, div, point, px, size,
 };
+use nyaterm_core::{AppRuntime, RuntimeMode, uuid};
 use nyaterm_terminal::{TerminalScreen, TerminalSnapshot};
 use nyaterm_terminal_gpui::{NyaTerminalLayoutCache, precompute_terminal_keyword_highlights};
 
@@ -1948,6 +1952,106 @@ fn local_surface_wheel_respects_protocol_scroll_modes() {
     };
     surface.set_protocol_state(alternate_scroll);
     assert!(!surface.can_handle_scroll_wheel_locally());
+}
+
+#[test]
+fn protocol_scroll_wheel_defers_parent_update_until_surface_lease_is_released() {
+    let mut cx = TestAppContext::single();
+    let root = std::env::temp_dir().join(format!(
+        "nyaterm-terminal-scroll-wheel-{}-{}",
+        std::process::id(),
+        uuid()
+    ));
+    let runtime = AppRuntime::from_parts_for_test(
+        RuntimeMode::Portable,
+        root.clone(),
+        root.join("config"),
+        root.join("logs"),
+        root.join("cache"),
+        None,
+    );
+    let stores = UiStoreHandles {
+        startup_restore: cx.new(|_| StartupRestoreStore::default()),
+        overlays: cx.new(|_| OverlayStore::default()),
+    };
+    let app = cx.new(|cx| NyaTermApp::new(runtime, stores, cx));
+    let session_id = "session";
+    let output = terminal_test_output_lines(80);
+    let surface = cx.update_entity(&app, |app, cx| {
+        app.session.select_active_session(session_id);
+        app.terminal
+            .seed_session_view(session_id.to_string(), output.clone(), "UTF-8");
+        let bounds = bounds(point(px(0.), px(0.)), size(px(400.), px(240.)));
+        assert!(app.remember_terminal_surface_bounds_for_session(Some(session_id), bounds,));
+        app.ensure_terminal_surface(session_id, cx)
+    });
+
+    let mut screen = TerminalScreen::default();
+    screen.advance_decoded_text(&output);
+    let snapshot = Arc::new(screen.viewport_snapshot(0));
+    let viewport_rows = snapshot.row_count().max(1);
+    let scrollback_len = snapshot.scrollback_len;
+    let bounds = bounds(point(px(0.), px(0.)), size(px(400.), px(240.)));
+    let protocol = TerminalProtocolState {
+        mouse_reporting: true,
+        ..TerminalProtocolState::default()
+    };
+    cx.update_entity(&surface, |surface, _| {
+        surface.set_protocol_state(protocol);
+        surface.apply_frame_snapshot(TerminalSurfaceFrameSnapshot::new(
+            snapshot.clone(),
+            TerminalScrollVisualState {
+                session_id: session_id.to_string(),
+                scroll_offset: 0,
+                scroll_residual_lines: 0.0,
+                display_offset: 0,
+                scrollback_len,
+                viewport_rows,
+                has_new_while_scrolled: false,
+                performance_overlay: None,
+                skipped_output_chars: 0,
+            },
+        ));
+        surface.painted_hit_test_geometry = Some(TerminalPaintedHitTestGeometry {
+            grid_bounds: Some(bounds),
+            display_offset: 0,
+            viewport_anchor_row: 0,
+            snapshot_rows: snapshot.row_count(),
+            viewport_rows,
+            visual_y_offset: 0.0,
+            cell_width: 8.0,
+            cell_height: 16.0,
+            revision: surface.revision,
+        });
+        surface.painted_hit_test_snapshot = Some(snapshot);
+    });
+    cx.update_entity(&app, |app, _| {
+        app.terminal
+            .view
+            .views
+            .get_mut(session_id)
+            .expect("seeded terminal view")
+            .protocol_state = protocol;
+    });
+
+    // The event callback holds the surface update lease; protocol wheel handling
+    // must wait until the callback returns before reading the geometry.
+    cx.update_entity(&surface, |surface, cx| {
+        surface.handle_scroll_wheel(
+            &ScrollWheelEvent {
+                position: point(px(8.), px(8.)),
+                delta: ScrollDelta::Lines(point(0., 1.)),
+                ..ScrollWheelEvent::default()
+            },
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        cx.read_entity(&surface, |surface, _| surface.protocol_state),
+        protocol
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 背景

在 macOS GPUI 界面中，Vim 等启用终端鼠标报告的程序使用滚轮时，应用会崩溃：

`cannot read TerminalSurface while it is already being updated`

## 原因

滚轮事件由 `TerminalSurface` 实体处理时，该实体仍处于 GPUI 更新租约中。协议滚轮路径随后同步调用父级 `NyaTermApp`，命中测试逻辑又读取同一个 `TerminalSurface`，因此触发 GPUI 的实体重入保护并 panic。

## 修复

- 协议接管的滚轮事件立即停止传播，保持原有事件消费语义。
- 使用 `cx.defer` 将父级滚轮处理延迟到当前 `TerminalSurface` 更新租约释放之后。
- 将处理结果在安全时机回写 Surface。
- 后续滚动位置通知也继续延迟，避免再次发生实体重入。
- 增加协议滚轮回归测试，覆盖 Surface 更新期间的父级读取场景。

普通本地滚动路径保持不变。

## 验证

- `cargo check --workspace`
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`