### PR TITLE
feat(suggestions): show full command in tooltip for truncated suggestions

### DIFF
--- a/src/components/terminal/CommandSuggestions.tsx
+++ b/src/components/terminal/CommandSuggestions.tsx
@@ -84,7 +84,7 @@ function SuggestionText({
     if (el) {
       setTruncated(el.scrollWidth > el.clientWidth);
     }
-  });
+  }, [result.display]);
 
   if (!truncated) {
     return (
@@ -108,7 +108,7 @@ function SuggestionText({
       </TooltipTrigger>
       <TooltipContent
         side="top"
-        className="max-w-[600px]"
+        className="z-[10000] max-w-[600px]"
         onMouseDown={(e) => e.preventDefault()}
       >
         <span className="font-mono text-[0.75rem] break-all">{result.command}</span>

--- a/src/components/terminal/CommandSuggestions.tsx
+++ b/src/components/terminal/CommandSuggestions.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MdDelete, MdFlashOn, MdHistory, MdTipsAndUpdates } from "react-icons/md";
 import { Button } from "@/components/ui/button";
@@ -64,6 +64,56 @@ function HighlightedCommand({ text, indices }: { text: string; indices: number[]
         ),
       )}
     </span>
+  );
+}
+
+/** Suggestion text with truncation-aware tooltip. Only shows tooltip when text overflows. */
+function SuggestionText({
+  result,
+  isSelected,
+}: {
+  result: FuzzyResult;
+  isSelected: boolean;
+}) {
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (el) {
+      setTruncated(el.scrollWidth > el.clientWidth);
+    }
+  });
+
+  if (!truncated) {
+    return (
+      <span ref={textRef} className="min-w-0 flex-1 truncate">
+        <HighlightedCommand text={result.display} indices={result.indices} />
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip open={isSelected || hovered}>
+      <TooltipTrigger asChild>
+        <span
+          ref={textRef}
+          className="min-w-0 flex-1 truncate"
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          <HighlightedCommand text={result.display} indices={result.indices} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        className="max-w-[600px]"
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        <span className="font-mono text-[0.75rem] break-all">{result.command}</span>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -148,9 +198,10 @@ function CommandSuggestions({
                 color: index === selectedIndex ? "var(--df-accent)" : "var(--df-text-dimmed)",
               }}
             />
-            <span className="min-w-0 flex-1 truncate">
-              <HighlightedCommand text={result.display} indices={result.indices} />
-            </span>
+            <SuggestionText
+              result={result}
+              isSelected={index === selectedIndex}
+            />
             {deleteHistory && (
               <Tooltip>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
## Problem

When using command suggestions (smart completion), if two long commands share the same prefix, they both get truncated to fit the 380px popup width. This makes it impossible to distinguish between them, as the differentiating part is cut off.

> 智能补全时候遇到2条较长的命令，且前面部分一样时候，无法分辨出2条命名的区别

Ref: #593

## Solution

Add a **truncation-aware tooltip** to each suggestion item in the popup:

1. **Runtime truncation detection**: Each suggestion item checks whether its text overflows the available width (`scrollWidth > clientWidth`).
2. **Tooltip only for truncated items**: Non-truncated items render as plain text without any tooltip overlay, avoiding unnecessary UI noise.
3. **Full command display**: The tooltip shows the complete command text with `break-all` wrapping and a `max-w-[600px]` cap, so the user can see the entire command.
4. **Keyboard + mouse support**: The tooltip opens both on:
   - **Mouse hover** — hover over any truncated suggestion item
   - **Keyboard selection** — use ↑/↓ arrow keys to navigate; the selected item's tooltip automatically opens

## Changes

- [src/components/terminal/CommandSuggestions.tsx](cci:7://file:///Users/Terry/it/source/git/nyaterm/src/components/terminal/CommandSuggestions.tsx:0:0-0:0):
  - Extracted [SuggestionText](cci:1://file:///Users/Terry/it/source/git/nyaterm/src/components/terminal/CommandSuggestions.tsx:69:0-117:1) component with truncation detection
  - Added controlled [Tooltip](cci:1://file:///Users/Terry/it/source/git/nyaterm/src/components/ui/tooltip.tsx:9:0-15:1) that opens on hover or keyboard selection
  - Tooltip content shows `result.command` (the actual command, not the display label)

Closes #593