### PR TITLE
fix: scroll terminal to cursor when typing with a selection

### DIFF
--- a/src/components/terminal/xterminalKeyboardController.ts
+++ b/src/components/terminal/xterminalKeyboardController.ts
@@ -262,9 +262,20 @@ export function installXTerminalKeyboardController({
     }
 
     if (terminal.hasSelection() && !getSmartCursorSelectedInputRange()) {
+      // The selection is preserved by design while typing (it is only cleared
+      // on mouse click), so input is sent with wasUserInput=false to skip
+      // xterm's selection clearing. That also skips xterm's scrollOnUserInput,
+      // so scroll back to the cursor explicitly to keep the prompt visible.
+      const inputPreservingSelection = (data: string) => {
+        terminal.input(data, false);
+        const buffer = terminal.buffer.active;
+        if (buffer.baseY !== buffer.viewportY) {
+          terminal.scrollToBottom();
+        }
+      };
       if (directInputData) {
         e.preventDefault();
-        terminal.input(directInputData, false);
+        inputPreservingSelection(directInputData);
         return false;
       }
       if (
@@ -274,12 +285,12 @@ export function installXTerminalKeyboardController({
         !e.altKey
       ) {
         e.preventDefault();
-        terminal.input("\x7f", false);
+        inputPreservingSelection("\x7f");
         return false;
       }
       if (e.key === "Enter" && !e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
-        terminal.input("\r", false);
+        inputPreservingSelection("\r");
         return false;
       }
       if (
@@ -290,7 +301,7 @@ export function installXTerminalKeyboardController({
         !e.shiftKey
       ) {
         e.preventDefault();
-        terminal.input("\x1b[D", false);
+        inputPreservingSelection("\x1b[D");
         return false;
       }
       if (
@@ -301,7 +312,7 @@ export function installXTerminalKeyboardController({
         !e.shiftKey
       ) {
         e.preventDefault();
-        terminal.input("\x1b[C", false);
+        inputPreservingSelection("\x1b[C");
         return false;
       }
       if (
@@ -312,7 +323,7 @@ export function installXTerminalKeyboardController({
         !e.shiftKey
       ) {
         e.preventDefault();
-        terminal.input("\x1b[A", false);
+        inputPreservingSelection("\x1b[A");
         return false;
       }
       if (
@@ -323,7 +334,7 @@ export function installXTerminalKeyboardController({
         !e.shiftKey
       ) {
         e.preventDefault();
-        terminal.input("\x1b[B", false);
+        inputPreservingSelection("\x1b[B");
         return false;
       }
       if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
@@ -358,65 +369,65 @@ export function installXTerminalKeyboardController({
         const keyLower = e.key.toLowerCase();
         if (ctrlCharMap[keyLower]) {
           e.preventDefault();
-          terminal.input(ctrlCharMap[keyLower], false);
+          inputPreservingSelection(ctrlCharMap[keyLower]);
           return false;
         }
         if (e.key === "ArrowLeft") {
           e.preventDefault();
-          terminal.input("\x1b[1;5D", false);
+          inputPreservingSelection("\x1b[1;5D");
           return false;
         }
         if (e.key === "ArrowRight") {
           e.preventDefault();
-          terminal.input("\x1b[1;5C", false);
+          inputPreservingSelection("\x1b[1;5C");
           return false;
         }
         if (e.key === "ArrowUp") {
           e.preventDefault();
-          terminal.input("\x1b[1;5A", false);
+          inputPreservingSelection("\x1b[1;5A");
           return false;
         }
         if (e.key === "ArrowDown") {
           e.preventDefault();
-          terminal.input("\x1b[1;5B", false);
+          inputPreservingSelection("\x1b[1;5B");
           return false;
         }
       }
       if ((e.altKey || e.metaKey) && !e.ctrlKey && !e.shiftKey) {
         if (e.key === "ArrowLeft") {
           e.preventDefault();
-          terminal.input("\x1b[1;3D", false);
+          inputPreservingSelection("\x1b[1;3D");
           return false;
         }
         if (e.key === "ArrowRight") {
           e.preventDefault();
-          terminal.input("\x1b[1;3C", false);
+          inputPreservingSelection("\x1b[1;3C");
           return false;
         }
         if (e.key === "ArrowUp") {
           e.preventDefault();
-          terminal.input("\x1b[1;3A", false);
+          inputPreservingSelection("\x1b[1;3A");
           return false;
         }
         if (e.key === "ArrowDown") {
           e.preventDefault();
-          terminal.input("\x1b[1;3B", false);
+          inputPreservingSelection("\x1b[1;3B");
           return false;
         }
         const keyLower = e.key.toLowerCase();
         if (keyLower === "b") {
           e.preventDefault();
-          terminal.input("\x1bb", false);
+          inputPreservingSelection("\x1bb");
           return false;
         }
         if (keyLower === "f") {
           e.preventDefault();
-          terminal.input("\x1bf", false);
+          inputPreservingSelection("\x1bf");
           return false;
         }
         if (keyLower === "d") {
           e.preventDefault();
-          terminal.input("\x1bd", false);
+          inputPreservingSelection("\x1bd");
           return false;
         }
       }


### PR DESCRIPTION
Fixes #518

## Problem

After selecting text in the terminal scrollback (e.g. historical log output) and scrolling away from the bottom, pressing any key no longer scrolls the viewport back to the cursor — the user cannot see what they type (while the suggestion popup, anchored at the cursor, still appears off-screen).

## Root cause

`xterminalKeyboardController.ts` deliberately sends key input via `terminal.input(data, false)` while a selection is active, so that xterm.js does not clear the selection on key press (the selection is only cleared on mouse click, by design).

However, in xterm.js `triggerDataEvent(e, wasUserInput)` gates **both** behaviors behind the same flag:

```js
t && scrollOnUserInput && ybase !== ydisp && this._onRequestScrollToBottom.fire();
t && this._onUserInput.fire();  // → clears the selection
```

Passing `false` skips the selection clearing but also skips `scrollOnUserInput`, so the viewport never returns to the cursor.

## Fix

Keep the selection-preservation behavior, but replicate xterm's `scrollOnUserInput` explicitly: after sending the input, scroll to the bottom when the viewport is not at the buffer bottom (`buffer.active.baseY !== buffer.active.viewportY`).

All key paths in the selection branch now go through a single `inputPreservingSelection` helper (printable input, backspace/delete, enter, arrows, ctrl combos, alt combos).

## Testing

- [x] `tsc --noEmit` clean, `pnpm lint` clean
- [x] Repro from the issue: `cat` a large file → scroll up → select history output → type: the viewport now scrolls back to the cursor and the selection is preserved
- [x] Typing while already at the bottom: no behavior change