### PR TITLE
  feat(editor): 内置编辑器支持 Ctrl+滚轮缩放字体

### DIFF
--- a/src-tauri/src/config/settings/transfer.rs
+++ b/src-tauri/src/config/settings/transfer.rs
@@ -9,6 +9,8 @@ pub struct TransferSettings {
     pub editor_type: String,
     #[serde(default = "default_internal_editor_display")]
     pub internal_editor_display: String,
+    #[serde(default = "default_internal_editor_font_size")]
+    pub internal_editor_font_size: u32,
     #[serde(default = "default_transfer_threads")]
     pub download_threads: u32,
     #[serde(default = "default_transfer_threads")]
@@ -54,6 +56,9 @@ fn default_editor_type() -> String {
 fn default_internal_editor_display() -> String {
     "workspace".to_string()
 }
+fn default_internal_editor_font_size() -> u32 {
+    13
+}
 fn default_duplicate_strategy() -> String {
     "ask".to_string()
 }
@@ -75,6 +80,7 @@ impl Default for TransferSettings {
         Self {
             editor_type: default_editor_type(),
             internal_editor_display: default_internal_editor_display(),
+            internal_editor_font_size: default_internal_editor_font_size(),
             download_threads: default_transfer_threads(),
             upload_threads: default_transfer_threads(),
             duplicate_strategy: default_duplicate_strategy(),
@@ -113,5 +119,6 @@ mod tests {
         assert!(!settings.recording_auto_start);
         assert_eq!(settings.editor_type, "external");
         assert_eq!(settings.internal_editor_display, "workspace");
+        assert_eq!(settings.internal_editor_font_size, 13);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { useRemoteStats } from "./hooks/useRemoteStats";
 import { useSecurityPromptQueue } from "./hooks/useSecurityPromptQueue";
 import { useSessionRuntimeState } from "./hooks/useSessionRuntimeState";
 import { resolveDisplayKeys } from "./hooks/useShortcutMap";
+import { useFileEditorZoom } from "./hooks/useFileEditorZoom";
 import { useTerminalZoom } from "./hooks/useTerminalZoom";
 import { useTabStatusIndicators } from "./hooks/useUnreadTabs";
 import { AI_OPEN_EVENT, type AIOpenIntent } from "./lib/aiEvents";
@@ -2035,6 +2036,8 @@ function App() {
     appSettings.keybindings,
     appSettings.interaction.terminal_zoom_enabled,
   );
+
+  useFileEditorZoom(updateAppSettings);
 
   const handleOpenSettings = useCallback(() => {
     openSettings();

--- a/src/components/panel/file-explorer/FileDocumentEditor.test.tsx
+++ b/src/components/panel/file-explorer/FileDocumentEditor.test.tsx
@@ -37,6 +37,16 @@ vi.mock("@/lib/codeMirrorFileView", () => ({
 vi.mock("@/lib/invoke", () => ({ invoke: vi.fn() }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
 
+vi.mock("@/context/AppContext", () => ({
+  useApp: () => ({
+    appSettings: {
+      transfer: {
+        internal_editor_font_size: 13,
+      },
+    },
+  }),
+}));
+
 function pane(): FileDocumentPane {
   return {
     id: "pane-file",

--- a/src/components/panel/file-explorer/FileDocumentEditor.tsx
+++ b/src/components/panel/file-explorer/FileDocumentEditor.tsx
@@ -15,7 +15,9 @@ import {
   registerFileDocument,
   updateFileDocumentState,
 } from "@/lib/fileDocumentRegistry";
+import { useApp } from "@/context/AppContext";
 import { invoke } from "@/lib/invoke";
+import { clampFileEditorFontSize } from "@/lib/fileEditorFontSize";
 import { formatSize } from "@/lib/utils";
 import type { FileDocumentPane } from "@/types/global";
 import { languageFromFilename, type TextFileOpenResult } from "./model";
@@ -35,6 +37,10 @@ interface FileDocumentEditorProps {
 
 export default function FileDocumentEditor({ pane, active }: FileDocumentEditorProps) {
   const { t } = useTranslation();
+  const { appSettings } = useApp();
+  const editorFontSize = clampFileEditorFontSize(
+    appSettings.transfer.internal_editor_font_size,
+  );
   const editorParentRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
   const suppressUpdateRef = useRef(false);
@@ -239,6 +245,7 @@ export default function FileDocumentEditor({ pane, active }: FileDocumentEditorP
     <div
       className="flex h-full min-h-0 flex-col bg-background/60"
       data-file-document-mode="edit"
+      data-file-editor-root="true"
       onKeyDown={(event) => {
         if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "s") {
           event.preventDefault();
@@ -285,7 +292,11 @@ export default function FileDocumentEditor({ pane, active }: FileDocumentEditorP
           {error}
         </div>
       ) : null}
-      <div ref={editorParentRef} className="min-h-0 flex-1" />
+      <div
+        ref={editorParentRef}
+        className="min-h-0 flex-1"
+        style={{ fontSize: `${editorFontSize}px` }}
+      />
       <div className="flex h-7 shrink-0 items-center justify-between border-t px-3 text-[11px] text-muted-foreground">
         <span>{languageFromFilename(pane.name || pane.file.path).toLocaleUpperCase()}</span>
         <span className="flex items-center gap-2">

--- a/src/components/panel/file-explorer/FilePreviewContent.tsx
+++ b/src/components/panel/file-explorer/FilePreviewContent.tsx
@@ -777,7 +777,13 @@ function ReadOnlyCodeMirror({
     return () => view.destroy();
   }, [content, language]);
 
-  return <div ref={parentRef} className="h-full min-h-0 bg-background/60" />;
+  return (
+    <div
+      ref={parentRef}
+      className="h-full min-h-0 bg-background/60"
+      style={{ fontSize: "13px" }}
+    />
+  );
 }
 
 function PdfPreview({ file }: { file: RemoteBinaryFile }) {

--- a/src/context/AppProvider.tsx
+++ b/src/context/AppProvider.tsx
@@ -185,6 +185,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   transfer: {
     editor_type: "external",
     internal_editor_display: "workspace",
+    internal_editor_font_size: 13,
     download_threads: 3,
     upload_threads: 3,
     duplicate_strategy: "ask",

--- a/src/context/ChildAppProvider.tsx
+++ b/src/context/ChildAppProvider.tsx
@@ -146,6 +146,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   transfer: {
     editor_type: "external",
     internal_editor_display: "workspace",
+    internal_editor_font_size: 13,
     download_threads: 3,
     upload_threads: 3,
     duplicate_strategy: "ask",

--- a/src/hooks/useFileEditorZoom.ts
+++ b/src/hooks/useFileEditorZoom.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  decreaseFileEditorFontSize,
+  increaseFileEditorFontSize,
+} from "@/lib/fileEditorFontSize";
+import type { AppSettings } from "@/types/global";
+
+type UpdateAppSettings = (
+  updates: Partial<AppSettings> | ((prev: AppSettings) => Partial<AppSettings>),
+) => void;
+
+const CTRL_WHEEL_ZOOM_THROTTLE_MS = 50;
+const FILE_EDITOR_ROOT_SELECTOR = '[data-file-editor-root="true"]';
+
+function isElement(value: EventTarget | null): value is Element {
+  return value instanceof Element;
+}
+
+function eventTargetIsInsideFileEditorRoot(event: WheelEvent) {
+  const pathContainsFileEditorRoot = event.composedPath().some((target) => {
+    if (!isElement(target)) return false;
+    return target.matches(FILE_EDITOR_ROOT_SELECTOR);
+  });
+  if (pathContainsFileEditorRoot) return true;
+
+  const target = event.target;
+  return isElement(target) && target.closest(FILE_EDITOR_ROOT_SELECTOR) !== null;
+}
+
+export function useFileEditorZoom(updateAppSettings: UpdateAppSettings) {
+  const lastCtrlWheelZoomAtRef = useRef(0);
+
+  const handleZoomIn = useCallback(() => {
+    updateAppSettings((prev) => ({
+      transfer: {
+        ...prev.transfer,
+        internal_editor_font_size: increaseFileEditorFontSize(
+          prev.transfer.internal_editor_font_size,
+        ),
+      },
+    }));
+  }, [updateAppSettings]);
+
+  const handleZoomOut = useCallback(() => {
+    updateAppSettings((prev) => ({
+      transfer: {
+        ...prev.transfer,
+        internal_editor_font_size: decreaseFileEditorFontSize(
+          prev.transfer.internal_editor_font_size,
+        ),
+      },
+    }));
+  }, [updateAppSettings]);
+
+  useEffect(() => {
+    const handleCtrlWheelZoom = (event: WheelEvent) => {
+      if (!event.ctrlKey && !event.metaKey) return;
+      if (event.deltaY === 0) return;
+      if (!eventTargetIsInsideFileEditorRoot(event)) return;
+
+      event.preventDefault();
+      const now = Date.now();
+      if (now - lastCtrlWheelZoomAtRef.current < CTRL_WHEEL_ZOOM_THROTTLE_MS) return;
+      lastCtrlWheelZoomAtRef.current = now;
+
+      if (event.deltaY < 0) {
+        handleZoomIn();
+      } else {
+        handleZoomOut();
+      }
+    };
+
+    window.addEventListener("wheel", handleCtrlWheelZoom, { passive: false, capture: true });
+    return () => {
+      window.removeEventListener("wheel", handleCtrlWheelZoom, true);
+    };
+  }, [handleZoomIn, handleZoomOut]);
+
+  return {
+    handleZoomIn,
+    handleZoomOut,
+  };
+}

--- a/src/lib/codeMirrorFileView.ts
+++ b/src/lib/codeMirrorFileView.ts
@@ -276,7 +276,6 @@ export function codeMirrorFileViewExtensions(
         height: "100%",
         backgroundColor: "var(--background)",
         color: "var(--foreground)",
-        fontSize: "13px",
       },
       "&.cm-focused": {
         outline: "none",

--- a/src/lib/fileEditorFontSize.test.ts
+++ b/src/lib/fileEditorFontSize.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampFileEditorFontSize,
+  DEFAULT_FILE_EDITOR_FONT_SIZE,
+  decreaseFileEditorFontSize,
+  increaseFileEditorFontSize,
+} from "./fileEditorFontSize";
+
+describe("clampFileEditorFontSize", () => {
+  it("clamps below the minimum", () => {
+    expect(clampFileEditorFontSize(1)).toBe(8);
+  });
+
+  it("clamps above the maximum", () => {
+    expect(clampFileEditorFontSize(100)).toBe(72);
+  });
+
+  it("rounds fractional sizes", () => {
+    expect(clampFileEditorFontSize(13.6)).toBe(14);
+  });
+
+  it("falls back to the default for non-finite values", () => {
+    expect(clampFileEditorFontSize(Number.NaN)).toBe(DEFAULT_FILE_EDITOR_FONT_SIZE);
+    expect(clampFileEditorFontSize(Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_FILE_EDITOR_FONT_SIZE,
+    );
+  });
+});
+
+describe("increaseFileEditorFontSize", () => {
+  it("steps up by one", () => {
+    expect(increaseFileEditorFontSize(13)).toBe(14);
+  });
+
+  it("stops at the maximum", () => {
+    expect(increaseFileEditorFontSize(72)).toBe(72);
+  });
+});
+
+describe("decreaseFileEditorFontSize", () => {
+  it("steps down by one", () => {
+    expect(decreaseFileEditorFontSize(13)).toBe(12);
+  });
+
+  it("stops at the minimum", () => {
+    expect(decreaseFileEditorFontSize(8)).toBe(8);
+  });
+});

--- a/src/lib/fileEditorFontSize.ts
+++ b/src/lib/fileEditorFontSize.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_FILE_EDITOR_FONT_SIZE = 13;
+export const MIN_FILE_EDITOR_FONT_SIZE = 8;
+export const MAX_FILE_EDITOR_FONT_SIZE = 72;
+export const FILE_EDITOR_FONT_SIZE_STEP = 1;
+
+export function clampFileEditorFontSize(fontSize: number): number {
+  if (!Number.isFinite(fontSize)) return DEFAULT_FILE_EDITOR_FONT_SIZE;
+  return Math.max(
+    MIN_FILE_EDITOR_FONT_SIZE,
+    Math.min(MAX_FILE_EDITOR_FONT_SIZE, Math.round(fontSize)),
+  );
+}
+
+export function increaseFileEditorFontSize(fontSize: number): number {
+  return clampFileEditorFontSize(fontSize + FILE_EDITOR_FONT_SIZE_STEP);
+}
+
+export function decreaseFileEditorFontSize(fontSize: number): number {
+  return clampFileEditorFontSize(fontSize - FILE_EDITOR_FONT_SIZE_STEP);
+}

--- a/src/pages/RemoteFileEditorPage.tsx
+++ b/src/pages/RemoteFileEditorPage.tsx
@@ -36,6 +36,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useApp } from "@/context/AppContext";
 import { useChildWindowCommand } from "@/hooks/useChildWindowCommand";
+import { useFileEditorZoom } from "@/hooks/useFileEditorZoom";
 import { CHILD_WINDOW_COMMANDS } from "@/lib/childWindowProtocol";
 import {
   type CursorPosition,
@@ -44,6 +45,7 @@ import {
   getDisplayLanguage,
 } from "@/lib/codeMirrorFileView";
 import { getErrorMessage } from "@/lib/errors";
+import { clampFileEditorFontSize } from "@/lib/fileEditorFontSize";
 import { MAX_EDITOR_FILE_BYTES } from "@/lib/fileEditorLimits";
 import { invoke } from "@/lib/invoke";
 import { cn, formatSize, parseJsonSearchParam } from "@/lib/utils";
@@ -162,7 +164,11 @@ function formatTargetLabel(target?: FileWindowTarget) {
 
 export default function RemoteFileEditorPage() {
   const { t } = useTranslation();
-  const { appSettings } = useApp();
+  const { appSettings, updateAppSettings } = useApp();
+  useFileEditorZoom(updateAppSettings);
+  const editorFontSize = clampFileEditorFontSize(
+    appSettings.transfer.internal_editor_font_size,
+  );
   const initialData = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     return parseJsonSearchParam<RemoteFileEditorData>(params.get("data"));
@@ -659,7 +665,10 @@ export default function RemoteFileEditorPage() {
     : t("fileEditor.title");
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background text-foreground">
+    <div
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-background text-foreground"
+      data-file-editor-root="true"
+    >
       <ChildWindowHeader
         title={activeHeaderTitle}
         icon={<MdDescription className="text-base" />}
@@ -856,7 +865,11 @@ export default function RemoteFileEditorPage() {
               {t("common.loading")}
             </div>
           )}
-          <div ref={editorParentRef} className="h-full min-h-0" />
+          <div
+            ref={editorParentRef}
+            className="h-full min-h-0"
+            style={{ fontSize: `${editorFontSize}px` }}
+          />
         </div>
 
         <div className="flex h-6 shrink-0 items-center justify-between gap-3 border-t bg-muted/15 px-3 font-mono text-[11px] text-muted-foreground">

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1333,6 +1333,7 @@ export interface TerminalSettings {
 export interface TransferSettings {
   editor_type: "external" | "internal";
   internal_editor_display: "workspace" | "window";
+  internal_editor_font_size: number;
   download_threads: number;
   upload_threads: number;
   duplicate_strategy: string;


### PR DESCRIPTION
 ## 概述
    
• 内置文件编辑器新增 Ctrl+滚轮(或 Cmd+滚轮)缩放字体，与终端缩放体验一致(50ms 节流，字号范围 8–72,步长 1)
• 两种显示模式均生效：工作区标签页模式、独立编辑器窗口模式
• 字号通过新设置项 transfer.internal_editor_font_size 持久化(默认 13),并借助现有 settings-changed 事件实现多窗口同步
• 预览(只读)模式保持固定 13px,行为不变

## 实现说明

• 移除 CodeMirror theme 中硬编码的 fontSize,改为编辑区容器通过 inline style 控制字号(CSS 继承)，缩放时无需重建编辑器 state
• 新增 useFileEditorZoom hook,逻辑对齐 useTerminalZoom,作用域限定在 [data-file-editor-root] 区域，不影响终端缩放
• Rust 端 TransferSettings 新增字段并使用 #[serde(default)],旧配置无需迁移，升级后默认字号与原硬编码值一致，视觉零变化

## 测试

• tsc、vitest(共 441 个用例，含 8 个新增)、biome lint、cargo check 均通过
• 已手动验证两种模式下的缩放、持久化与跨窗口同步