### PR TITLE
fix(ui): align checkable menu item icons

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1480,8 +1480,10 @@ export default function Header({
             item.action?.();
           }}
         >
-          {item.icon && (
-            <DynamicIcon name={item.icon} className="text-[1rem] text-[var(--df-text-muted)]" />
+          {!item.checked && item.icon && (
+            <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+              <DynamicIcon name={item.icon} className="text-[1rem] text-[var(--df-text-muted)]" />
+            </span>
           )}
           <span className="flex-1">{item.label}</span>
           {item.shortcut && <MenubarShortcut>{item.shortcut}</MenubarShortcut>}


### PR DESCRIPTION
## Summary

- Reuse the existing leading accessory slot for checked menu items.
- Show the functional icon when unchecked and the checkmark when checked.
- Keep menu labels aligned without adding an extra leading column.
- Apply the behavior generically to all checked menu items that also define an icon.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint src/components/layout/Header.tsx`
- `git diff --check`

## Notes

`biome check` / `prettier --check` still report pre-existing formatting and import-order differences in `Header.tsx`; this PR intentionally avoids unrelated whole-file formatting changes.
