### PR TITLE
fix(zmodem): 改用非阻塞文件选择器

### DIFF
--- a/src-tauri/src/cmd/session.rs
+++ b/src-tauri/src/cmd/session.rs
@@ -921,6 +921,45 @@ pub async fn ack_session_output(
 }
 
 #[tauri::command]
+pub async fn zmodem_pick_download_dir(
+    window: tauri::Window,
+) -> AppResult<Option<tauri_plugin_dialog::FilePath>> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    let dialog = window.dialog().file();
+    #[cfg(any(windows, target_os = "macos"))]
+    let dialog = dialog.set_parent(&window);
+    dialog.pick_folder(move |path| {
+        let _ = result_tx.send(path.map(|path| path.simplified()));
+    });
+
+    result_rx
+        .await
+        .map_err(|_| AppError::Channel("ZMODEM folder picker result was dropped".to_string()))
+}
+
+#[tauri::command]
+pub async fn zmodem_pick_upload_files(
+    window: tauri::Window,
+) -> AppResult<Option<Vec<tauri_plugin_dialog::FilePath>>> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    let dialog = window.dialog().file();
+    #[cfg(any(windows, target_os = "macos"))]
+    let dialog = dialog.set_parent(&window);
+    dialog.pick_files(move |paths| {
+        let _ = result_tx
+            .send(paths.map(|paths| paths.into_iter().map(|path| path.simplified()).collect()));
+    });
+
+    result_rx
+        .await
+        .map_err(|_| AppError::Channel("ZMODEM file picker result was dropped".to_string()))
+}
+
+#[tauri::command]
 pub async fn zmodem_accept_download(
     state: tauri::State<'_, Arc<SessionManager>>,
     session_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -263,6 +263,8 @@ pub fn run() {
             cmd::session::respond_ssh_agent_auth,
             cmd::session::cancel_ssh_agent_auth,
             cmd::session::respond_host_key_verify,
+            cmd::session::zmodem_pick_download_dir,
+            cmd::session::zmodem_pick_upload_files,
             cmd::session::zmodem_accept_download,
             cmd::session::zmodem_accept_upload,
             cmd::session::zmodem_cancel,

--- a/src/components/terminal/zmodemTerminalEvents.test.ts
+++ b/src/components/terminal/zmodemTerminalEvents.test.ts
@@ -1,0 +1,191 @@
+import type { Terminal } from "@xterm/xterm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  completePendingZmodemUpload: vi.fn(),
+  failPendingZmodemUpload: vi.fn(),
+  getPendingZmodemUploadConflictMode: vi.fn(),
+  getPendingZmodemUploadPaths: vi.fn(),
+  hasPendingZmodemUpload: vi.fn(),
+  markPendingZmodemUploadActive: vi.fn(),
+  probeAndResolveRemoteConflicts: vi.fn(),
+  toastDismiss: vi.fn(),
+  toastError: vi.fn(),
+  toastMessage: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/lib/invoke", () => ({ invoke: mocks.invoke }));
+vi.mock("@/lib/terminalZmodemUpload", () => ({
+  completePendingZmodemUpload: mocks.completePendingZmodemUpload,
+  failPendingZmodemUpload: mocks.failPendingZmodemUpload,
+  getPendingZmodemUploadConflictMode: mocks.getPendingZmodemUploadConflictMode,
+  getPendingZmodemUploadPaths: mocks.getPendingZmodemUploadPaths,
+  hasPendingZmodemUpload: mocks.hasPendingZmodemUpload,
+  markPendingZmodemUploadActive: mocks.markPendingZmodemUploadActive,
+  probeAndResolveRemoteConflicts: mocks.probeAndResolveRemoteConflicts,
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    dismiss: mocks.toastDismiss,
+    error: mocks.toastError,
+    message: mocks.toastMessage,
+    success: mocks.toastSuccess,
+  },
+}));
+
+import { createZmodemEventHandler } from "./zmodemTerminalEvents";
+
+function createHandler() {
+  const writeTerminalStatus = vi.fn();
+  const terminal = { write: vi.fn() } as unknown as Terminal;
+  const handler = createZmodemEventHandler(
+    terminal,
+    "ssh-1",
+    () => (key) => key,
+    () => "ask",
+    undefined,
+    writeTerminalStatus,
+  );
+  return { handler, writeTerminalStatus };
+}
+
+describe("zmodem detected file pickers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPendingZmodemUploadConflictMode.mockReturnValue("overwrite");
+    mocks.getPendingZmodemUploadPaths.mockReturnValue(null);
+    mocks.hasPendingZmodemUpload.mockReturnValue(false);
+    mocks.probeAndResolveRemoteConflicts.mockResolvedValue({
+      paths: [],
+      probeSkipped: false,
+      conflictMode: "overwrite",
+    });
+    mocks.toastMessage.mockReturnValue("zmodem-upload");
+    mocks.invoke.mockResolvedValue(undefined);
+  });
+
+  it("accepts a selected download folder through the ZMODEM picker command", async () => {
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "zmodem_pick_download_dir") {
+        return Promise.resolve("C:\\Downloads");
+      }
+      return Promise.resolve(undefined);
+    });
+    const { handler } = createHandler();
+
+    handler.handle({ type: "detected", direction: "download" });
+
+    await vi.waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("zmodem_accept_download", {
+        sessionId: "ssh-1",
+        saveDir: "C:\\Downloads",
+      }),
+    );
+    expect(mocks.invoke).toHaveBeenCalledWith("zmodem_pick_download_dir");
+    expect(mocks.invoke).not.toHaveBeenCalledWith(
+      "zmodem_cancel",
+      expect.anything(),
+    );
+  });
+
+  it("cancels ZMODEM when the download folder picker is closed", async () => {
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "zmodem_pick_download_dir") {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(undefined);
+    });
+    const { handler, writeTerminalStatus } = createHandler();
+
+    handler.handle({ type: "detected", direction: "download" });
+
+    await vi.waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("zmodem_cancel", {
+        sessionId: "ssh-1",
+      }),
+    );
+    expect(mocks.invoke).not.toHaveBeenCalledWith(
+      "zmodem_accept_download",
+      expect.anything(),
+    );
+    expect(writeTerminalStatus).toHaveBeenLastCalledWith(
+      expect.stringContaining("zmodem.cancelled"),
+    );
+  });
+
+  it("probes conflicts before accepting files selected for upload", async () => {
+    const selectedPaths = ["C:\\tmp\\first.txt", "C:\\tmp\\second.txt"];
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "zmodem_pick_upload_files") {
+        return Promise.resolve(selectedPaths);
+      }
+      return Promise.resolve(undefined);
+    });
+    mocks.probeAndResolveRemoteConflicts.mockResolvedValue({
+      paths: selectedPaths,
+      probeSkipped: false,
+      conflictMode: "overwrite",
+    });
+    const { handler } = createHandler();
+
+    handler.handle({ type: "detected", direction: "upload" });
+
+    await vi.waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("zmodem_accept_upload", {
+        sessionId: "ssh-1",
+        filePaths: selectedPaths,
+        conflictMode: "overwrite",
+      }),
+    );
+    expect(mocks.invoke).toHaveBeenCalledWith("zmodem_pick_upload_files");
+    expect(mocks.probeAndResolveRemoteConflicts).toHaveBeenCalledWith(
+      "ssh-1",
+      selectedPaths,
+      "ask",
+    );
+  });
+
+  it("cancels ZMODEM when the upload file picker is closed", async () => {
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "zmodem_pick_upload_files") {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(undefined);
+    });
+    const { handler, writeTerminalStatus } = createHandler();
+
+    handler.handle({ type: "detected", direction: "upload" });
+
+    await vi.waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("zmodem_cancel", {
+        sessionId: "ssh-1",
+      }),
+    );
+    expect(mocks.probeAndResolveRemoteConflicts).not.toHaveBeenCalled();
+    expect(writeTerminalStatus).toHaveBeenLastCalledWith(
+      expect.stringContaining("zmodem.cancelled"),
+    );
+  });
+
+  it("bypasses the picker when upload paths are already pending", async () => {
+    const pendingPaths = ["C:\\tmp\\ready.txt"];
+    mocks.getPendingZmodemUploadPaths.mockReturnValue(pendingPaths);
+    mocks.getPendingZmodemUploadConflictMode.mockReturnValue("skip");
+    mocks.hasPendingZmodemUpload.mockReturnValue(true);
+    const { handler } = createHandler();
+
+    handler.handle({ type: "detected", direction: "upload" });
+
+    await vi.waitFor(() =>
+      expect(mocks.invoke).toHaveBeenCalledWith("zmodem_accept_upload", {
+        sessionId: "ssh-1",
+        filePaths: pendingPaths,
+        conflictMode: "skip",
+      }),
+    );
+    expect(mocks.invoke).not.toHaveBeenCalledWith("zmodem_pick_upload_files");
+    expect(mocks.probeAndResolveRemoteConflicts).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/terminal/zmodemTerminalEvents.ts
+++ b/src/components/terminal/zmodemTerminalEvents.ts
@@ -278,12 +278,11 @@ export function createZmodemEventHandler(
     payload: Extract<NormalizedZmodemPayload, { type: "detected" }>,
   ) => {
     const t = getT();
-    const { open: openDialog } = await import("@tauri-apps/plugin-dialog");
     if (disposed) return;
 
     if (payload.direction === "download") {
       writeTerminalStatus(`\r\n\x1b[36m[ZMODEM] ${t("zmodem.selectSaveDir")}\x1b[0m\r\n`);
-      const dir = await openDialog({ directory: true, multiple: false });
+      const dir = await invoke<string | null>("zmodem_pick_download_dir");
       if (disposed) return;
       if (dir) {
         await invoke("zmodem_accept_download", {
@@ -319,7 +318,7 @@ export function createZmodemEventHandler(
       return;
     }
 
-    const selected = await openDialog({ multiple: true });
+    const selected = await invoke<string[] | null>("zmodem_pick_upload_files");
     if (disposed) return;
     if (selected && selected.length > 0) {
       const filePaths = selected.map(String);


### PR DESCRIPTION
## 修复

为 ZMODEM 的 `sz` 保存目录和 `rz` 多文件选择新增 Rust 侧非阻塞 picker 命令，使用 dialog callback API 并通过 oneshot 将结果返回前端；Windows/macOS 继续绑定当前窗口。前端仅在 ZMODEM detected 流程改用新命令，保留取消提示、远端冲突探测、`zmodem_accept_*` 以及已准备上传文件的快速路径，其他 dialog 与 ZMODEM 协议逻辑不变。

## 验证

新增 5 个回归测试覆盖下载选择/取消、上传选择/取消和 pending upload 绕过 picker；Rust 检查、前端 lint 和生产构建均通过。当前环境无法运行 Windows 11 GUI，因此 picker 的鼠标显示与实际交互流畅度仍需在 Windows 11 安装版确认。

Fixes #565