### PR TITLE
fix(terminal): 限制长逻辑行高亮开销

### DIFF
--- a/src/lib/keywordHighlighter.test.ts
+++ b/src/lib/keywordHighlighter.test.ts
@@ -483,6 +483,238 @@ describe("KeywordHighlighter", () => {
     highlighter.dispose();
   });
 
+  it.each([false, true])(
+    "skips a decoration-dense wrapped logical line atomically when cross-wrap matching is %s",
+    (highlightAcrossWrappedLines) => {
+      const denseText = "ERROR ".repeat(XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine);
+      const wrappedRows =
+        Math.floor(
+          XTERM_PERFORMANCE_CONFIG.highlighting.maxDecorationsPerLogicalLine /
+            XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine,
+        ) + 1;
+      const startY = 100;
+      const normalY = startY + wrappedRows;
+      const lines = Array.from({ length: 240 }, () => createLine(""));
+      for (let index = 0; index < wrappedRows; index++) {
+        lines[startY + index] = createLine(denseText, { wrapped: index > 0 });
+      }
+      lines[normalY] = createLine("ERROR");
+      const harness = createHarness({
+        lines,
+        baseY: 220,
+        viewportY: startY,
+        rows: wrappedRows + 1,
+        cols: denseText.length,
+      });
+      const highlighter = new KeywordHighlighter(harness.terminal);
+      highlighter.setRules([rule()], true, highlightAcrossWrappedLines);
+      flushWriteRefresh();
+
+      expect(
+        harness.decorations.filter(
+          (entry) => entry.marker.line >= startY && entry.marker.line < normalY,
+        ),
+      ).toHaveLength(0);
+      expect(harness.decorations.filter((entry) => entry.marker.line === normalY)).toHaveLength(1);
+      expect(rafCallbacks).toHaveLength(0);
+      for (let lineY = startY; lineY < normalY; lineY++) {
+        expect(lines[lineY].translateSpy).toHaveBeenCalledTimes(1);
+      }
+
+      harness.write();
+      flushWriteRefresh();
+      expect(rafCallbacks).toHaveLength(0);
+      for (let lineY = startY; lineY < normalY; lineY++) {
+        expect(lines[lineY].translateSpy).toHaveBeenCalledTimes(1);
+      }
+
+      harness.active.viewportY = 160;
+      harness.render();
+      flushScrollRefresh();
+      harness.active.viewportY = startY;
+      harness.render();
+      flushScrollRefresh();
+      expect(
+        harness.decorations.filter(
+          (entry) => entry.marker.line >= startY && entry.marker.line < normalY,
+        ),
+      ).toHaveLength(0);
+      for (let lineY = startY; lineY < normalY; lineY++) {
+        expect(lines[lineY].translateSpy).toHaveBeenCalledTimes(1);
+      }
+      highlighter.dispose();
+    },
+  );
+
+  it.each([false, true])(
+    "drops existing wrapped-line decorations atomically after the logical-line cap is exceeded (%s)",
+    (highlightAcrossWrappedLines) => {
+      const denseText = "ERROR ".repeat(XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine);
+      const denseRows = Math.floor(
+        XTERM_PERFORMANCE_CONFIG.highlighting.maxDecorationsPerLogicalLine /
+          XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine,
+      );
+      const startY = 100;
+      const lines = Array.from({ length: 140 }, () => createLine(""));
+      for (let index = 0; index < denseRows; index++) {
+        lines[startY + index] = createLine(denseText, { wrapped: index > 0 });
+      }
+      lines[startY + denseRows] = createLine("", { wrapped: true });
+      const harness = createHarness({
+        lines,
+        baseY: startY,
+        viewportY: startY,
+        rows: denseRows + 1,
+        cols: denseText.length,
+      });
+      const highlighter = new KeywordHighlighter(harness.terminal);
+      highlighter.setRules([rule()], true, highlightAcrossWrappedLines);
+      flushWriteRefresh();
+
+      const initialDecorations = harness.decorations.filter(
+        (entry) => entry.marker.line >= startY && entry.marker.line <= startY + denseRows,
+      );
+      expect(initialDecorations).toHaveLength(
+        XTERM_PERFORMANCE_CONFIG.highlighting.maxDecorationsPerLogicalLine,
+      );
+      expect(rafCallbacks).toHaveLength(0);
+
+      lines[startY + denseRows] = createLine(denseText, { wrapped: true });
+      harness.write();
+      flushWriteRefresh();
+
+      expect(harness.decorations).toHaveLength(initialDecorations.length);
+      expect(initialDecorations.every((entry) => entry.decoration.isDisposed)).toBe(true);
+      expect(rafCallbacks).toHaveLength(0);
+      highlighter.dispose();
+    },
+  );
+
+  it.each([false, true])(
+    "skips a wrapped logical line after its refresh budget expires and continues with later lines (%s)",
+    (highlightAcrossWrappedLines) => {
+      const denseText = "ERROR ".repeat(XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine);
+      const wrappedRows =
+        Math.floor(
+          XTERM_PERFORMANCE_CONFIG.highlighting.maxDecorationsPerLogicalLine /
+            XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine,
+        ) + 1;
+      const startY = 100;
+      const normalY = startY + wrappedRows;
+      let now = 0;
+      const lines = Array.from({ length: normalY + 1 }, () => createLine(""));
+      for (let index = 0; index < wrappedRows; index++) {
+        const line = createLine(denseText, { wrapped: index > 0 });
+        line.translateSpy.mockImplementation((trimRight: boolean) => {
+          now = 4;
+          return trimRight ? denseText.replace(/\s+$/u, "") : denseText;
+        });
+        lines[startY + index] = line;
+      }
+      lines[normalY] = createLine("ERROR");
+      const harness = createHarness({
+        lines,
+        baseY: startY,
+        viewportY: startY,
+        rows: wrappedRows + 1,
+        cols: denseText.length,
+      });
+      const highlighter = new KeywordHighlighter(harness.terminal);
+      const performanceNow = vi.spyOn(performance, "now").mockImplementation(() => now);
+
+      highlighter.setRules([rule()], true, highlightAcrossWrappedLines);
+      flushWriteRefresh();
+      expect(rafCallbacks).toHaveLength(1);
+      expect(harness.decorations).toHaveLength(0);
+      const initialScanCounts = Array.from(
+        { length: wrappedRows },
+        (_, index) => lines[startY + index].translateSpy.mock.calls.length,
+      );
+
+      const [[rafId, continuation]] = [...rafCallbacks.entries()];
+      rafCallbacks.delete(rafId);
+      now = 100;
+      continuation(100);
+
+      expect(rafCallbacks).toHaveLength(0);
+      expect(
+        Array.from(
+          { length: wrappedRows },
+          (_, index) => lines[startY + index].translateSpy.mock.calls.length,
+        ),
+      ).toEqual(initialScanCounts);
+      expect(
+        harness.decorations.filter(
+          (entry) => entry.marker.line >= startY && entry.marker.line < normalY,
+        ),
+      ).toHaveLength(0);
+      expect(harness.decorations.filter((entry) => entry.marker.line === normalY)).toHaveLength(1);
+      performanceNow.mockRestore();
+      highlighter.dispose();
+    },
+  );
+
+  it.each([false, true])(
+    "skips a wrapped logical line when the refresh budget expires after its final scan check (%s)",
+    (highlightAcrossWrappedLines) => {
+      const startY = 100;
+      const normalY = startY + 2;
+      const lines = Array.from({ length: normalY + 1 }, () => createLine(""));
+      lines[startY] = createLine("ERROR");
+      lines[startY + 1] = createLine("ERROR", { wrapped: true });
+      lines[normalY] = createLine("ERROR");
+      const harness = createHarness({
+        lines,
+        baseY: startY,
+        viewportY: startY,
+        rows: 3,
+      });
+      const highlighter = new KeywordHighlighter(harness.terminal);
+      let now = 0;
+      let errorNullMatches = 0;
+      const originalExec = RegExp.prototype.exec;
+      const execSpy = vi.spyOn(RegExp.prototype, "exec").mockImplementation(function (this: RegExp, text: string) {
+        const result = originalExec.call(this, text);
+        if (this.source === "ERROR" && result === null) {
+          errorNullMatches++;
+          const expiryNullMatch = highlightAcrossWrappedLines ? 1 : 2;
+          if (errorNullMatches === expiryNullMatch) now = 4;
+        }
+        return result;
+      });
+      const performanceNow = vi.spyOn(performance, "now").mockImplementation(() => now);
+
+      highlighter.setRules([rule()], true, highlightAcrossWrappedLines);
+      flushWriteRefresh();
+      expect(rafCallbacks).toHaveLength(1);
+      expect(harness.decorations).toHaveLength(0);
+      const initialScanCounts = [
+        lines[startY].translateSpy.mock.calls.length,
+        lines[startY + 1].translateSpy.mock.calls.length,
+      ];
+
+      const [[rafId, continuation]] = [...rafCallbacks.entries()];
+      rafCallbacks.delete(rafId);
+      now = 100;
+      continuation(100);
+
+      expect(rafCallbacks).toHaveLength(0);
+      expect([
+        lines[startY].translateSpy.mock.calls.length,
+        lines[startY + 1].translateSpy.mock.calls.length,
+      ]).toEqual(initialScanCounts);
+      expect(
+        harness.decorations.filter(
+          (entry) => entry.marker.line === startY || entry.marker.line === startY + 1,
+        ),
+      ).toHaveLength(0);
+      expect(harness.decorations.filter((entry) => entry.marker.line === normalY)).toHaveLength(1);
+      execSpy.mockRestore();
+      performanceNow.mockRestore();
+      highlighter.dispose();
+    },
+  );
+
   it("delays resume and cancels it when suspension returns", () => {
     const lines = Array.from({ length: 80 }, (_, index) =>
       createLine(index === 20 ? "ERROR" : ""),

--- a/src/lib/keywordHighlighter.test.ts
+++ b/src/lib/keywordHighlighter.test.ts
@@ -132,6 +132,7 @@ function createHarness(options: {
   const renderListeners = new Set<() => void>();
   const markers: FakeMarker[] = [];
   const decorations: DecorationRecord[] = [];
+  const getLineSpy = vi.fn((lineY: number) => options.lines[lineY]);
   const active = {
     type: "normal" as "normal" | "alternate",
     baseY: options.baseY,
@@ -140,7 +141,7 @@ function createHarness(options: {
     get length() {
       return options.lines.length;
     },
-    getLine: (lineY: number) => options.lines[lineY],
+    getLine: getLineSpy,
     getNullCell: () => createCell(),
   };
   const subscribe = (listeners: Set<() => void>, listener: () => void): IDisposable => {
@@ -174,6 +175,7 @@ function createHarness(options: {
   return {
     active,
     decorations,
+    getLineSpy,
     markers,
     terminal,
     render: () => {
@@ -714,6 +716,182 @@ describe("KeywordHighlighter", () => {
       highlighter.dispose();
     },
   );
+
+  it.each([false, true])(
+    "bounds a 10,000-row logical line and reuses immutable suppression (%s)",
+    (highlightAcrossWrappedLines) => {
+      const giantRows = 10_000;
+      const normalY = giantRows;
+      const lines = Array.from({ length: giantRows + 1 }, (_, index) =>
+        createLine(index === normalY ? "ERROR" : "", {
+          wrapped: index > 0 && index < normalY,
+        }),
+      );
+      const rows = 501;
+      const viewportY = giantRows - 500;
+      const harness = createHarness({ lines, baseY: normalY, viewportY, rows });
+      const highlighter = new KeywordHighlighter(harness.terminal);
+      let now = 0;
+      const performanceNow = vi.spyOn(performance, "now").mockImplementation(() => now);
+
+      highlighter.setRules([rule()], true, highlightAcrossWrappedLines);
+      flushWriteRefresh();
+
+      const maxBoundedReads =
+        XTERM_PERFORMANCE_CONFIG.highlighting.maxLogicalLineRows * 2 + 100;
+      expect(harness.getLineSpy.mock.calls.length).toBeLessThan(maxBoundedReads);
+      expect(lines[giantRows - 1].translateSpy).not.toHaveBeenCalled();
+      expect(harness.decorations.filter((entry) => entry.marker.line === normalY)).toHaveLength(1);
+      expect(rafCallbacks).toHaveLength(0);
+
+      const internals = highlighter as unknown as {
+        suppressedLineCache: Map<number, true>;
+      };
+      expect(internals.suppressedLineCache.size).toBeGreaterThan(0);
+      const firstRefreshReads = harness.getLineSpy.mock.calls.length;
+
+      harness.active.viewportY--;
+      harness.render();
+      flushScrollRefresh();
+
+      const scrollRefreshReads = harness.getLineSpy.mock.calls.length - firstRefreshReads;
+      expect(scrollRefreshReads).toBeLessThan(rows + 50);
+      const readsBeforeWrite = harness.getLineSpy.mock.calls.length;
+
+      harness.getLineSpy.mockImplementation((lineY: number) => {
+        now++;
+        return lines[lineY];
+      });
+      now = 100;
+      harness.write();
+      flushWriteRefresh();
+
+      const secondRefreshReads = harness.getLineSpy.mock.calls.length - readsBeforeWrite;
+      expect(secondRefreshReads).toBeLessThan(rows + 50);
+      expect(lines[giantRows - 1].translateSpy).not.toHaveBeenCalled();
+
+      harness.resize();
+      expect(internals.suppressedLineCache).toHaveLength(0);
+      performanceNow.mockRestore();
+      highlighter.dispose();
+    },
+  );
+
+  it.each([false, true])(
+    "keeps a logical-line boundary timeout out of the persistent suppression cache (%s)",
+    (highlightAcrossWrappedLines) => {
+      const lines = [
+        createLine("ERROR"),
+        createLine("ERROR", { wrapped: true }),
+        createLine("ERROR"),
+      ];
+      const harness = createHarness({ lines, baseY: 2, viewportY: 0, rows: 3 });
+      let now = 0;
+      let lineReads = 0;
+      harness.getLineSpy.mockImplementation((lineY: number) => {
+        lineReads++;
+        if (lineReads === 2) now = 4;
+        return lines[lineY];
+      });
+      const performanceNow = vi.spyOn(performance, "now").mockImplementation(() => now);
+      const highlighter = new KeywordHighlighter(harness.terminal);
+
+      highlighter.setRules([rule()], true, highlightAcrossWrappedLines);
+      flushWriteRefresh();
+
+      const internals = highlighter as unknown as {
+        suppressedLineCache: Map<number, true>;
+      };
+      expect(internals.suppressedLineCache).toHaveLength(0);
+      expect(lines[0].translateSpy).not.toHaveBeenCalled();
+      expect(lines[1].translateSpy).not.toHaveBeenCalled();
+      expect(rafCallbacks).toHaveLength(1);
+
+      const [[rafId, continuation]] = [...rafCallbacks.entries()];
+      rafCallbacks.delete(rafId);
+      now = 100;
+      continuation(100);
+
+      expect(lines[0].translateSpy).not.toHaveBeenCalled();
+      expect(lines[1].translateSpy).not.toHaveBeenCalled();
+      expect(harness.decorations.filter((entry) => entry.marker.line === 2)).toHaveLength(1);
+      expect(rafCallbacks).toHaveLength(0);
+
+      now = 200;
+      harness.write();
+      flushWriteRefresh();
+
+      expect(lines[0].translateSpy).toHaveBeenCalledTimes(1);
+      expect(lines[1].translateSpy).toHaveBeenCalledTimes(1);
+      expect(internals.suppressedLineCache).toHaveLength(0);
+      performanceNow.mockRestore();
+      highlighter.dispose();
+    },
+  );
+
+  it("only persists row-limit suppression for immutable scrollback rows", () => {
+    const logicalRows = 600;
+    const lines = Array.from({ length: logicalRows + 1 }, (_, index) =>
+      createLine(index === logicalRows ? "ERROR" : "", {
+        wrapped: index > 0 && index < logicalRows,
+      }),
+    );
+    const harness = createHarness({ lines, baseY: 550, viewportY: 540, rows: 30 });
+    const highlighter = new KeywordHighlighter(harness.terminal);
+
+    highlighter.setRules([rule()], true);
+    flushWriteRefresh();
+
+    const internals = highlighter as unknown as {
+      suppressedLineCache: Map<number, true>;
+    };
+    expect(internals.suppressedLineCache.size).toBeGreaterThan(0);
+    expect([...internals.suppressedLineCache.keys()].every((lineY) => lineY < harness.active.baseY)).toBe(
+      true,
+    );
+    highlighter.dispose();
+  });
+
+  it("invalidates deterministic suppression after scrollback trimming", () => {
+    const denseText = "ERROR ".repeat(XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine);
+    const wrappedRows =
+      Math.floor(
+        XTERM_PERFORMANCE_CONFIG.highlighting.maxDecorationsPerLogicalLine /
+          XTERM_PERFORMANCE_CONFIG.highlighting.maxMatchesPerLine,
+      ) + 1;
+    const startY = 100;
+    const lines = Array.from({ length: 240 }, () => createLine(""));
+    for (let index = 0; index < wrappedRows; index++) {
+      lines[startY + index] = createLine(denseText, { wrapped: index > 0 });
+    }
+    const harness = createHarness({
+      lines,
+      baseY: 220,
+      viewportY: startY,
+      rows: wrappedRows,
+      cols: denseText.length,
+    });
+    const highlighter = new KeywordHighlighter(harness.terminal);
+
+    highlighter.setRules([rule()], true);
+    flushWriteRefresh();
+
+    const internals = highlighter as unknown as {
+      suppressedLineCache: Map<number, true>;
+    };
+    expect(internals.suppressedLineCache.size).toBe(wrappedRows);
+
+    for (let index = 0; index < wrappedRows; index++) {
+      lines[startY + index] = createLine("");
+    }
+    harness.markers[0].dispose();
+    harness.active.viewportY++;
+    harness.render();
+    flushScrollRefresh();
+
+    expect(internals.suppressedLineCache).toHaveLength(0);
+    highlighter.dispose();
+  });
 
   it("delays resume and cancels it when suspension returns", () => {
     const lines = Array.from({ length: 80 }, (_, index) =>

--- a/src/lib/keywordHighlighter.ts
+++ b/src/lib/keywordHighlighter.ts
@@ -48,6 +48,7 @@ interface RefreshBudget {
 interface SpanScanResult {
   spans: HighlightSpan[];
   complete: boolean;
+  scannedChars: number;
 }
 
 interface WrappedSpanScanResult {
@@ -91,6 +92,8 @@ export class KeywordHighlighter implements IDisposable {
   private resumeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private resumeRefreshFrame: number | null = null;
   private continuationRefreshFrame: number | null = null;
+  /** Logical lines skipped after exhausting one refresh budget, until the continuation chain ends. */
+  private continuationSkippedLogicalStarts = new Set<number>();
   private enabled = false;
   private suspended = false;
   private highlightAcrossWrappedLines = false;
@@ -354,6 +357,7 @@ export class KeywordHighlighter implements IDisposable {
     this.clearAllTimers();
     this.clearDecorations();
     this.clearMatchCache();
+    this.continuationSkippedLogicalStarts.clear();
     this.disposeSentinel();
     this.bufferTrimmed = false;
   }
@@ -563,7 +567,7 @@ export class KeywordHighlighter implements IDisposable {
   ): SpanScanResult {
     const maxCols = Math.min(line.length, this.term.cols);
     const lineText = line.translateToString(true, 0, maxCols);
-    if (!lineText) return { spans: [], complete: true };
+    if (!lineText) return { spans: [], complete: true, scannedChars: 0 };
 
     // Only build the wide-char map if actually needed (non-ASCII present)
     const hasMultibyte = /[^\u0000-\u00FF]/.test(lineText);
@@ -578,12 +582,16 @@ export class KeywordHighlighter implements IDisposable {
 
     for (const { regex, color } of this.compiledRules) {
       if (spans.length >= config.maxMatchesPerLine) break;
-      if (this.isBudgetExhausted(budget)) return { spans, complete: false };
+      if (this.isBudgetExhausted(budget)) {
+        return { spans, complete: false, scannedChars: lineText.length };
+      }
       regex.lastIndex = 0;
 
       while (true) {
         if (spans.length >= config.maxMatchesPerLine) break;
-        if (this.isBudgetExhausted(budget)) return { spans, complete: false };
+        if (this.isBudgetExhausted(budget)) {
+          return { spans, complete: false, scannedChars: lineText.length };
+        }
         const match = regex.exec(lineText);
         if (match === null) break;
 
@@ -626,7 +634,48 @@ export class KeywordHighlighter implements IDisposable {
       }
     }
 
-    return { spans, complete: true };
+    return { spans, complete: true, scannedChars: lineText.length };
+  }
+
+  private scanPhysicalLogicalLine(
+    buffer: XTerm["buffer"]["active"],
+    startY: number,
+    endY: number,
+    scratchCell: IBufferCell,
+    config: KeywordHighlightPerformanceConfig,
+    budget: RefreshBudget,
+  ): WrappedSpanScanResult {
+    const lineYs = Array.from({ length: endY - startY + 1 }, (_, index) => startY + index);
+    const emptyByLine = () =>
+      new Map(lineYs.map((lineY) => [lineY, [] as HighlightSpan[]] as const));
+    const spansByLine = emptyByLine();
+    let logicalLength = 0;
+    let decorationCandidates = 0;
+
+    for (const lineY of lineYs) {
+      if (this.isBudgetExhausted(budget)) {
+        return { spansByLine, lineYs, complete: false, cacheable: false };
+      }
+      const line = buffer.getLine(lineY);
+      if (!line) continue;
+
+      const result = this.scanPhysicalLine(line, scratchCell, config, budget);
+      if (!result.complete) {
+        return { spansByLine, lineYs, complete: false, cacheable: false };
+      }
+
+      logicalLength += result.scannedChars;
+      decorationCandidates += result.spans.length;
+      if (
+        logicalLength > KeywordHighlighter.MAX_LOGICAL_LINE_SCAN_CHARS ||
+        decorationCandidates > config.maxDecorationsPerLogicalLine
+      ) {
+        return { spansByLine: emptyByLine(), lineYs, complete: true, cacheable: true };
+      }
+      spansByLine.set(lineY, result.spans);
+    }
+
+    return { spansByLine, lineYs, complete: true, cacheable: true };
   }
 
   private scanWrappedLogicalLine(
@@ -673,12 +722,13 @@ export class KeywordHighlighter implements IDisposable {
 
     const logicalText = segments.map((segment) => segment.text).join("");
     if (logicalText.length > KeywordHighlighter.MAX_LOGICAL_LINE_SCAN_CHARS) {
-      return { spansByLine: emptyByLine, lineYs, complete: true, cacheable: false };
+      return { spansByLine: emptyByLine, lineYs, complete: true, cacheable: true };
     }
     const occupied = new Uint8Array(logicalText.length);
 
     const spansByLine = emptyByLine;
     const acceptedMatchesByLine = new Map<number, number>();
+    let decorationCandidates = 0;
 
     for (const { regex, color } of this.compiledRules) {
       if (this.isBudgetExhausted(budget)) {
@@ -726,7 +776,7 @@ export class KeywordHighlighter implements IDisposable {
         }
         if (lineLimitReached) continue;
 
-        const acceptedLineYs: number[] = [];
+        const candidateSpans: Array<{ lineY: number; span: HighlightSpan }> = [];
         for (const segment of matchedSegments) {
           const localStart = Math.max(strStart, segment.startIndex) - segment.startIndex;
           const localEnd = Math.min(strEnd, segment.endIndex) - segment.startIndex;
@@ -738,20 +788,31 @@ export class KeywordHighlighter implements IDisposable {
           const cellEndCol = segment.cellMap ? (segment.cellMap[localEnd] ?? localEnd) : localEnd;
           const cellWidth = cellEndCol - cellStartCol;
           if (cellWidth <= 0) continue;
-          spansByLine.get(segment.lineY)?.push({
-            cellStartCol,
-            cellWidth,
-            color,
+          candidateSpans.push({
+            lineY: segment.lineY,
+            span: { cellStartCol, cellWidth, color },
           });
-          acceptedLineYs.push(segment.lineY);
         }
 
-        if (acceptedLineYs.length === 0) continue;
+        if (candidateSpans.length === 0) continue;
+        if (decorationCandidates + candidateSpans.length > config.maxDecorationsPerLogicalLine) {
+          return {
+            spansByLine: new Map(lineYs.map((lineY) => [lineY, [] as HighlightSpan[]])),
+            lineYs,
+            complete: true,
+            cacheable: true,
+          };
+        }
+
+        for (const { lineY, span } of candidateSpans) {
+          spansByLine.get(lineY)?.push(span);
+        }
+        decorationCandidates += candidateSpans.length;
 
         for (let k = strStart; k < strEnd; k++) {
           occupied[k] = 1;
         }
-        for (const lineY of acceptedLineYs) {
+        for (const { lineY } of candidateSpans) {
           acceptedMatchesByLine.set(lineY, (acceptedMatchesByLine.get(lineY) ?? 0) + 1);
         }
       }
@@ -786,6 +847,10 @@ export class KeywordHighlighter implements IDisposable {
   private refreshViewport(reason: RefreshReason): void {
     if (!this.enabled || this.suspended || this.compiledRules.length === 0) return;
     if (!this.term?.buffer?.active) return;
+
+    if (reason !== "continuation") {
+      this.continuationSkippedLogicalStarts.clear();
+    }
 
     if (this.term.buffer.active.type === "alternate") {
       this.invalidateAll();
@@ -841,36 +906,6 @@ export class KeywordHighlighter implements IDisposable {
       if (this.isBudgetExhausted(budget)) break;
       const line = buffer.getLine(lineY);
       if (!line) continue;
-      processedLines.add(lineY);
-
-      if (!this.highlightAcrossWrappedLines) {
-        let spans: HighlightSpan[];
-        if (lineY < screenStartY) {
-          const cached = this.getCachedMatches(lineY);
-          if (cached !== undefined) {
-            stats.cacheHits++;
-            spans = cached;
-          } else {
-            stats.cacheMisses++;
-            stats.scannedLines++;
-            const result = this.scanPhysicalLine(line, scratchCell, config, budget);
-            spans = result.spans;
-            if (result.complete) this.setCachedMatches(lineY, spans);
-          }
-        } else {
-          stats.scannedLines++;
-          spans = this.scanPhysicalLine(line, scratchCell, config, budget).spans;
-        }
-        this.materializeSpans(
-          lineY,
-          spans,
-          cursorAbsoluteY,
-          requiredKeys,
-          config,
-          budget,
-        );
-        continue;
-      }
 
       const { startY, endY } = this.getLogicalLineBounds(buffer, lineY, totalLines);
       const canMemoize = endY < screenStartY;
@@ -889,7 +924,11 @@ export class KeywordHighlighter implements IDisposable {
         canMemoize && logicalLineYs.every((cachedLineY) => this.lineMatchCache.has(cachedLineY));
 
       let spansByLine: Map<number, HighlightSpan[]>;
-      if (allRowsCached) {
+      if (this.continuationSkippedLogicalStarts.has(startY)) {
+        spansByLine = new Map(
+          logicalLineYs.map((skippedLineY) => [skippedLineY, [] as HighlightSpan[]]),
+        );
+      } else if (allRowsCached) {
         spansByLine = new Map();
         for (const cachedLineY of logicalLineYs) {
           const cached = this.getCachedMatches(cachedLineY);
@@ -901,17 +940,21 @@ export class KeywordHighlighter implements IDisposable {
       } else {
         if (canMemoize) stats.cacheMisses++;
         stats.scannedLines += logicalLineYs.length;
-        const result = this.scanWrappedLogicalLine(
-          buffer,
-          startY,
-          endY,
-          scratchCell,
-          config,
-          budget,
-        );
+        const result = this.highlightAcrossWrappedLines
+          ? this.scanWrappedLogicalLine(buffer, startY, endY, scratchCell, config, budget)
+          : this.scanPhysicalLogicalLine(buffer, startY, endY, scratchCell, config, budget);
         spansByLine = result.spansByLine;
+        const scanInterruptedByBudget =
+          (!result.complete && budget.hitLimit) || (result.complete && this.isBudgetExpired(budget));
+        if (scanInterruptedByBudget) {
+          this.continuationSkippedLogicalStarts.add(startY);
+          spansByLine = new Map(
+            logicalLineYs.map((skippedLineY) => [skippedLineY, [] as HighlightSpan[]]),
+          );
+        }
         if (
           canMemoize &&
+          !scanInterruptedByBudget &&
           result.complete &&
           result.cacheable &&
           result.lineYs.length <= config.maxCachedMatchLines
@@ -938,6 +981,7 @@ export class KeywordHighlighter implements IDisposable {
         );
         if (budget.hitLimit) break;
       }
+      lineY = endY;
     }
 
     // Evict decorations that have drifted outside the overscan zone. If the refresh

--- a/src/lib/keywordHighlighter.ts
+++ b/src/lib/keywordHighlighter.ts
@@ -56,6 +56,15 @@ interface WrappedSpanScanResult {
   lineYs: number[];
   complete: boolean;
   cacheable: boolean;
+  suppressedByHardLimit: boolean;
+}
+
+type LogicalLineBoundsStatus = "complete" | "budget" | "row_limit";
+
+interface LogicalLineBoundsResult {
+  startY: number;
+  endY: number;
+  status: LogicalLineBoundsStatus;
 }
 
 type RefreshReason = "write" | "scroll_idle" | "resume" | "continuation" | "resize";
@@ -87,13 +96,15 @@ export class KeywordHighlighter implements IDisposable {
   private decorationCache = new Map<string, CachedDecoration>();
   /** Immutable absolute buffer line index → resolved highlight spans (including []). */
   private lineMatchCache = new Map<number, HighlightSpan[]>();
+  /** Immutable rows belonging to a logical line suppressed by a deterministic hard limit. */
+  private suppressedLineCache = new Map<number, true>();
   private writeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private scrollDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private resumeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private resumeRefreshFrame: number | null = null;
   private continuationRefreshFrame: number | null = null;
-  /** Logical lines skipped after exhausting one refresh budget, until the continuation chain ends. */
-  private continuationSkippedLogicalStarts = new Set<number>();
+  /** Rows skipped after exhausting one refresh budget, until the continuation chain ends. */
+  private continuationSkippedRows = new Set<number>();
   private enabled = false;
   private suspended = false;
   private highlightAcrossWrappedLines = false;
@@ -107,7 +118,10 @@ export class KeywordHighlighter implements IDisposable {
 
   private static readonly MAX_LOGICAL_LINE_SCAN_CHARS = 16 * 1024;
 
-  constructor(term: XTerm, private readonly sessionId?: string) {
+  constructor(
+    term: XTerm,
+    private readonly sessionId?: string,
+  ) {
     this.term = term;
 
     this.disposables.push(
@@ -351,13 +365,14 @@ export class KeywordHighlighter implements IDisposable {
 
   private clearMatchCache(): void {
     this.lineMatchCache.clear();
+    this.suppressedLineCache.clear();
   }
 
   private invalidateAll(): void {
     this.clearAllTimers();
     this.clearDecorations();
     this.clearMatchCache();
-    this.continuationSkippedLogicalStarts.clear();
+    this.continuationSkippedRows.clear();
     this.disposeSentinel();
     this.bufferTrimmed = false;
   }
@@ -371,6 +386,7 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private setCachedMatches(lineY: number, spans: HighlightSpan[]): void {
+    this.suppressedLineCache.delete(lineY);
     this.lineMatchCache.delete(lineY);
     this.lineMatchCache.set(lineY, spans);
     const maxLines = XTERM_PERFORMANCE_CONFIG.highlighting.maxCachedMatchLines;
@@ -379,6 +395,29 @@ export class KeywordHighlighter implements IDisposable {
       if (oldest === undefined) break;
       this.lineMatchCache.delete(oldest);
     }
+  }
+
+  private hasCachedSuppression(lineY: number): boolean {
+    if (!this.suppressedLineCache.has(lineY)) return false;
+    this.suppressedLineCache.delete(lineY);
+    this.suppressedLineCache.set(lineY, true);
+    return true;
+  }
+
+  private setCachedSuppression(lineY: number): void {
+    this.lineMatchCache.delete(lineY);
+    this.suppressedLineCache.delete(lineY);
+    this.suppressedLineCache.set(lineY, true);
+    const maxLines = XTERM_PERFORMANCE_CONFIG.highlighting.maxCachedMatchLines;
+    while (this.suppressedLineCache.size > maxLines) {
+      const oldest = this.suppressedLineCache.keys().next().value;
+      if (oldest === undefined) break;
+      this.suppressedLineCache.delete(oldest);
+    }
+  }
+
+  private cacheSuppressedRows(lineYs: Iterable<number>): void {
+    for (const lineY of lineYs) this.setCachedSuppression(lineY);
   }
 
   private buildStringToCellMap(
@@ -427,20 +466,59 @@ export class KeywordHighlighter implements IDisposable {
     buffer: XTerm["buffer"]["active"],
     lineY: number,
     totalLines: number,
-  ): { startY: number; endY: number } {
+    maxRows: number,
+    budget: RefreshBudget,
+  ): LogicalLineBoundsResult {
+    if (lineY + 1 < totalLines && this.suppressedLineCache.has(lineY + 1)) {
+      if (this.isBudgetExhausted(budget)) return { startY: lineY, endY: lineY, status: "budget" };
+      const nextLine = buffer.getLine(lineY + 1);
+      if (this.isBudgetExhausted(budget)) return { startY: lineY, endY: lineY, status: "budget" };
+      if (nextLine?.isWrapped) return { startY: lineY, endY: lineY, status: "row_limit" };
+    }
+
     let startY = lineY;
+    let visitedRows = 1;
     while (startY > 0) {
+      if (this.isBudgetExhausted(budget)) return { startY, endY: lineY, status: "budget" };
       const currentLine = buffer.getLine(startY);
+      if (this.isBudgetExhausted(budget)) return { startY, endY: lineY, status: "budget" };
       if (!currentLine?.isWrapped) break;
+      if (this.suppressedLineCache.has(startY - 1)) {
+        return { startY, endY: lineY, status: "row_limit" };
+      }
+      if (visitedRows >= maxRows) return { startY, endY: lineY, status: "row_limit" };
       startY--;
+      visitedRows++;
     }
 
     let endY = lineY;
     while (endY + 1 < totalLines) {
+      if (this.isBudgetExhausted(budget)) return { startY, endY, status: "budget" };
       const nextLine = buffer.getLine(endY + 1);
+      if (this.isBudgetExhausted(budget)) return { startY, endY, status: "budget" };
       if (!nextLine?.isWrapped) break;
+      if (this.suppressedLineCache.has(endY + 1)) {
+        return { startY, endY, status: "row_limit" };
+      }
+      if (visitedRows >= maxRows) return { startY, endY, status: "row_limit" };
       endY++;
+      visitedRows++;
     }
+
+    return { startY, endY, status: "complete" };
+  }
+
+  private getLogicalLineBoundsInRange(
+    buffer: XTerm["buffer"]["active"],
+    lineY: number,
+    minY: number,
+    maxY: number,
+  ): { startY: number; endY: number } {
+    let startY = lineY;
+    while (startY > minY && buffer.getLine(startY)?.isWrapped) startY--;
+
+    let endY = lineY;
+    while (endY < maxY && buffer.getLine(endY + 1)?.isWrapped) endY++;
 
     return { startY, endY };
   }
@@ -654,14 +732,26 @@ export class KeywordHighlighter implements IDisposable {
 
     for (const lineY of lineYs) {
       if (this.isBudgetExhausted(budget)) {
-        return { spansByLine, lineYs, complete: false, cacheable: false };
+        return {
+          spansByLine,
+          lineYs,
+          complete: false,
+          cacheable: false,
+          suppressedByHardLimit: false,
+        };
       }
       const line = buffer.getLine(lineY);
       if (!line) continue;
 
       const result = this.scanPhysicalLine(line, scratchCell, config, budget);
       if (!result.complete) {
-        return { spansByLine, lineYs, complete: false, cacheable: false };
+        return {
+          spansByLine,
+          lineYs,
+          complete: false,
+          cacheable: false,
+          suppressedByHardLimit: false,
+        };
       }
 
       logicalLength += result.scannedChars;
@@ -670,12 +760,24 @@ export class KeywordHighlighter implements IDisposable {
         logicalLength > KeywordHighlighter.MAX_LOGICAL_LINE_SCAN_CHARS ||
         decorationCandidates > config.maxDecorationsPerLogicalLine
       ) {
-        return { spansByLine: emptyByLine(), lineYs, complete: true, cacheable: true };
+        return {
+          spansByLine: emptyByLine(),
+          lineYs,
+          complete: true,
+          cacheable: false,
+          suppressedByHardLimit: true,
+        };
       }
       spansByLine.set(lineY, result.spans);
     }
 
-    return { spansByLine, lineYs, complete: true, cacheable: true };
+    return {
+      spansByLine,
+      lineYs,
+      complete: true,
+      cacheable: true,
+      suppressedByHardLimit: false,
+    };
   }
 
   private scanWrappedLogicalLine(
@@ -691,7 +793,13 @@ export class KeywordHighlighter implements IDisposable {
 
     for (let currentY = startY; currentY <= endY; currentY++) {
       if (this.isBudgetExhausted(budget)) {
-        return { spansByLine: new Map(), lineYs: [], complete: false, cacheable: false };
+        return {
+          spansByLine: new Map(),
+          lineYs: [],
+          complete: false,
+          cacheable: false,
+          suppressedByHardLimit: false,
+        };
       }
       const line = buffer.getLine(currentY);
       if (!line) continue;
@@ -717,12 +825,24 @@ export class KeywordHighlighter implements IDisposable {
     const lineYs = segments.map((segment) => segment.lineY);
     const emptyByLine = new Map(lineYs.map((lineY) => [lineY, [] as HighlightSpan[]]));
     if (logicalLength === 0) {
-      return { spansByLine: emptyByLine, lineYs, complete: true, cacheable: true };
+      return {
+        spansByLine: emptyByLine,
+        lineYs,
+        complete: true,
+        cacheable: true,
+        suppressedByHardLimit: false,
+      };
     }
 
     const logicalText = segments.map((segment) => segment.text).join("");
     if (logicalText.length > KeywordHighlighter.MAX_LOGICAL_LINE_SCAN_CHARS) {
-      return { spansByLine: emptyByLine, lineYs, complete: true, cacheable: true };
+      return {
+        spansByLine: emptyByLine,
+        lineYs,
+        complete: true,
+        cacheable: false,
+        suppressedByHardLimit: true,
+      };
     }
     const occupied = new Uint8Array(logicalText.length);
 
@@ -732,13 +852,25 @@ export class KeywordHighlighter implements IDisposable {
 
     for (const { regex, color } of this.compiledRules) {
       if (this.isBudgetExhausted(budget)) {
-        return { spansByLine, lineYs, complete: false, cacheable: false };
+        return {
+          spansByLine,
+          lineYs,
+          complete: false,
+          cacheable: false,
+          suppressedByHardLimit: false,
+        };
       }
       regex.lastIndex = 0;
 
       while (true) {
         if (this.isBudgetExhausted(budget)) {
-          return { spansByLine, lineYs, complete: false, cacheable: false };
+          return {
+            spansByLine,
+            lineYs,
+            complete: false,
+            cacheable: false,
+            suppressedByHardLimit: false,
+          };
         }
         const match = regex.exec(logicalText);
         if (match === null) break;
@@ -800,7 +932,8 @@ export class KeywordHighlighter implements IDisposable {
             spansByLine: new Map(lineYs.map((lineY) => [lineY, [] as HighlightSpan[]])),
             lineYs,
             complete: true,
-            cacheable: true,
+            cacheable: false,
+            suppressedByHardLimit: true,
           };
         }
 
@@ -818,7 +951,13 @@ export class KeywordHighlighter implements IDisposable {
       }
     }
 
-    return { spansByLine, lineYs, complete: true, cacheable: true };
+    return {
+      spansByLine,
+      lineYs,
+      complete: true,
+      cacheable: true,
+      suppressedByHardLimit: false,
+    };
   }
 
   private materializeSpans(
@@ -849,7 +988,7 @@ export class KeywordHighlighter implements IDisposable {
     if (!this.term?.buffer?.active) return;
 
     if (reason !== "continuation") {
-      this.continuationSkippedLogicalStarts.clear();
+      this.continuationSkippedRows.clear();
     }
 
     if (this.term.buffer.active.type === "alternate") {
@@ -903,11 +1042,54 @@ export class KeywordHighlighter implements IDisposable {
     const processedLogicalStarts = new Set<number>();
 
     for (let lineY = scanStart; lineY <= scanEnd; lineY++) {
+      if (this.continuationSkippedRows.has(lineY)) {
+        while (lineY <= scanEnd && this.continuationSkippedRows.has(lineY)) {
+          processedLines.add(lineY);
+          lineY++;
+        }
+        lineY--;
+        continue;
+      }
+      if (lineY < screenStartY && this.hasCachedSuppression(lineY)) {
+        do {
+          stats.cacheHits++;
+          processedLines.add(lineY);
+          lineY++;
+        } while (lineY <= scanEnd && lineY < screenStartY && this.hasCachedSuppression(lineY));
+        lineY--;
+        continue;
+      }
+
       if (this.isBudgetExhausted(budget)) break;
       const line = buffer.getLine(lineY);
       if (!line) continue;
 
-      const { startY, endY } = this.getLogicalLineBounds(buffer, lineY, totalLines);
+      const bounds = this.getLogicalLineBounds(
+        buffer,
+        lineY,
+        totalLines,
+        config.maxLogicalLineRows,
+        budget,
+      );
+      if (bounds.status !== "complete") {
+        const localBounds = this.getLogicalLineBoundsInRange(buffer, lineY, scanStart, scanEnd);
+        const localLineYs = Array.from(
+          { length: localBounds.endY - localBounds.startY + 1 },
+          (_, index) => localBounds.startY + index,
+        );
+        for (const localLineY of localLineYs) processedLines.add(localLineY);
+
+        if (bounds.status === "budget") {
+          for (const localLineY of localLineYs) this.continuationSkippedRows.add(localLineY);
+        } else {
+          this.cacheSuppressedRows(localLineYs.filter((localLineY) => localLineY < screenStartY));
+        }
+
+        lineY = localBounds.endY;
+        continue;
+      }
+
+      const { startY, endY } = bounds;
       const canMemoize = endY < screenStartY;
       if (processedLogicalStarts.has(startY)) continue;
       processedLogicalStarts.add(startY);
@@ -924,11 +1106,7 @@ export class KeywordHighlighter implements IDisposable {
         canMemoize && logicalLineYs.every((cachedLineY) => this.lineMatchCache.has(cachedLineY));
 
       let spansByLine: Map<number, HighlightSpan[]>;
-      if (this.continuationSkippedLogicalStarts.has(startY)) {
-        spansByLine = new Map(
-          logicalLineYs.map((skippedLineY) => [skippedLineY, [] as HighlightSpan[]]),
-        );
-      } else if (allRowsCached) {
+      if (allRowsCached) {
         spansByLine = new Map();
         for (const cachedLineY of logicalLineYs) {
           const cached = this.getCachedMatches(cachedLineY);
@@ -945,14 +1123,23 @@ export class KeywordHighlighter implements IDisposable {
           : this.scanPhysicalLogicalLine(buffer, startY, endY, scratchCell, config, budget);
         spansByLine = result.spansByLine;
         const scanInterruptedByBudget =
-          (!result.complete && budget.hitLimit) || (result.complete && this.isBudgetExpired(budget));
+          (!result.complete && budget.hitLimit) ||
+          (result.complete && this.isBudgetExpired(budget));
         if (scanInterruptedByBudget) {
-          this.continuationSkippedLogicalStarts.add(startY);
+          for (
+            let skippedLineY = Math.max(startY, scanStart);
+            skippedLineY <= Math.min(endY, scanEnd);
+            skippedLineY++
+          ) {
+            this.continuationSkippedRows.add(skippedLineY);
+          }
           spansByLine = new Map(
             logicalLineYs.map((skippedLineY) => [skippedLineY, [] as HighlightSpan[]]),
           );
         }
-        if (
+        if (canMemoize && !scanInterruptedByBudget && result.suppressedByHardLimit) {
+          this.cacheSuppressedRows(result.lineYs);
+        } else if (
           canMemoize &&
           !scanInterruptedByBudget &&
           result.complete &&
@@ -1021,6 +1208,7 @@ export class KeywordHighlighter implements IDisposable {
           decorations_created: stats.decorationsCreated,
           decorations_disposed: stats.decorationsDisposed,
           match_cache_size: this.lineMatchCache.size,
+          suppressed_line_cache_size: this.suppressedLineCache.size,
         },
       });
     }

--- a/src/lib/xtermPerformance.ts
+++ b/src/lib/xtermPerformance.ts
@@ -16,6 +16,8 @@ export const XTERM_PERFORMANCE_CONFIG = {
     maxDecorations: 1_000,
     /** Hard cap for new keyword highlight decorations created by one refresh. */
     maxDecorationsPerRefresh: 100,
+    /** Safety cap for keyword highlight decorations contributed by one logical line. */
+    maxDecorationsPerLogicalLine: 100,
     /** Hard cap for accepted keyword highlight matches on one physical line. */
     maxMatchesPerLine: 20,
     /** Main-thread time budget for one viewport refresh. */

--- a/src/lib/xtermPerformance.ts
+++ b/src/lib/xtermPerformance.ts
@@ -18,6 +18,8 @@ export const XTERM_PERFORMANCE_CONFIG = {
     maxDecorationsPerRefresh: 100,
     /** Safety cap for keyword highlight decorations contributed by one logical line. */
     maxDecorationsPerLogicalLine: 100,
+    /** Hard cap for physical rows traversed while resolving one logical line. */
+    maxLogicalLineRows: 512,
     /** Hard cap for accepted keyword highlight matches on one physical line. */
     maxMatchesPerLine: 20,
     /** Main-thread time budget for one viewport refresh. */


### PR DESCRIPTION
## 修复
- 为实验性关键字高亮限制单个 logical line 的 decoration 数量；超过 decoration 或逻辑行扫描上限时整行省略高亮，并对可安全复用的不可变 scrollback 缓存空结果。
- 当 RefreshBudget 在扫描过程中或最后一次扫描检查之后耗尽时，都将该 logical line 在当前 continuation 链中原子跳过并清理已有 decoration，避免后续 RAF 从头重扫；纯时间中断不会写入 scrollback 空结果缓存，后续普通行仍可继续高亮。
- 保持普通单行、短 wrapped line、ANSI foreground 保护以及 `keyword_highlights_across_wrapped_lines=true` 时的跨物理行匹配行为不变。

## 验证
聚焦测试覆盖 decoration 上限、原子清理、扫描中超时以及 post-scan 超时两种 continuation 边界；lint 和生产构建均通过。

Fixes #580