### PR TITLE
fix(terminal): 窗口重新聚焦时强制刷新终端

### DIFF
--- a/src/components/terminal/useTerminalRefreshEffects.test.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.test.ts
@@ -61,7 +61,7 @@ describe("useTerminalRefreshEffects", () => {
     expect(activeRefresh).not.toHaveProperty("clearTextureAtlas");
   });
 
-  it("forces fit and repaint when the native window regains focus", async () => {
+  it("forces fit and repaint without stealing focus when the native window regains focus", async () => {
     const schedule = vi.fn();
     renderHook(() =>
       useTerminalRefreshEffects({
@@ -92,7 +92,7 @@ describe("useTerminalRefreshEffects", () => {
         force: true,
         refresh: true,
         clearTextureAtlas: false,
-        focus: true,
+        focus: false,
       }),
     );
   });

--- a/src/components/terminal/useTerminalRefreshEffects.test.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.test.ts
@@ -5,6 +5,7 @@ import type { TerminalFitScheduler } from "./terminalFitScheduler";
 import { useTerminalRefreshEffects } from "./useTerminalRefreshEffects";
 
 const windowMocks = vi.hoisted(() => ({
+  focusChanged: undefined as ((event: { payload: boolean }) => void) | undefined,
   scaleChanged: undefined as
     | ((event: { payload: { scaleFactor: number } }) => void)
     | undefined,
@@ -14,7 +15,10 @@ vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({
     onResized: async () => vi.fn(),
     onMoved: async () => vi.fn(),
-    onFocusChanged: async () => vi.fn(),
+    onFocusChanged: async (callback: (event: { payload: boolean }) => void) => {
+      windowMocks.focusChanged = callback;
+      return vi.fn();
+    },
     onScaleChanged: async (
       callback: (event: { payload: { scaleFactor: number } }) => void,
     ) => {
@@ -26,6 +30,7 @@ vi.mock("@tauri-apps/api/window", () => ({
 
 describe("useTerminalRefreshEffects", () => {
   beforeEach(() => {
+    windowMocks.focusChanged = undefined;
     windowMocks.scaleChanged = undefined;
   });
 
@@ -54,6 +59,42 @@ describe("useTerminalRefreshEffects", () => {
       expect.objectContaining({ force: true, refresh: true, focus: true }),
     );
     expect(activeRefresh).not.toHaveProperty("clearTextureAtlas");
+  });
+
+  it("forces fit and repaint when the native window regains focus", async () => {
+    const schedule = vi.fn();
+    renderHook(() =>
+      useTerminalRefreshEffects({
+        terminalRef: { current: {} as Terminal },
+        fitSchedulerRef: {
+          current: { schedule } as unknown as TerminalFitScheduler,
+        },
+        active: true,
+        visible: true,
+        terminalReady: true,
+        performanceMode: "normal",
+        sessionId: "session-1",
+        showGutter: false,
+        showContentPadding: false,
+      }),
+    );
+    await waitFor(() => expect(windowMocks.focusChanged).toBeTypeOf("function"));
+    schedule.mockClear();
+
+    windowMocks.focusChanged?.({ payload: false });
+    expect(schedule).not.toHaveBeenCalled();
+
+    windowMocks.focusChanged?.({ payload: true });
+    expect(schedule).toHaveBeenCalledTimes(1);
+    expect(schedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "window-focus",
+        force: true,
+        refresh: true,
+        clearTextureAtlas: false,
+        focus: true,
+      }),
+    );
   });
 
   it("still invalidates textures after a DPI scale change", async () => {

--- a/src/components/terminal/useTerminalRefreshEffects.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.ts
@@ -165,7 +165,7 @@ export function useTerminalRefreshEffects({
         force: force || isScaleChange,
         refresh: true,
         clearTextureAtlas: isScaleChange,
-        focus: active && visible,
+        focus: reason === "window-focus" ? false : active && visible,
       });
     };
 

--- a/src/components/terminal/useTerminalRefreshEffects.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.ts
@@ -202,7 +202,7 @@ export function useTerminalRefreshEffects({
       .catch(() => {});
     appWindow
       .onFocusChanged(({ payload }) => {
-        if (!disposed && payload) scheduleWindowFit("window-focus");
+        if (!disposed && payload) scheduleWindowFit("window-focus", true);
       })
       .then((unlisten) => {
         unlistenFocused = unlisten;


### PR DESCRIPTION
## 修复

- 原生窗口重新获得焦点时为现有 `window-focus` 调度传入 `force: true`，即使终端 cols/rows 未变化也会执行 fit 和 repaint，并继续只为活动且可见的终端恢复 focus。
- 增加 `onFocusChanged` 回归测试，验证失焦不会触发刷新、重新聚焦不会清除 texture atlas，并按 Biome 要求修正新增测试语句格式。

## 验证

聚焦 Vitest、全量 lint、生产构建和最终差异检查均通过；完整双文件 Biome check 仍仅受既有格式/import 基线差异影响。当前验证环境为 Linux，尚未在 macOS 26.5.2/aarch64 上执行 issue 原始切窗场景的实机视觉验证。

Fixes #556