### PR TITLE
fix: 恢复前台终端输入焦点

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -800,6 +800,13 @@ function App() {
     : "";
   const windowTitle = activeTabName ? `${activeTabName} - NyaTerm` : "NyaTerm";
   const activePane = activeTab ? getActivePane(activeTab) : null;
+  const activeSessionId =
+    activePane &&
+    activePane.paneKind === "terminal" &&
+    !activePane.connecting &&
+    !activePane.connectError
+      ? activePane.sessionId
+      : null;
   const activeConnection = activePane?.connectionId
     ? (savedConnections.find((connection) => connection.id === activePane.connectionId) ?? null)
     : null;
@@ -3198,6 +3205,7 @@ function App() {
     handleResetActivityBarLayout,
   } = useActivityBarController({
     uiConfig,
+    activeSessionId,
     recordingSessions,
     multiPanelOpen,
     panelOpenMode,
@@ -3210,13 +3218,6 @@ function App() {
 
   // --- Panel content rendering (side-independent) ---
 
-  const activeSessionId =
-    activePane &&
-    activePane.paneKind === "terminal" &&
-    !activePane.connecting &&
-    !activePane.connectError
-      ? activePane.sessionId
-      : null;
   useMcpActiveSession(activeSessionId);
   const activeSshSessionId =
     activePane &&

--- a/src/components/layout/ActivityBar.focus.test.tsx
+++ b/src/components/layout/ActivityBar.focus.test.tsx
@@ -1,0 +1,65 @@
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { preventActivityBarSettingsMouseFocus } from "./ActivityBar";
+
+describe("ActivityBar settings focus", () => {
+  it("keeps content focus on primary mouse down while preserving click", () => {
+    const onClick = vi.fn();
+    render(<ActivityBarButtonHarness itemId="settings" onClick={onClick} />);
+    const contentInput = screen.getByLabelText("content");
+    const button = screen.getByRole("button", { name: "settings" });
+    contentInput.focus();
+    const mouseDown = createEvent.mouseDown(button, { button: 0 });
+
+    fireEvent(button, mouseDown);
+    fireEvent.click(button);
+
+    expect(mouseDown.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(contentInput);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("does not change mouse focus behavior for other activity items", () => {
+    render(<ActivityBarButtonHarness itemId="fileExplorer" />);
+    const button = screen.getByRole("button", { name: "fileExplorer" });
+    const mouseDown = createEvent.mouseDown(button, { button: 0 });
+
+    fireEvent(button, mouseDown);
+
+    expect(mouseDown.defaultPrevented).toBe(false);
+  });
+
+  it.each(["{Enter}", " "])("still supports keyboard activation with %s", async (key) => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<ActivityBarButtonHarness itemId="settings" onClick={onClick} />);
+    const button = screen.getByRole("button", { name: "settings" });
+    button.focus();
+
+    await user.keyboard(key);
+
+    expect(document.activeElement).toBe(button);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});
+
+function ActivityBarButtonHarness({
+  itemId,
+  onClick = vi.fn(),
+}: {
+  itemId: string;
+  onClick?: () => void;
+}) {
+  return (
+    <>
+      <input aria-label="content" />
+      <button
+        type="button"
+        aria-label={itemId}
+        onMouseDown={(event) => preventActivityBarSettingsMouseFocus(event, itemId)}
+        onClick={onClick}
+      />
+    </>
+  );
+}

--- a/src/components/layout/ActivityBar.focus.test.tsx
+++ b/src/components/layout/ActivityBar.focus.test.tsx
@@ -1,65 +1,65 @@
 import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { preventActivityBarSettingsMouseFocus } from "./ActivityBar";
+import ActivityBar from "./ActivityBar";
 
-describe("ActivityBar settings focus", () => {
-  it("keeps content focus on primary mouse down while preserving click", () => {
-    const onClick = vi.fn();
-    render(<ActivityBarButtonHarness itemId="settings" onClick={onClick} />);
-    const contentInput = screen.getByLabelText("content");
-    const button = screen.getByRole("button", { name: "settings" });
-    contentInput.focus();
+describe("ActivityBar settings interactions", () => {
+  it("keeps the native drag path and mouse activation for settings", () => {
+    const onSelect = vi.fn();
+    renderActivityBar(onSelect);
+    const button = screen.getByRole("button", { name: "Settings" });
     const mouseDown = createEvent.mouseDown(button, { button: 0 });
+    const dataTransfer = {
+      effectAllowed: "",
+      setData: vi.fn(),
+    } as unknown as DataTransfer;
 
     fireEvent(button, mouseDown);
+    fireEvent.dragStart(button, { dataTransfer });
     fireEvent.click(button);
 
-    expect(mouseDown.defaultPrevented).toBe(true);
-    expect(document.activeElement).toBe(contentInput);
-    expect(onClick).toHaveBeenCalledOnce();
-  });
-
-  it("does not change mouse focus behavior for other activity items", () => {
-    render(<ActivityBarButtonHarness itemId="fileExplorer" />);
-    const button = screen.getByRole("button", { name: "fileExplorer" });
-    const mouseDown = createEvent.mouseDown(button, { button: 0 });
-
-    fireEvent(button, mouseDown);
-
+    expect(button).toHaveProperty("draggable", true);
     expect(mouseDown.defaultPrevented).toBe(false);
+    expect(dataTransfer.setData).toHaveBeenCalledWith(
+      "application/x-nyaterm-activity",
+      JSON.stringify({ id: "settings", zone: "left_bottom" }),
+    );
+    expect(dataTransfer.effectAllowed).toBe("move");
+    expect(onSelect).toHaveBeenCalledWith("settings");
   });
 
   it.each(["{Enter}", " "])("still supports keyboard activation with %s", async (key) => {
     const user = userEvent.setup();
-    const onClick = vi.fn();
-    render(<ActivityBarButtonHarness itemId="settings" onClick={onClick} />);
-    const button = screen.getByRole("button", { name: "settings" });
+    const onSelect = vi.fn();
+    renderActivityBar(onSelect);
+    const button = screen.getByRole("button", { name: "Settings" });
     button.focus();
 
     await user.keyboard(key);
 
     expect(document.activeElement).toBe(button);
-    expect(onClick).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith("settings");
   });
 });
 
-function ActivityBarButtonHarness({
-  itemId,
-  onClick = vi.fn(),
-}: {
-  itemId: string;
-  onClick?: () => void;
-}) {
-  return (
-    <>
-      <input aria-label="content" />
-      <button
-        type="button"
-        aria-label={itemId}
-        onMouseDown={(event) => preventActivityBarSettingsMouseFocus(event, itemId)}
-        onClick={onClick}
-      />
-    </>
+function renderActivityBar(onSelect: (id: string) => void) {
+  render(
+    <ActivityBar
+      items={[]}
+      bottomItems={[{ id: "settings", icon: null, tooltip: "Settings" }]}
+      activeId={null}
+      onSelect={onSelect}
+      onReorder={vi.fn()}
+      onMoveItem={vi.fn()}
+      onHideItem={vi.fn()}
+      onShowItem={vi.fn()}
+      onToggleLabel={vi.fn()}
+      onRequestResetLayout={vi.fn()}
+      panelOpenMode="docked"
+      onPanelOpenModeChange={vi.fn()}
+      showLabels
+      side="left"
+      zone={{ top: "left_top", bottom: "left_bottom" }}
+    />,
   );
 }

--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -1,5 +1,6 @@
 import {
   type DragEvent,
+  type MouseEvent,
   type MutableRefObject,
   type PointerEvent,
   type ReactNode,
@@ -38,6 +39,15 @@ export interface ActivityBarItem {
 
 const DRAG_MIME = "application/x-nyaterm-activity";
 const POINTER_DRAG_THRESHOLD_PX = 4;
+
+export function preventActivityBarSettingsMouseFocus(
+  event: MouseEvent<HTMLButtonElement>,
+  itemId: string,
+) {
+  if (itemId === "settings" && event.button === 0) {
+    event.preventDefault();
+  }
+}
 
 interface PointerActivityDragState {
   itemId: string;
@@ -562,6 +572,7 @@ function ActivityBarButton({
               onPointerMove={onPointerMove}
               onPointerUp={onPointerEnd}
               onPointerCancel={onPointerCancel}
+              onMouseDown={(event) => preventActivityBarSettingsMouseFocus(event, item.id)}
               onContextMenu={(event) => event.stopPropagation()}
               className={`relative flex flex-col items-center justify-center w-full transition-colors ${showLabel ? "min-h-12 gap-0.5 py-1" : "h-9"}`}
               style={{

--- a/src/components/layout/ActivityBar.tsx
+++ b/src/components/layout/ActivityBar.tsx
@@ -1,6 +1,5 @@
 import {
   type DragEvent,
-  type MouseEvent,
   type MutableRefObject,
   type PointerEvent,
   type ReactNode,
@@ -39,15 +38,6 @@ export interface ActivityBarItem {
 
 const DRAG_MIME = "application/x-nyaterm-activity";
 const POINTER_DRAG_THRESHOLD_PX = 4;
-
-export function preventActivityBarSettingsMouseFocus(
-  event: MouseEvent<HTMLButtonElement>,
-  itemId: string,
-) {
-  if (itemId === "settings" && event.button === 0) {
-    event.preventDefault();
-  }
-}
 
 interface PointerActivityDragState {
   itemId: string;
@@ -572,7 +562,6 @@ function ActivityBarButton({
               onPointerMove={onPointerMove}
               onPointerUp={onPointerEnd}
               onPointerCancel={onPointerCancel}
-              onMouseDown={(event) => preventActivityBarSettingsMouseFocus(event, item.id)}
               onContextMenu={(event) => event.stopPropagation()}
               className={`relative flex flex-col items-center justify-center w-full transition-colors ${showLabel ? "min-h-12 gap-0.5 py-1" : "h-9"}`}
               style={{

--- a/src/components/terminal/useTerminalRefreshEffects.test.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.test.ts
@@ -32,6 +32,7 @@ describe("useTerminalRefreshEffects", () => {
   beforeEach(() => {
     windowMocks.focusChanged = undefined;
     windowMocks.scaleChanged = undefined;
+    vi.restoreAllMocks();
   });
 
   it("repaints an active visible terminal without texture invalidation", () => {
@@ -61,11 +62,63 @@ describe("useTerminalRefreshEffects", () => {
     expect(activeRefresh).not.toHaveProperty("clearTextureAtlas");
   });
 
-  it("forces fit and repaint without stealing focus when the native window regains focus", async () => {
+  it("restores the terminal that owned input focus when the native window regains focus", async () => {
     const schedule = vi.fn();
+    const focus = vi.fn();
+    const textarea = document.createElement("textarea");
+    document.body.append(textarea);
+    textarea.focus();
     renderHook(() =>
       useTerminalRefreshEffects({
-        terminalRef: { current: {} as Terminal },
+        terminalRef: { current: { textarea, focus } as unknown as Terminal },
+        fitSchedulerRef: {
+          current: { schedule } as unknown as TerminalFitScheduler,
+        },
+        active: true,
+        visible: true,
+        terminalReady: true,
+        performanceMode: "normal",
+        sessionId: "session-1",
+        showGutter: false,
+        showContentPadding: false,
+      }),
+    );
+    await waitFor(() => expect(windowMocks.focusChanged).toBeTypeOf("function"));
+    schedule.mockClear();
+    const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    textarea.dispatchEvent(new FocusEvent("blur", { relatedTarget: null }));
+
+    windowMocks.focusChanged?.({ payload: false });
+    expect(schedule).not.toHaveBeenCalled();
+    expect(focus).not.toHaveBeenCalled();
+
+    hasFocus.mockReturnValue(true);
+    windowMocks.focusChanged?.({ payload: true });
+    expect(schedule).toHaveBeenCalledTimes(1);
+    expect(focus).toHaveBeenCalledOnce();
+    expect(schedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "window-focus",
+        force: true,
+        refresh: true,
+        clearTextureAtlas: false,
+        focus: false,
+      }),
+    );
+  });
+
+  it("does not reclaim focus after another in-app control owns DOM focus", async () => {
+    const schedule = vi.fn();
+    const focus = vi.fn();
+    const textarea = document.createElement("textarea");
+    const searchInput = document.createElement("input");
+    document.body.append(textarea, searchInput);
+    textarea.focus();
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    renderHook(() =>
+      useTerminalRefreshEffects({
+        terminalRef: { current: { textarea, focus } as unknown as Terminal },
         fitSchedulerRef: {
           current: { schedule } as unknown as TerminalFitScheduler,
         },
@@ -81,18 +134,55 @@ describe("useTerminalRefreshEffects", () => {
     await waitFor(() => expect(windowMocks.focusChanged).toBeTypeOf("function"));
     schedule.mockClear();
 
-    windowMocks.focusChanged?.({ payload: false });
-    expect(schedule).not.toHaveBeenCalled();
-
+    textarea.dispatchEvent(
+      new FocusEvent("blur", {
+        relatedTarget: searchInput,
+      }),
+    );
     windowMocks.focusChanged?.({ payload: true });
-    expect(schedule).toHaveBeenCalledTimes(1);
+
+    expect(focus).not.toHaveBeenCalled();
     expect(schedule).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "window-focus",
         force: true,
         refresh: true,
-        clearTextureAtlas: false,
         focus: false,
+      }),
+    );
+  });
+
+  it("keeps the active refresh focus path when a hidden terminal becomes active and visible", () => {
+    const schedule = vi.fn();
+    const terminalRef = { current: {} as Terminal };
+    const fitSchedulerRef = {
+      current: { schedule } as unknown as TerminalFitScheduler,
+    };
+    const { rerender } = renderHook(
+      ({ active, visible }) =>
+        useTerminalRefreshEffects({
+          terminalRef,
+          fitSchedulerRef,
+          active,
+          visible,
+          terminalReady: true,
+          performanceMode: "normal",
+          sessionId: "session-1",
+          showGutter: false,
+          showContentPadding: false,
+        }),
+      { initialProps: { active: false, visible: false } },
+    );
+    schedule.mockClear();
+
+    rerender({ active: true, visible: true });
+
+    expect(schedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "active",
+        force: true,
+        refresh: true,
+        focus: true,
       }),
     );
   });

--- a/src/components/terminal/useTerminalRefreshEffects.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.ts
@@ -124,6 +124,8 @@ export function useTerminalRefreshEffects({
     if (!terminalReady) return;
 
     let disposed = false;
+    const terminalTextarea = terminalRef.current?.textarea ?? null;
+    let terminalOwnedInputFocus = document.activeElement === terminalTextarea;
     let unlistenResized: (() => void) | undefined;
     let unlistenMoved: (() => void) | undefined;
     let unlistenFocused: (() => void) | undefined;
@@ -181,7 +183,19 @@ export function useTerminalRefreshEffects({
       installResolutionListener();
     };
 
+    const handleTerminalFocus = () => {
+      terminalOwnedInputFocus = true;
+    };
+
+    const handleTerminalBlur = (event: FocusEvent) => {
+      if (event.relatedTarget !== null && document.hasFocus()) {
+        terminalOwnedInputFocus = false;
+      }
+    };
+
     installResolutionListener();
+    terminalTextarea?.addEventListener("focus", handleTerminalFocus);
+    terminalTextarea?.addEventListener("blur", handleTerminalBlur);
 
     const appWindow = getCurrentWindow();
     appWindow
@@ -202,7 +216,11 @@ export function useTerminalRefreshEffects({
       .catch(() => {});
     appWindow
       .onFocusChanged(({ payload }) => {
-        if (!disposed && payload) scheduleWindowFit("window-focus", true);
+        if (disposed || !payload || snapshotRestoringRef?.current) return;
+        scheduleWindowFit("window-focus", true);
+        if (terminalOwnedInputFocus && active && visible) {
+          terminalRef.current?.focus();
+        }
       })
       .then((unlisten) => {
         unlistenFocused = unlisten;
@@ -220,6 +238,8 @@ export function useTerminalRefreshEffects({
     return () => {
       disposed = true;
       resolutionQuery?.removeEventListener("change", handleResolutionChange);
+      terminalTextarea?.removeEventListener("focus", handleTerminalFocus);
+      terminalTextarea?.removeEventListener("blur", handleTerminalBlur);
       unlistenResized?.();
       unlistenMoved?.();
       unlistenFocused?.();

--- a/src/hooks/useActivityBarController.test.tsx
+++ b/src/hooks/useActivityBarController.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import type { TFunction } from "i18next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cloneDefaultActivityBarLayout } from "@/lib/appWorkspace";
+import type { UiConfig } from "@/types/global";
+import { useActivityBarController } from "./useActivityBarController";
+
+const mocks = vi.hoisted(() => ({
+  focusTerminalSession: vi.fn(),
+  openSettings: vi.fn<() => Promise<unknown>>(),
+}));
+
+vi.mock("@/lib/appSessionFactory", () => ({
+  focusTerminalSession: mocks.focusTerminalSession,
+}));
+
+vi.mock("@/lib/windowManager", () => ({
+  openSettings: mocks.openSettings,
+}));
+
+describe("useActivityBarController settings focus", () => {
+  beforeEach(() => {
+    mocks.focusTerminalSession.mockReset();
+    mocks.openSettings.mockReset();
+  });
+
+  it("restores the session captured when settings was selected", async () => {
+    let resolveSettings: (() => void) | undefined;
+    const settingsPromise = new Promise<void>((resolve) => {
+      resolveSettings = resolve;
+    });
+    mocks.openSettings.mockReturnValue(settingsPromise);
+    const { result, rerender } = renderController("session-1");
+
+    act(() => result.current.handleItemSelect("settings"));
+    rerender({ activeSessionId: "session-2" });
+
+    expect(mocks.openSettings).toHaveBeenCalledOnce();
+    expect(mocks.focusTerminalSession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveSettings?.();
+      await settingsPromise;
+    });
+
+    expect(mocks.focusTerminalSession).toHaveBeenCalledOnce();
+    expect(mocks.focusTerminalSession).toHaveBeenCalledWith("session-1");
+  });
+
+  it("restores focus ownership when opening settings rejects", async () => {
+    let rejectSettings: ((reason?: unknown) => void) | undefined;
+    const settingsPromise = new Promise<void>((_, reject) => {
+      rejectSettings = reject;
+    });
+    mocks.openSettings.mockReturnValue(settingsPromise);
+    const { result } = renderController("session-1");
+
+    act(() => result.current.handleItemSelect("settings"));
+
+    await act(async () => {
+      rejectSettings?.(new Error("settings failed"));
+      await settingsPromise.catch(() => {});
+    });
+
+    expect(mocks.focusTerminalSession).toHaveBeenCalledOnce();
+    expect(mocks.focusTerminalSession).toHaveBeenCalledWith("session-1");
+  });
+});
+
+function renderController(initialActiveSessionId: string | null) {
+  const updateUi = vi.fn();
+  return renderHook(
+    ({ activeSessionId }) =>
+      useActivityBarController({
+        uiConfig: createUiConfig(),
+        activeSessionId,
+        recordingSessions: new Set(),
+        multiPanelOpen: false,
+        panelOpenMode: "docked",
+        onFloatingPanelSelect: vi.fn(),
+        onFloatingPanelMove: vi.fn(),
+        updateUi,
+        setIsLocked: vi.fn(),
+        t: ((key: string) => key) as TFunction,
+      }),
+    { initialProps: { activeSessionId: initialActiveSessionId } },
+  );
+}
+
+function createUiConfig(): UiConfig {
+  return {
+    activity_bar_layout: cloneDefaultActivityBarLayout(),
+    panel_open_mode: "docked",
+    active_left_panel: null,
+    active_right_panel: null,
+    left_open_panels: [],
+    right_open_panels: [],
+    show_notes_panel: true,
+    show_remote_stats: true,
+    show_gpu_monitor: true,
+    show_ascend_npu_monitor: true,
+    show_process_manager: true,
+    show_docker_manager: true,
+  } as unknown as UiConfig;
+}

--- a/src/hooks/useActivityBarController.tsx
+++ b/src/hooks/useActivityBarController.tsx
@@ -36,6 +36,7 @@ import {
   toggleActivityBarItemVisibility,
   type PanelOpenMode,
 } from "@/lib/appWorkspace";
+import { focusTerminalSession } from "@/lib/appSessionFactory";
 import { openSettings } from "@/lib/windowManager";
 import type { ActivityBarLayout, ActivityBarZone, UiConfig } from "@/types/global";
 
@@ -221,6 +222,7 @@ function normalizeActivityBarState(uiConfig: UiConfig): Partial<UiConfig> | null
 
 interface UseActivityBarControllerOptions {
   uiConfig: UiConfig;
+  activeSessionId: string | null;
   recordingSessions: Set<string>;
   multiPanelOpen: boolean;
   panelOpenMode: PanelOpenMode;
@@ -233,6 +235,7 @@ interface UseActivityBarControllerOptions {
 
 export function useActivityBarController({
   uiConfig,
+  activeSessionId,
   recordingSessions,
   multiPanelOpen,
   panelOpenMode,
@@ -328,7 +331,9 @@ export function useActivityBarController({
   const handleItemSelect = useCallback(
     (id: string) => {
       if (id === "settings") {
-        openSettings();
+        const terminalSessionId = activeSessionId;
+        const restoreTerminalFocus = () => focusTerminalSession(terminalSessionId);
+        void openSettings().then(restoreTerminalFocus, restoreTerminalFocus);
         return;
       }
       if (id === "lock") {
@@ -366,6 +371,7 @@ export function useActivityBarController({
       }
     },
     [
+      activeSessionId,
       layout,
       multiPanelOpen,
       onFloatingPanelSelect,


### PR DESCRIPTION
## 修复
- 记录 xterm textarea 的真实输入焦点所有权，仅在主窗口重新获得原生焦点且终端仍为活动、可见状态时恢复输入焦点；`window-focus` 的 scheduler 请求继续保持 `focus: false`，避免分屏终端竞争焦点。
- 不再拦截 ActivityBar 设置项的原生 `mousedown`，保留 Windows/Linux 的 `draggable` / `dragstart` 排序路径；设置窗口创建完成或失败后，通过既有 `focusTerminalSession()` 路径对选择设置时捕获的活动终端重新建立输入焦点所有权，同时保持鼠标和 Enter/Space 激活行为。

## 验证
回归测试覆盖 settings 未取消 primary `mousedown`、原生 `dragstart` MIME 路径、鼠标/键盘激活，以及设置打开成功或失败后按选择时 session 恢复焦点；原有 native window 回焦和应用内输入不被抢焦测试继续通过。lint 和 TypeScript 类型检查最终均通过，lint 仅保留与本 PR 无关的既有提示。

Fixes #584