### PR TITLE
fix(terminal): reveal cursor after live position changes

### DIFF
--- a/crates/nyaterm-desktop/src/features/mod.rs
+++ b/crates/nyaterm-desktop/src/features/mod.rs
@@ -26,6 +26,8 @@ mod shell;
 mod sync;
 mod sync_input;
 mod terminal;
+#[cfg(test)]
+mod test_support;
 mod text_inputs;
 mod transfers;
 mod translation;

--- a/crates/nyaterm-desktop/src/features/shell/cursor_blink.rs
+++ b/crates/nyaterm-desktop/src/features/shell/cursor_blink.rs
@@ -103,16 +103,12 @@ impl NyaTermApp {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
     use std::time::Duration;
 
     use gpui::{AppContext as _, TestAppContext};
-    use nyaterm_core::{AiExecutionProfile, AppRuntime, RuntimeMode, uuid};
-    use nyaterm_transport::LocalSessionConfig;
 
-    use crate::entities::{OverlayStore, StartupRestoreStore, UiStoreHandles};
-    use crate::features::NyaTermApp;
-    use crate::models::{SessionLaunchConfig, SessionRuntimeMetadata};
+    use crate::features::test_support::app_with_visible_local_session;
+    use crate::test_support::TestConfigDir;
 
     use super::{
         CURSOR_BLINK_INTERVAL, cursor_blink_clock_should_run, cursor_blink_phase_may_advance,
@@ -120,61 +116,11 @@ mod tests {
 
     const SESSION_ID: &str = "cursor-blink-session";
 
-    fn unique_test_dir() -> PathBuf {
-        // A uuid rather than a clock reading: these tests run in parallel and
-        // Windows' ~15ms clock granularity lets a nanosecond timestamp repeat,
-        // which would share one config dir and so one settings database.
-        std::env::temp_dir().join(format!(
-            "nyaterm-cursor-blink-{}-{}",
-            std::process::id(),
-            uuid()
-        ))
-    }
-
-    /// One visible local session with the blink setting on.
-    fn app_with_blinking_caret(cx: &mut TestAppContext) -> gpui::Entity<NyaTermApp> {
-        let root = unique_test_dir();
-        let runtime = AppRuntime::from_parts_for_test(
-            RuntimeMode::Portable,
-            root.clone(),
-            root.join("config"),
-            root.join("logs"),
-            root.join("cache"),
-            None,
-        );
-        let stores = UiStoreHandles {
-            startup_restore: cx.new(|_| StartupRestoreStore::default()),
-            overlays: cx.new(|_| OverlayStore::default()),
-        };
-        let app = cx.new(|cx| NyaTermApp::new(runtime, stores, cx));
-        cx.update_entity(&app, |app, _| {
-            let mut summary = app.settings.summary().clone();
-            summary.cursor_blink = true;
-            app.settings.replace_summary(summary);
-            app.session.register_session_metadata(
-                SESSION_ID,
-                SessionRuntimeMetadata {
-                    ssh_config: None,
-                    ssh_multiplex_key: None,
-                    source_connection_id: None,
-                    ai_execution_profile: AiExecutionProfile::Posix,
-                    launch_config: SessionLaunchConfig::Local(LocalSessionConfig {
-                        name: "Local session".to_string(),
-                        ..LocalSessionConfig::default()
-                    }),
-                    disconnected: false,
-                },
-            );
-            app.session.select_active_session(SESSION_ID);
-            app.terminal
-                .seed_session_view(SESSION_ID.to_string(), String::new(), "UTF-8");
-            app.shell.show_workspace();
-            assert!(
-                !app.visible_terminal_session_ids().is_empty(),
-                "the fixture must have a visible session or the clock will not run"
-            );
-        });
-        app
+    fn app_with_blinking_caret(
+        cx: &mut TestAppContext,
+        root: &TestConfigDir,
+    ) -> gpui::Entity<crate::features::NyaTermApp> {
+        app_with_visible_local_session(cx, root.path(), SESSION_ID)
     }
 
     /// The bug Phase 0 could only paper over: the caret's half-period must be the
@@ -185,8 +131,9 @@ mod tests {
     /// schedule -- a 500ms tick, say -- fails one of these two.
     #[test]
     fn the_caret_toggles_exactly_one_interval_apart() {
+        let root = TestConfigDir::new("nyaterm-cursor-blink");
         let mut cx = TestAppContext::single();
-        let app = app_with_blinking_caret(&mut cx);
+        let app = app_with_blinking_caret(&mut cx, &root);
         cx.update_entity(&app, |app, cx| {
             app.ensure_cursor_blink_clock(cx);
             assert!(app.shell.cursor_blink_on(), "the caret starts visible");
@@ -224,8 +171,9 @@ mod tests {
     /// can only be the clock re-arming itself.
     #[test]
     fn the_clock_keeps_its_own_cadence_with_no_runtime_tick() {
+        let root = TestConfigDir::new("nyaterm-cursor-blink");
         let mut cx = TestAppContext::single();
-        let app = app_with_blinking_caret(&mut cx);
+        let app = app_with_blinking_caret(&mut cx, &root);
         cx.update_entity(&app, |app, cx| app.ensure_cursor_blink_clock(cx));
 
         for expected_on in [false, true, false, true] {
@@ -240,8 +188,9 @@ mod tests {
     /// Turning the setting off leaves the caret visible rather than stranded hidden.
     #[test]
     fn the_clock_stops_and_leaves_the_caret_visible() {
+        let root = TestConfigDir::new("nyaterm-cursor-blink");
         let mut cx = TestAppContext::single();
-        let app = app_with_blinking_caret(&mut cx);
+        let app = app_with_blinking_caret(&mut cx, &root);
         cx.update_entity(&app, |app, cx| app.ensure_cursor_blink_clock(cx));
 
         // Toggle into the hidden half of the cycle first, so a stop that forgot to
@@ -266,6 +215,20 @@ mod tests {
                 !app.shell.cursor_blink_clock_is_armed(),
                 "and it must actually stop rather than spin at 530ms forever"
             );
+        });
+    }
+
+    #[test]
+    fn resetting_cursor_blink_phase_makes_hidden_caret_visible() {
+        let root = TestConfigDir::new("nyaterm-cursor-blink");
+        let mut cx = TestAppContext::single();
+        let app = app_with_blinking_caret(&mut cx, &root);
+
+        cx.update_entity(&app, |app, _| {
+            app.shell.set_cursor_blink_on(false);
+            assert!(app.shell.reset_cursor_blink_phase());
+            assert!(app.shell.cursor_blink_on());
+            assert!(!app.shell.reset_cursor_blink_phase());
         });
     }
 

--- a/crates/nyaterm-desktop/src/features/shell/runtime_state.rs
+++ b/crates/nyaterm-desktop/src/features/shell/runtime_state.rs
@@ -291,6 +291,12 @@ impl ShellFeatureState {
         self.runtime.cursor_blink_on = !self.runtime.cursor_blink_on;
     }
 
+    /// Restore the visible blink phase after cursor movement so the new position
+    /// cannot remain hidden.
+    pub(in crate::features) fn reset_cursor_blink_phase(&mut self) -> bool {
+        self.set_cursor_blink_on(true)
+    }
+
     /// Force the caret's blink phase. Returns whether it changed.
     pub(in crate::features) fn set_cursor_blink_on(&mut self, on: bool) -> bool {
         let changed = self.runtime.cursor_blink_on != on;

--- a/crates/nyaterm-desktop/src/features/terminal/terminal_runtime/view_io/mod.rs
+++ b/crates/nyaterm-desktop/src/features/terminal/terminal_runtime/view_io/mod.rs
@@ -205,6 +205,13 @@ fn terminal_cursor_visible_for_display_offset(
         && (!blink_enabled || cursor_blink_on)
 }
 
+fn terminal_cursor_position_changed(
+    previous: Option<(usize, usize)>,
+    current: Option<(usize, usize)>,
+) -> bool {
+    current.is_some() && previous != current
+}
+
 #[cfg(test)]
 fn terminal_snapshot_with_newer_edge_row(
     base: std::sync::Arc<TerminalSnapshot>,
@@ -886,10 +893,17 @@ impl NyaTermApp {
         if session_id.is_empty() {
             return;
         }
+        let is_active = self.session.active_id() == Some(session_id);
         let paint_started_at = Instant::now();
         self.ensure_paint_theme_caches();
         let surface = self.ensure_terminal_surface(session_id, cx);
-        let is_active = self.session.active_id() == Some(session_id);
+        // Read only the lightweight row/column pair for the active surface; no
+        // snapshot is cloned, and inactive surfaces do not need this check.
+        let previous_cursor_position = if is_active {
+            surface.read(cx).cursor_position()
+        } else {
+            None
+        };
         let is_visible = self.terminal_session_has_visible_surface(session_id);
         let presentation = TerminalPresentation::resolve(is_active, is_visible);
         let work_policy = TerminalWorkPolicy::for_presentation(presentation);
@@ -1093,6 +1107,17 @@ impl NyaTermApp {
             });
             return;
         };
+        let current_cursor_position = (snapshot.display_offset == 0
+            && snapshot.cursor.row != usize::MAX)
+            .then_some((snapshot.cursor.row, snapshot.cursor.col));
+        if is_active
+            && display_offset == 0
+            && terminal_cursor_position_changed(previous_cursor_position, current_cursor_position)
+        {
+            // Full-screen programs such as Vim must show the new position even
+            // when the previous frame was in the hidden blink phase.
+            self.shell.reset_cursor_blink_phase();
+        }
         let cursor_row = snapshot.cursor.row;
         let remote_cursor_visible = snapshot.cursor.visible
             && snapshot.cursor.shape != nyaterm_terminal::CursorShape::Hidden

--- a/crates/nyaterm-desktop/src/features/terminal/terminal_runtime/view_io/tests.rs
+++ b/crates/nyaterm-desktop/src/features/terminal/terminal_runtime/view_io/tests.rs
@@ -1,24 +1,28 @@
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use gpui::{KeyDownEvent, MouseButton};
+use gpui::{AppContext as _, KeyDownEvent, MouseButton, TestAppContext};
 use nyaterm_terminal::TerminalScreen;
 
 use crate::features::terminal::terminal_surface_entity::terminal_snapshot_anchor_row_for_display_offset;
+use crate::features::test_support::app_with_visible_local_session;
 use crate::models::{
     TerminalBufferCellPos, TerminalFrameActionLinks, TerminalSelection, TerminalViewState,
 };
 use crate::terminal::{TerminalBufferMatch, TerminalKeyMode};
+use crate::test_support::TestConfigDir;
 
 use super::{
     TERMINAL_INPUT_LATENCY_WINDOW, TERMINAL_USER_SCROLL_ACTIVE_WINDOW,
-    lost_mouse_report_release_button, terminal_cursor_visible_for_display_offset,
-    terminal_input_latency_active, terminal_key_bytes_for_mode_and_settings,
-    terminal_keyword_highlight_updates_allowed, terminal_live_action_link_enrichment_allowed,
-    terminal_mouse_report_button, terminal_paint_snapshot_for_view,
-    terminal_paint_window_snapshot_for_view, terminal_retained_snapshot_matches_view,
-    terminal_scroll_retained_window_extra_rows, terminal_scroll_snapshot_request_offset,
-    terminal_scroll_text_first_decorations, terminal_selection_for_session,
-    terminal_session_write_failure_log, terminal_should_defer_key_text_to_input_handler_for_state,
+    lost_mouse_report_release_button, terminal_cursor_position_changed,
+    terminal_cursor_visible_for_display_offset, terminal_input_latency_active,
+    terminal_key_bytes_for_mode_and_settings, terminal_keyword_highlight_updates_allowed,
+    terminal_live_action_link_enrichment_allowed, terminal_mouse_report_button,
+    terminal_paint_snapshot_for_view, terminal_paint_window_snapshot_for_view,
+    terminal_retained_snapshot_matches_view, terminal_scroll_retained_window_extra_rows,
+    terminal_scroll_snapshot_request_offset, terminal_scroll_text_first_decorations,
+    terminal_selection_for_session, terminal_session_write_failure_log,
+    terminal_should_defer_key_text_to_input_handler_for_state,
     terminal_should_track_command_suggestion_input, terminal_snapshot_covers_display_offset,
     terminal_snapshot_with_newer_edge_row, terminal_snapshot_with_retained_scroll_window,
     terminal_status_changed, terminal_user_scroll_active, terminal_visual_display_offset,
@@ -96,6 +100,8 @@ fn terminal_output_lines(count: usize) -> String {
         .map(|index| format!("line {index:03}\n"))
         .collect::<String>()
 }
+
+const CURSOR_POSITION_SESSION_ID: &str = "cursor-position-session";
 
 #[test]
 fn terminal_paint_snapshot_waits_without_authoritative_scrollback_snapshot() {
@@ -295,6 +301,52 @@ fn terminal_cursor_visibility_uses_display_offset_not_raw_scroll_offset() {
     assert!(!terminal_cursor_visible_for_display_offset(
         true, false, 0, true, true, false
     ));
+}
+
+#[test]
+fn terminal_cursor_position_change_is_detected_for_a_new_live_position() {
+    assert!(terminal_cursor_position_changed(Some((4, 7)), Some((4, 8)),));
+}
+
+#[test]
+fn moving_the_live_cursor_resets_a_hidden_blink_phase_before_paint() {
+    let root = TestConfigDir::new("nyaterm-cursor-position");
+    let mut cx = TestAppContext::single();
+    let app = app_with_visible_local_session(&mut cx, root.path(), CURSOR_POSITION_SESSION_ID);
+
+    cx.update_entity(&app, |app, cx| {
+        let mut screen = TerminalScreen::default();
+        screen.advance_decoded_text("prompt");
+        let old_snapshot = Arc::new(screen.snapshot());
+        screen.advance(b"\x1b[1C");
+        let new_snapshot = Arc::new(screen.snapshot());
+
+        app.terminal
+            .view
+            .views
+            .get_mut(CURSOR_POSITION_SESSION_ID)
+            .expect("fixture session view should exist")
+            .frame_snapshot = Some(old_snapshot);
+        app.sync_terminal_surface_paint(CURSOR_POSITION_SESSION_ID, cx);
+
+        app.shell.set_cursor_blink_on(false);
+        app.terminal
+            .view
+            .views
+            .get_mut(CURSOR_POSITION_SESSION_ID)
+            .expect("fixture session view should exist")
+            .frame_snapshot = Some(new_snapshot);
+        app.sync_terminal_surface_paint(CURSOR_POSITION_SESSION_ID, cx);
+
+        assert!(app.shell.cursor_blink_on());
+        let surface = app
+            .terminal
+            .view
+            .surfaces
+            .get(CURSOR_POSITION_SESSION_ID)
+            .expect("fixture terminal surface should exist");
+        assert!(surface.read(cx).cursor_is_shown());
+    });
 }
 
 #[test]

--- a/crates/nyaterm-desktop/src/features/terminal/terminal_surface_entity/mod.rs
+++ b/crates/nyaterm-desktop/src/features/terminal/terminal_surface_entity/mod.rs
@@ -397,6 +397,20 @@ impl TerminalSurface {
         self.snapshot.is_some()
     }
 
+    /// Return the surface's committed live cursor position; scrolled snapshots
+    /// do not have a paintable cursor.
+    pub(in crate::features) fn cursor_position(&self) -> Option<(usize, usize)> {
+        self.snapshot.as_ref().and_then(|snapshot| {
+            (snapshot.display_offset == 0 && snapshot.cursor.row != usize::MAX)
+                .then_some((snapshot.cursor.row, snapshot.cursor.col))
+        })
+    }
+
+    #[cfg(test)]
+    pub(in crate::features) fn cursor_is_shown(&self) -> bool {
+        self.show_cursor
+    }
+
     pub(in crate::features) fn painted_hit_test_state(
         &self,
     ) -> Option<(TerminalPaintedHitTestGeometry, Arc<TerminalSnapshot>)> {

--- a/crates/nyaterm-desktop/src/features/test_support.rs
+++ b/crates/nyaterm-desktop/src/features/test_support.rs
@@ -1,0 +1,59 @@
+use std::path::Path;
+
+use gpui::AppContext as _;
+use nyaterm_core::{AiExecutionProfile, AppRuntime, RuntimeMode};
+use nyaterm_transport::LocalSessionConfig;
+
+use crate::entities::{OverlayStore, StartupRestoreStore, UiStoreHandles};
+use crate::models::{SessionLaunchConfig, SessionRuntimeMetadata};
+
+use super::NyaTermApp;
+
+/// Build a visible local terminal session for GPUI tests.
+pub(in crate::features) fn app_with_visible_local_session(
+    cx: &mut gpui::TestAppContext,
+    root: &Path,
+    session_id: &str,
+) -> gpui::Entity<NyaTermApp> {
+    let runtime = AppRuntime::from_parts_for_test(
+        RuntimeMode::Portable,
+        root.to_path_buf(),
+        root.join("config"),
+        root.join("logs"),
+        root.join("cache"),
+        None,
+    );
+    let stores = UiStoreHandles {
+        startup_restore: cx.new(|_| StartupRestoreStore::default()),
+        overlays: cx.new(|_| OverlayStore::default()),
+    };
+    let app = cx.new(|cx| NyaTermApp::new(runtime, stores, cx));
+    cx.update_entity(&app, |app, _| {
+        let mut summary = app.settings.summary().clone();
+        summary.cursor_blink = true;
+        app.settings.replace_summary(summary);
+        app.session.register_session_metadata(
+            session_id,
+            SessionRuntimeMetadata {
+                ssh_config: None,
+                ssh_multiplex_key: None,
+                source_connection_id: None,
+                ai_execution_profile: AiExecutionProfile::Posix,
+                launch_config: SessionLaunchConfig::Local(LocalSessionConfig {
+                    name: "Local session".to_string(),
+                    ..LocalSessionConfig::default()
+                }),
+                disconnected: false,
+            },
+        );
+        app.session.select_active_session(session_id);
+        app.terminal
+            .seed_session_view(session_id.to_string(), String::new(), "UTF-8");
+        app.shell.show_workspace();
+        assert!(
+            !app.visible_terminal_session_ids().is_empty(),
+            "the fixture must have a visible session"
+        );
+    });
+    app
+}


### PR DESCRIPTION
## 背景

启用光标闪烁时，光标会在显示与隐藏相位之间切换。Vim 等全屏程序移动光标后，如果新位置沿用了上一帧的隐藏相位，光标会暂时不可见，用户无法确认光标实际移动到了哪里。

## 改动内容

- 对比 TerminalSurface 已提交的 live 光标位置与当前权威 terminal snapshot 的位置。
- 仅在 active session 且处于 live display offset 时，检测行列坐标变化并恢复可见闪烁相位。
- 在计算 `show_cursor` 前完成相位恢复，确保新位置先显示。
- 非 active session 跳过光标位置读取，减少无意义的 Entity 访问。
- 抽取共享的 GPUI 本地 session 测试夹具，避免测试初始化代码重复，并自动清理临时目录。
- 本次仅恢复闪烁相位，不改变现有 530ms 定时器节奏。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p nyaterm-desktop --tests`
- `cargo clippy -p nyaterm-desktop --lib --tests -- -D warnings`
- 光标位置变化集成测试、blink 测试、view_io 测试
- desktop lib 测试（跳过已有的 notes/store 调度器异常测试）：1319 passed