### PR TITLE
fix: 修复 Windows 本地终端路径同步

### DIFF
--- a/src-tauri/src/core/terminal_session/local/config.rs
+++ b/src-tauri/src/core/terminal_session/local/config.rs
@@ -7,8 +7,8 @@ pub struct LocalSessionConfig {
     pub fail_on_missing_working_dir: bool,
     pub name: String,
     pub encoding: String,
-    /// When true, enable Local dynamic-title/cwd integration for this
-    /// connection. Command-history confirmation remains an independent policy.
+    /// When true, allow Local dynamic titles to be promoted for this connection.
+    /// Windows cwd tracking and command-history confirmation are independent policies.
     pub dynamic_tab_title: bool,
 }
 

--- a/src-tauri/src/core/terminal_session/local/session.rs
+++ b/src-tauri/src/core/terminal_session/local/session.rs
@@ -1,3 +1,7 @@
+fn local_managed_integration_enabled(dynamic_title_enabled: bool, windows_host: bool) -> bool {
+    windows_host || dynamic_title_enabled
+}
+
 /// Spawns a local shell in a PTY and registers the session with the manager.
 pub async fn create_local_session(
     app: AppHandle,
@@ -33,6 +37,8 @@ pub async fn create_local_session(
     let dynamic_title_enabled = config
         .as_ref()
         .is_some_and(|cfg| cfg.dynamic_tab_title);
+    let managed_integration_enabled =
+        local_managed_integration_enabled(dynamic_title_enabled, cfg!(target_os = "windows"));
     let allow_injection = config.as_ref().is_none_or(|cfg| {
         should_allow_local_injection(
             &cfg.shell_path,
@@ -45,16 +51,16 @@ pub async fn create_local_session(
     let startup = build_local_startup_script(
         &shell_name,
         &ready_marker,
-        dynamic_title_enabled,
+        managed_integration_enabled,
         allow_injection,
     );
-    if dynamic_title_enabled && !startup.dynamic_title_integration_requested {
+    if managed_integration_enabled && !startup.dynamic_title_integration_requested {
         tracing::info!(
             shell = %shell_name,
             custom_argv = config
                 .as_ref()
                 .is_some_and(|cfg| !cfg.shell_args.is_empty()),
-            "Local dynamic-title hook unavailable; continuing in passive title mode"
+            "Local title/cwd hook unavailable; continuing in passive mode"
         );
     }
     let LocalStartupScript {

--- a/src-tauri/src/core/terminal_session/local/startup.rs
+++ b/src-tauri/src/core/terminal_session/local/startup.rs
@@ -1,5 +1,5 @@
-// Local PTY dynamic-title integration. Remote SSH integration remains in
-// `core::ssh::osc` so Local title policy cannot change released SSH/history behavior.
+// Local PTY managed title/cwd integration. Remote SSH integration remains in
+// `core::ssh::osc` so Local policy cannot change released SSH/history behavior.
 
 use crate::core::ssh::osc::{
     ControlSequenceKind, ShellKind, control_sequence_payload, find_control_sequence_end,
@@ -114,15 +114,15 @@ impl LocalStartupScript {
     }
 }
 
-/// Build Local-only dynamic-title hooks. `allow_injection` must be false for
-/// every non-empty user argv and unresolved wrapper shell.
+/// Build Local-only managed title/cwd hooks. `allow_injection` must be false
+/// for every non-empty user argv and unresolved wrapper shell.
 pub fn build_local_startup_script(
     shell_name: &str,
     ready_marker: &str,
-    enabled: bool,
+    managed_integration_enabled: bool,
     allow_injection: bool,
 ) -> LocalStartupScript {
-    if !enabled || !allow_injection {
+    if !managed_integration_enabled || !allow_injection {
         return LocalStartupScript::none();
     }
 

--- a/src-tauri/src/core/terminal_session/local/tests.rs
+++ b/src-tauri/src/core/terminal_session/local/tests.rs
@@ -13,8 +13,9 @@ mod tests {
         ZmodemDirection, apply_working_dir_to_command, build_cmd_prompt,
         build_local_startup_script, cancel_startup_for_pending_zmodem, detect_local_zmodem,
         drain_startup_pipeline_on_cancel, input_cancels_startup_injection,
-        is_unresolved_shell_wrapper, lock_or_recover, managed_cwd_runtime_ready,
-        parse_shell_args, reconcile_managed_cwd_payloads, resolve_shell_command,
+        is_unresolved_shell_wrapper, local_managed_integration_enabled, lock_or_recover,
+        managed_cwd_runtime_ready, parse_shell_args, reconcile_managed_cwd_payloads,
+        resolve_shell_command,
         should_allow_local_injection,
         validate_working_dir_before_spawn,
     };
@@ -1608,6 +1609,34 @@ mod tests {
         let no_inject = build_local_startup_script("powershell.exe", &marker, true, false);
         assert!(!no_inject.dynamic_title_integration_requested);
         assert!(no_inject.pwsh_init_args.is_none());
+    }
+
+    #[test]
+    fn windows_local_cwd_integration_does_not_require_dynamic_titles() {
+        let marker = ready_marker();
+        let dynamic_title_enabled = false;
+        let managed_integration_enabled =
+            local_managed_integration_enabled(dynamic_title_enabled, true);
+        assert!(managed_integration_enabled);
+        assert!(!local_managed_integration_enabled(false, false));
+
+        let pwsh = build_local_startup_script(
+            "powershell.exe",
+            &marker,
+            managed_integration_enabled,
+            true,
+        );
+        assert!(pwsh.dynamic_title_integration_requested);
+        assert!(pwsh.pwsh_init_args.is_some());
+
+        let custom_argv = build_local_startup_script(
+            "powershell.exe",
+            &marker,
+            managed_integration_enabled,
+            false,
+        );
+        assert!(!custom_argv.dynamic_title_integration_requested);
+        assert!(custom_argv.pwsh_init_args.is_none());
     }
 
     #[cfg(target_os = "windows")]

--- a/src/components/panel/file-explorer/FileExplorer.tsx
+++ b/src/components/panel/file-explorer/FileExplorer.tsx
@@ -107,6 +107,7 @@ import {
   buildRemoteUploadPath,
   buildMoveSuccessRefreshPlan,
   buildSessionCacheSnapshot,
+  canTrackTerminalCwd,
   compareFileEntries,
   DEFAULT_FILE_LIST_COLUMN_WIDTHS,
   DEFAULT_FILE_SORT_DIRECTIONS,
@@ -124,6 +125,7 @@ import {
   getLocalPathName,
   type InlineRenameState,
   isParentDirectoryEntry,
+  isSameExplorerDirectory,
   joinExplorerPath,
   type LoadDirectoryOptions,
   MIN_FILE_LIST_COLUMN_WIDTHS,
@@ -136,6 +138,7 @@ import {
   pushVisitedHistory,
   type RemoteTextFile,
   type ResolvedLocalDropPathEntry,
+  subscribeFileExplorerSessionSnapshots,
   syncExplorerDirectoryToTerminalCwd,
   syncExplorerDirectoryToTerminalCwdChange,
   type TextFileOpenResult,
@@ -1038,19 +1041,21 @@ function FileExplorerPane({
       return;
     }
     setRemoteFileBrowserEnabled(hasLocalSession ? true : null);
-    invoke<SessionInfo[]>("list_sessions")
-      .then((sessions) => {
-        const s = sessions.find((s) => s.id === activeSessionId);
-        const active = s?.injection_active ?? false;
-        setCwdTrackingActive(active);
+    return subscribeFileExplorerSessionSnapshots({
+      listenSessionsChanged: (handler) => listen("sessions-changed", handler),
+      readSessions: () => invoke<SessionInfo[]>("list_sessions"),
+      onSessions: (sessions) => {
+        const session = sessions.find((session) => session.id === activeSessionId);
+        setCwdTrackingActive(canTrackTerminalCwd(session));
         setRemoteFileBrowserEnabled(
-          hasLocalSession ? true : (s?.remote_file_browser_enabled ?? true),
+          hasLocalSession ? true : (session?.remote_file_browser_enabled ?? true),
         );
-      })
-      .catch(() => {
+      },
+      onError: () => {
         setCwdTrackingActive(false);
         setRemoteFileBrowserEnabled(true);
-      });
+      },
+    });
   }, [activeSessionId, hasLocalSession, hasSshSession]);
 
   useEffect(() => {
@@ -1460,6 +1465,11 @@ function FileExplorerPane({
       return;
     }
 
+    if (!cwdTrackingActive) {
+      autoSyncCwdMountSyncKeyRef.current = null;
+      return;
+    }
+
     if (!canBrowseFiles || !currentPath) {
       return;
     }
@@ -1492,6 +1502,7 @@ function FileExplorerPane({
     autoSyncScopeId,
     canBrowseFiles,
     currentPath,
+    cwdTrackingActive,
     explorerBackend,
     loadDirectory,
   ]);
@@ -2167,7 +2178,7 @@ function FileExplorerPane({
       const normalizedCwd = normalizeExplorerPath(cwd, backend);
       if (
         normalizedCwd &&
-        normalizedCwd !== normalizeExplorerPath(currentPathRef.current, backend)
+        !isSameExplorerDirectory(normalizedCwd, currentPathRef.current, backend)
       ) {
         loadDirectory(normalizedCwd);
       }

--- a/src/components/panel/file-explorer/model.test.ts
+++ b/src/components/panel/file-explorer/model.test.ts
@@ -3,7 +3,9 @@ import {
   buildMoveSuccessRefreshPlan,
   buildMoveOperations,
   buildMoveTargetPath,
+  canTrackTerminalCwd,
   isMoveToSameDirectory,
+  subscribeFileExplorerSessionSnapshots,
   syncExplorerDirectoryToTerminalCwd,
   syncExplorerDirectoryToTerminalCwdChange,
 } from "./model";
@@ -122,6 +124,88 @@ describe("file explorer move path helpers", () => {
 });
 
 describe("file explorer terminal cwd sync", () => {
+  it("uses the Local managed cwd integration capability instead of command injection", () => {
+    expect(
+      canTrackTerminalCwd({
+        session_type: "Local",
+        injection_active: false,
+        dynamic_title_integration_active: true,
+      }),
+    ).toBe(true);
+    expect(
+      canTrackTerminalCwd({
+        session_type: "Local",
+        injection_active: true,
+        dynamic_title_integration_active: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps SSH cwd tracking tied to command injection", () => {
+    expect(
+      canTrackTerminalCwd({
+        session_type: "SSH",
+        injection_active: true,
+        dynamic_title_integration_active: false,
+      }),
+    ).toBe(true);
+    expect(
+      canTrackTerminalCwd({
+        session_type: "SSH",
+        injection_active: false,
+        dynamic_title_integration_active: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("registers sessions-changed before the initial snapshot and observes Local ready", async () => {
+    let resolveListen!: (dispose: () => void) => void;
+    let sessionsChanged!: () => void;
+    let integrationActive = false;
+    let cwdTrackingActive = false;
+    const readSessions = vi.fn(async () => [
+      {
+        session_type: "Local" as const,
+        injection_active: false,
+        dynamic_title_integration_active: integrationActive,
+      },
+    ]);
+    const listenSessionsChanged = vi.fn(
+      (handler: () => void) =>
+        new Promise<() => void>((resolve) => {
+          sessionsChanged = handler;
+          resolveListen = resolve;
+        }),
+    );
+
+    const stop = subscribeFileExplorerSessionSnapshots({
+      listenSessionsChanged,
+      readSessions,
+      onSessions: (sessions) => {
+        cwdTrackingActive = canTrackTerminalCwd(sessions[0]);
+      },
+      onError: vi.fn(),
+    });
+
+    await Promise.resolve();
+    expect(readSessions).not.toHaveBeenCalled();
+
+    resolveListen(() => {});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(readSessions).toHaveBeenCalledTimes(1);
+    expect(cwdTrackingActive).toBe(false);
+
+    integrationActive = true;
+    sessionsChanged();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(readSessions).toHaveBeenCalledTimes(2);
+    expect(cwdTrackingActive).toBe(true);
+
+    stop();
+  });
+
   it("loads the terminal cwd silently when auto-sync is enabled and the path changed", async () => {
     const readTerminalCwd = vi.fn().mockResolvedValue("/new");
     const loadDirectory = vi.fn().mockResolvedValue(true);
@@ -159,6 +243,25 @@ describe("file explorer terminal cwd sync", () => {
     ).resolves.toBe(false);
 
     expect(readTerminalCwd).toHaveBeenCalledWith("session-1");
+    expect(loadDirectory).not.toHaveBeenCalled();
+  });
+
+  it("does not reload a Windows Local path for drive-case or trailing-separator differences", async () => {
+    const readTerminalCwd = vi.fn().mockResolvedValue("c:\\Work\\Project\\");
+    const loadDirectory = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      syncExplorerDirectoryToTerminalCwd({
+        enabled: true,
+        canBrowseFiles: true,
+        sessionId: "session-1",
+        backend: "local",
+        currentPath: "C:\\Work\\Project",
+        readTerminalCwd,
+        loadDirectory,
+      }),
+    ).resolves.toBe(false);
+
     expect(loadDirectory).not.toHaveBeenCalled();
   });
 
@@ -245,6 +348,21 @@ describe("file explorer terminal cwd sync", () => {
         backend: "remote",
         currentPath: "/old",
         cwd: "/old/",
+        loadDirectory,
+      }),
+    ).toBe(false);
+
+    expect(loadDirectory).not.toHaveBeenCalled();
+  });
+
+  it("ignores Windows Local cwd events that differ only by drive case or trailing separator", () => {
+    const loadDirectory = vi.fn().mockResolvedValue(true);
+
+    expect(
+      syncExplorerDirectoryToTerminalCwdChange({
+        backend: "local",
+        currentPath: "C:\\Work\\Project",
+        cwd: "c:\\Work\\Project\\",
         loadDirectory,
       }),
     ).toBe(false);

--- a/src/components/panel/file-explorer/model.ts
+++ b/src/components/panel/file-explorer/model.ts
@@ -1,4 +1,4 @@
-import type { FileEntry } from "@/types/global";
+import type { FileEntry, SessionInfo } from "@/types/global";
 
 export interface ResolvedLocalDropPathEntry {
   path: string;
@@ -43,6 +43,72 @@ export type LoadDirectoryOptions = {
 };
 
 export type FileExplorerBackendKind = "remote" | "local";
+
+export function canTrackTerminalCwd(
+  session:
+    | Pick<
+        SessionInfo,
+        "session_type" | "injection_active" | "dynamic_title_integration_active"
+      >
+    | null
+    | undefined,
+) {
+  if (!session) return false;
+  if (session.session_type === "Local") {
+    return session.dynamic_title_integration_active;
+  }
+  return session.session_type === "SSH" && session.injection_active;
+}
+
+export function subscribeFileExplorerSessionSnapshots<T>({
+  listenSessionsChanged,
+  readSessions,
+  onSessions,
+  onError,
+}: {
+  listenSessionsChanged: (handler: () => void) => Promise<() => void>;
+  readSessions: () => Promise<T[]>;
+  onSessions: (sessions: T[]) => void;
+  onError: () => void;
+}) {
+  let cancelled = false;
+  let refreshGeneration = 0;
+
+  const refreshSessions = () => {
+    const generation = ++refreshGeneration;
+    void readSessions()
+      .then((sessions) => {
+        if (cancelled || generation !== refreshGeneration) return;
+        onSessions(sessions);
+      })
+      .catch(() => {
+        if (cancelled || generation !== refreshGeneration) return;
+        onError();
+      });
+  };
+
+  const listener = listenSessionsChanged(refreshSessions)
+    .then((dispose) => {
+      if (cancelled) {
+        dispose();
+        return null;
+      }
+      // Register before taking the initial snapshot so a Local ready event
+      // cannot land between list_sessions and sessions-changed subscription.
+      refreshSessions();
+      return dispose;
+    })
+    .catch(() => {
+      if (!cancelled) onError();
+      return null;
+    });
+
+  return () => {
+    cancelled = true;
+    refreshGeneration += 1;
+    void listener.then((dispose) => dispose?.());
+  };
+}
 
 export type BreadcrumbSegment = {
   id: string;
@@ -678,23 +744,25 @@ export function isMoveToSameDirectory(
   targetDirectory: string,
   backend: FileExplorerBackendKind,
 ) {
-  const normalizedSourceDirectory = normalizeExplorerPath(
-    sourceDirectory,
-    backend,
-  );
-  const normalizedTargetDirectory = normalizeExplorerPath(
-    targetDirectory,
-    backend,
-  );
-  if (!normalizedSourceDirectory || !normalizedTargetDirectory) return false;
+  return isSameExplorerDirectory(sourceDirectory, targetDirectory, backend);
+}
+
+export function isSameExplorerDirectory(
+  firstPath: string,
+  secondPath: string,
+  backend: FileExplorerBackendKind,
+) {
+  const normalizedFirstPath = normalizeExplorerPath(firstPath, backend);
+  const normalizedSecondPath = normalizeExplorerPath(secondPath, backend);
+  if (!normalizedFirstPath || !normalizedSecondPath) return false;
   if (backend === "remote") {
-    return normalizedSourceDirectory === normalizedTargetDirectory;
+    return normalizedFirstPath === normalizedSecondPath;
   }
-  return isLocalWindowsStylePath(normalizedSourceDirectory) ||
-    isLocalWindowsStylePath(normalizedTargetDirectory)
-    ? normalizedSourceDirectory.toLocaleLowerCase() ===
-        normalizedTargetDirectory.toLocaleLowerCase()
-    : normalizedSourceDirectory === normalizedTargetDirectory;
+  return isLocalWindowsStylePath(normalizedFirstPath) ||
+    isLocalWindowsStylePath(normalizedSecondPath)
+    ? normalizedFirstPath.toLocaleLowerCase() ===
+        normalizedSecondPath.toLocaleLowerCase()
+    : normalizedFirstPath === normalizedSecondPath;
 }
 
 export function buildMoveSuccessRefreshPlan(
@@ -867,7 +935,7 @@ export function syncExplorerDirectoryToTerminalCwdChange({
   const normalizedCwd = normalizeExplorerPath(cwd, backend);
   if (
     !normalizedCwd ||
-    normalizedCwd === normalizeExplorerPath(currentPath, backend)
+    isSameExplorerDirectory(normalizedCwd, currentPath, backend)
   ) {
     return false;
   }
@@ -892,7 +960,7 @@ export async function syncExplorerDirectoryToTerminalCwd({
       (await readTerminalCwd(sessionId)) ?? "",
       backend,
     );
-    if (!cwd || cwd === normalizeExplorerPath(currentPath, backend)) {
+    if (!cwd || isSameExplorerDirectory(cwd, currentPath, backend)) {
       return false;
     }
     return loadDirectory(cwd, { silent: true });


### PR DESCRIPTION
## 修复

- 将 Windows Local cwd shell 集成与动态标签标题显示策略解耦，在关闭动态标题时仍为可安全注入的受支持 shell 提供 cwd 跟踪，同时保持自定义 argv、包装器及命令确认策略不变。
- 文件浏览器按 Local 的 `dynamic_title_integration_active` 和 SSH 的 `injection_active` 判断 cwd 能力，并改为先注册 `sessions-changed` 再读取初始会话快照，避免 Local ready 事件在初始化窗口中丢失。
- Windows 本地路径同步复用等价目录判断，避免仅驱动器字母大小写或尾部分隔符差异触发重复加载。

## 验证

前端 cwd/监听顺序回归、lint 和生产构建均通过；未变的 Rust Local 候选测试二进制也通过全部 48 个测试。常规 Rust 重链接仅因当前工作机磁盘空间不足而无法完成。

Fixes #563