### PR TITLE
fix(terminal): 切换终端后保持底部视口

### DIFF
--- a/src/components/terminal/useTerminalRefreshEffects.test.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.test.ts
@@ -11,6 +11,17 @@ const windowMocks = vi.hoisted(() => ({
     | undefined,
 }));
 
+function createTerminal(baseY = 0, viewportY = baseY) {
+  const scrollToBottom = vi.fn();
+  return {
+    terminal: {
+      buffer: { active: { baseY, viewportY } },
+      scrollToBottom,
+    } as unknown as Terminal,
+    scrollToBottom,
+  };
+}
+
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({
     onResized: async () => vi.fn(),
@@ -34,11 +45,12 @@ describe("useTerminalRefreshEffects", () => {
     windowMocks.scaleChanged = undefined;
   });
 
-  it("repaints an active visible terminal without texture invalidation", () => {
+  it("restores the bottom viewport after an active terminal fit", () => {
     const schedule = vi.fn();
+    const { terminal, scrollToBottom } = createTerminal(12, 12);
     renderHook(() =>
       useTerminalRefreshEffects({
-        terminalRef: { current: {} as Terminal },
+        terminalRef: { current: terminal },
         fitSchedulerRef: {
           current: { schedule } as unknown as TerminalFitScheduler,
         },
@@ -59,13 +71,68 @@ describe("useTerminalRefreshEffects", () => {
       expect.objectContaining({ force: true, refresh: true, focus: true }),
     );
     expect(activeRefresh).not.toHaveProperty("clearTextureAtlas");
+    activeRefresh.onComplete({ applied: true });
+    expect(scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves manual scrollback after an active terminal fit", () => {
+    const schedule = vi.fn();
+    const { terminal, scrollToBottom } = createTerminal(12, 4);
+    renderHook(() =>
+      useTerminalRefreshEffects({
+        terminalRef: { current: terminal },
+        fitSchedulerRef: {
+          current: { schedule } as unknown as TerminalFitScheduler,
+        },
+        active: true,
+        visible: true,
+        terminalReady: true,
+        performanceMode: "normal",
+        sessionId: "session-1",
+        showGutter: false,
+        showContentPadding: false,
+      }),
+    );
+
+    const activeRefresh = schedule.mock.calls
+      .map(([request]) => request)
+      .find((request) => request.reason === "active");
+    activeRefresh.onComplete({ applied: true });
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("does not change the viewport when an active terminal fit is skipped", () => {
+    const schedule = vi.fn();
+    const { terminal, scrollToBottom } = createTerminal(12, 12);
+    renderHook(() =>
+      useTerminalRefreshEffects({
+        terminalRef: { current: terminal },
+        fitSchedulerRef: {
+          current: { schedule } as unknown as TerminalFitScheduler,
+        },
+        active: true,
+        visible: true,
+        terminalReady: true,
+        performanceMode: "normal",
+        sessionId: "session-1",
+        showGutter: false,
+        showContentPadding: false,
+      }),
+    );
+
+    const activeRefresh = schedule.mock.calls
+      .map(([request]) => request)
+      .find((request) => request.reason === "active");
+    activeRefresh.onComplete({ applied: false });
+    expect(scrollToBottom).not.toHaveBeenCalled();
   });
 
   it("forces fit and repaint without stealing focus when the native window regains focus", async () => {
     const schedule = vi.fn();
+    const { terminal } = createTerminal();
     renderHook(() =>
       useTerminalRefreshEffects({
-        terminalRef: { current: {} as Terminal },
+        terminalRef: { current: terminal },
         fitSchedulerRef: {
           current: { schedule } as unknown as TerminalFitScheduler,
         },
@@ -99,9 +166,10 @@ describe("useTerminalRefreshEffects", () => {
 
   it("still invalidates textures after a DPI scale change", async () => {
     const schedule = vi.fn();
+    const { terminal } = createTerminal();
     renderHook(() =>
       useTerminalRefreshEffects({
-        terminalRef: { current: {} as Terminal },
+        terminalRef: { current: terminal },
         fitSchedulerRef: {
           current: { schedule } as unknown as TerminalFitScheduler,
         },
@@ -132,9 +200,10 @@ describe("useTerminalRefreshEffects", () => {
   it("suppresses incidental refreshes while a snapshot restore is finalizing", async () => {
     const schedule = vi.fn();
     const snapshotRestoringRef = { current: true };
+    const { terminal } = createTerminal();
     renderHook(() =>
       useTerminalRefreshEffects({
-        terminalRef: { current: {} as Terminal },
+        terminalRef: { current: terminal },
         fitSchedulerRef: {
           current: { schedule } as unknown as TerminalFitScheduler,
         },

--- a/src/components/terminal/useTerminalRefreshEffects.ts
+++ b/src/components/terminal/useTerminalRefreshEffects.ts
@@ -87,11 +87,23 @@ export function useTerminalRefreshEffects({
 
   useEffect(() => {
     if (active && visible && terminalReady && fitSchedulerRef.current && terminalRef.current) {
+      const terminal = terminalRef.current;
+      const buffer = terminal.buffer.active;
+      const wasAtBottom = buffer.viewportY === buffer.baseY;
       fitSchedulerRef.current.schedule({
         reason: "active",
         force: true,
         refresh: true,
         focus: true,
+        onComplete: (result) => {
+          if (
+            result.applied &&
+            wasAtBottom &&
+            terminalRef.current === terminal
+          ) {
+            terminal.scrollToBottom();
+          }
+        },
       });
     }
   }, [active, fitSchedulerRef, terminalReady, terminalRef, visible]);


### PR DESCRIPTION
## 修复

- 在终端进入 active 状态并安排强制 fit 前记录当前 viewport 是否跟随 buffer 底部。
- fit 成功应用后，仅在原先位于底部且仍是同一个终端实例时恢复到底部，避免切换终端后命令行跑到上方、需要按 Enter 才重新显示。
- 用户主动停留在 scrollback 时保持原位置；隐藏等原因导致 fit 未实际应用时也不会修改 viewport。

## 验证

新增针对底部恢复、手动 scrollback 和 skipped fit 的回归覆盖；全量 Vitest 575 个测试、lint 和 TypeScript 检查均通过。lint 仅保留两个与本次修改无关的既有诊断。

Fixes #592