### PR TITLE
fix(terminal): restore input focus after terminal rebuilds

### DIFF
--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -106,6 +106,7 @@ import type { TerminalOutputDrain } from "./terminalOutputDrain";
 import { AlternateScreenStateTracker } from "./alternateScreenStateTracker";
 import type { Dec2026FrameGate } from "./dec2026FrameGate";
 import { useTerminalExternalDrop } from "./useTerminalExternalDrop";
+import { useTerminalFocusRestore } from "./useTerminalFocusRestore";
 import { useTerminalRefreshEffects } from "./useTerminalRefreshEffects";
 import {
   buildClipboardPathPasteText,
@@ -253,6 +254,10 @@ export default function XTerminal({
   const disconnectedNoticeShownRef = useRef(false);
   const disconnectedCloseRequestedRef = useRef(false);
   const reconnectingRef = useRef(false);
+  // Set when a terminal renderer is torn down while it owned keyboard focus
+  // (e.g. a reconnect swaps the session id) so the rebuilt terminal can take
+  // the focus back once it is ready. See issue #603.
+  const pendingFocusRestoreRef = useRef(false);
   const preservedReconnectContentRef = useRef<TerminalReconnectSnapshot | null>(
     null,
   );
@@ -2479,6 +2484,11 @@ export default function XTerminal({
       if (!isHibernateRendererCleanup) {
         resumeDynamicTitlePublication(sessionId);
       }
+      const previousTextarea = terminal.textarea;
+      pendingFocusRestoreRef.current =
+        Boolean(previousTextarea) &&
+        document.activeElement === previousTextarea &&
+        activeRef.current;
       terminal.dispose();
       terminalRef.current = null;
       setTerminalInstance(null);
@@ -2488,6 +2498,20 @@ export default function XTerminal({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hibernated, sessionId, terminalGeneration, terminalTransparencyEnabled]);
+
+  // Restore keyboard focus after an in-place terminal rebuild (reconnect swaps
+  // the session id, hibernate wake, transparency toggle). Without this the
+  // disposed renderer's textarea drops focus to <body> and typing after a
+  // reconnect silently does nothing until the user clicks the terminal.
+  useTerminalFocusRestore({
+    terminalRef,
+    pendingFocusRestoreRef,
+    activeRef,
+    visibleRef,
+    terminalReady,
+    restoringSnapshot,
+    hibernated,
+  });
 
   // Appearance, theme, and interaction settings sync.
   // Declared AFTER the terminal creation effect so effects from these hooks

--- a/src/components/terminal/useTerminalFocusRestore.test.ts
+++ b/src/components/terminal/useTerminalFocusRestore.test.ts
@@ -1,0 +1,181 @@
+import { renderHook } from "@testing-library/react";
+import type { Terminal } from "@xterm/xterm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTerminalFocusRestore } from "./useTerminalFocusRestore";
+
+type MutableRef<T> = { current: T };
+
+function createHarness(options?: {
+  active?: boolean;
+  visible?: boolean;
+  terminalReady?: boolean;
+  restoringSnapshot?: boolean;
+  hibernated?: boolean;
+  pendingFocusRestore?: boolean;
+}) {
+  const focus = vi.fn();
+  const terminal = { focus } as unknown as Terminal;
+  const harness = {
+    terminalRef: { current: terminal } as MutableRef<Terminal | null>,
+    pendingFocusRestoreRef: {
+      current: options?.pendingFocusRestore ?? false,
+    } as MutableRef<boolean>,
+    activeRef: { current: options?.active ?? true } as MutableRef<boolean>,
+    visibleRef: { current: options?.visible ?? true } as MutableRef<boolean>,
+    focus,
+  };
+
+  const utils = renderHook(
+    (props: { terminalReady: boolean; restoringSnapshot: boolean; hibernated: boolean }) =>
+      useTerminalFocusRestore({
+        terminalRef: harness.terminalRef,
+        pendingFocusRestoreRef: harness.pendingFocusRestoreRef,
+        activeRef: harness.activeRef,
+        visibleRef: harness.visibleRef,
+        ...props,
+      }),
+    {
+      initialProps: {
+        terminalReady: options?.terminalReady ?? false,
+        restoringSnapshot: options?.restoringSnapshot ?? false,
+        hibernated: options?.hibernated ?? false,
+      },
+    },
+  );
+
+  return { ...harness, ...utils };
+}
+
+describe("useTerminalFocusRestore", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    (document.activeElement as HTMLElement | null)?.blur?.();
+  });
+
+  it("restores focus once the rebuilt terminal is ready and revealed", () => {
+    const harness = createHarness({
+      terminalReady: false,
+      restoringSnapshot: true,
+      pendingFocusRestore: true,
+    });
+
+    // Snapshot replay finishes: the terminal reports ready but the restore
+    // overlay still hides the container.
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: true,
+      hibernated: false,
+    });
+    expect(harness.focus).not.toHaveBeenCalled();
+    expect(harness.pendingFocusRestoreRef.current).toBe(true);
+
+    // Final fit reveals the container; focus is reclaimed now.
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: false,
+      hibernated: false,
+    });
+    expect(harness.focus).toHaveBeenCalledTimes(1);
+    expect(harness.pendingFocusRestoreRef.current).toBe(false);
+  });
+
+  it("focuses the active pane after a hibernate wake even though it had no focus before", () => {
+    // Issue #613: a background tab hibernates without focus; switching to it
+    // wakes the renderer, and the focus requests emitted during the hidden
+    // restore window are silently dropped.
+    const harness = createHarness({
+      terminalReady: false,
+      restoringSnapshot: true,
+      pendingFocusRestore: false,
+    });
+
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: true,
+      hibernated: false,
+    });
+    expect(harness.focus).not.toHaveBeenCalled();
+
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: false,
+      hibernated: false,
+    });
+    expect(harness.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the pending flag while hibernated and restores after wake", () => {
+    const harness = createHarness({
+      terminalReady: false,
+      restoringSnapshot: false,
+      hibernated: true,
+      pendingFocusRestore: true,
+    });
+
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: false,
+      hibernated: true,
+    });
+    expect(harness.focus).not.toHaveBeenCalled();
+    expect(harness.pendingFocusRestoreRef.current).toBe(true);
+
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: false,
+      hibernated: false,
+    });
+    expect(harness.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not steal focus another element took while the terminal rebuilt", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    const harness = createHarness({
+      terminalReady: true,
+      restoringSnapshot: false,
+      pendingFocusRestore: true,
+    });
+
+    expect(harness.focus).not.toHaveBeenCalled();
+    expect(harness.pendingFocusRestoreRef.current).toBe(false);
+    input.remove();
+  });
+
+  it("skips focus for inactive or hidden panes and clears the flag", () => {
+    const inactive = createHarness({
+      terminalReady: true,
+      restoringSnapshot: false,
+      active: false,
+      pendingFocusRestore: false,
+    });
+    expect(inactive.focus).not.toHaveBeenCalled();
+    expect(inactive.pendingFocusRestoreRef.current).toBe(false);
+
+    const hidden = createHarness({
+      terminalReady: true,
+      restoringSnapshot: false,
+      visible: false,
+      pendingFocusRestore: true,
+    });
+    expect(hidden.focus).not.toHaveBeenCalled();
+    expect(hidden.pendingFocusRestoreRef.current).toBe(false);
+  });
+
+  it("restores focus on a rebuild without snapshot restore", () => {
+    const harness = createHarness({
+      terminalReady: false,
+      restoringSnapshot: false,
+      pendingFocusRestore: true,
+    });
+
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: false,
+      hibernated: false,
+    });
+    expect(harness.focus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/terminal/useTerminalFocusRestore.test.ts
+++ b/src/components/terminal/useTerminalFocusRestore.test.ts
@@ -144,6 +144,26 @@ describe("useTerminalFocusRestore", () => {
     input.remove();
   });
 
+  it("does not restore focus if the pane becomes inactive while rebuilding", () => {
+    const harness = createHarness({
+      terminalReady: false,
+      restoringSnapshot: true,
+      pendingFocusRestore: true,
+    });
+
+    // The old renderer owned focus, but the user switched to another pane
+    // before this rebuild finished.
+    harness.activeRef.current = false;
+    harness.rerender({
+      terminalReady: true,
+      restoringSnapshot: false,
+      hibernated: false,
+    });
+
+    expect(harness.focus).not.toHaveBeenCalled();
+    expect(harness.pendingFocusRestoreRef.current).toBe(false);
+  });
+
   it("skips focus for inactive or hidden panes and clears the flag", () => {
     const inactive = createHarness({
       terminalReady: true,

--- a/src/components/terminal/useTerminalFocusRestore.ts
+++ b/src/components/terminal/useTerminalFocusRestore.ts
@@ -37,10 +37,8 @@ export function useTerminalFocusRestore({
   // biome-ignore lint/correctness/useExhaustiveDependencies: refs are intentionally read once per ready/reveal transition.
   useEffect(() => {
     if (!terminalReady || restoringSnapshot || hibernated) return;
-    const hadFocusBeforeRebuild = pendingFocusRestoreRef.current;
     pendingFocusRestoreRef.current = false;
-    if (!visibleRef.current) return;
-    if (!hadFocusBeforeRebuild && !activeRef.current) return;
+    if (!visibleRef.current || !activeRef.current) return;
     const activeElement = document.activeElement;
     // Only reclaim focus when nothing else has taken it while the terminal was
     // being rebuilt (e.g. the user clicked another pane or an input).

--- a/src/components/terminal/useTerminalFocusRestore.ts
+++ b/src/components/terminal/useTerminalFocusRestore.ts
@@ -1,0 +1,50 @@
+import type { Terminal } from "@xterm/xterm";
+import { type RefObject, useEffect } from "react";
+
+interface UseTerminalFocusRestoreParams {
+  terminalRef: RefObject<Terminal | null>;
+  pendingFocusRestoreRef: RefObject<boolean>;
+  activeRef: RefObject<boolean>;
+  visibleRef: RefObject<boolean>;
+  terminalReady: boolean;
+  restoringSnapshot: boolean;
+  hibernated: boolean;
+}
+
+/**
+ * Restores keyboard focus after an in-place terminal rebuild (a reconnect swaps
+ * the session id, a hibernate wake, or a transparency toggle).
+ *
+ * Every focus request issued while the snapshot-restore overlay still hides
+ * the container is silently dropped — `focus()` is a no-op on a
+ * `visibility: hidden` element. That swallows both the focus the terminal
+ * owned before the rebuild (reconnect, issue #603) and the focus requests for
+ * the newly active pane (hibernate wake on tab switch, issue #613: the
+ * `focus-terminal-<sessionId>` event and the "active" fit's `focus: true`
+ * both fire inside the hidden window). Once the rebuilt terminal is ready and
+ * revealed, reclaim focus for the active visible pane — mirroring the "active"
+ * fit's existing intent — without stealing it from another focused element.
+ */
+export function useTerminalFocusRestore({
+  terminalRef,
+  pendingFocusRestoreRef,
+  activeRef,
+  visibleRef,
+  terminalReady,
+  restoringSnapshot,
+  hibernated,
+}: UseTerminalFocusRestoreParams) {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refs are intentionally read once per ready/reveal transition.
+  useEffect(() => {
+    if (!terminalReady || restoringSnapshot || hibernated) return;
+    const hadFocusBeforeRebuild = pendingFocusRestoreRef.current;
+    pendingFocusRestoreRef.current = false;
+    if (!visibleRef.current) return;
+    if (!hadFocusBeforeRebuild && !activeRef.current) return;
+    const activeElement = document.activeElement;
+    // Only reclaim focus when nothing else has taken it while the terminal was
+    // being rebuilt (e.g. the user clicked another pane or an input).
+    if (activeElement && activeElement !== document.body) return;
+    terminalRef.current?.focus();
+  }, [terminalReady, restoringSnapshot, hibernated]);
+}


### PR DESCRIPTION
## Summary

修复两个终端失去输入焦点的 bug：

- Fixes #603 —— 断开后按回车重连，连接完成后无法直接输入（失去焦点）
- Fixes #613 —— 切换回一个触发休眠的标签后，输入焦点丢失

## Root Cause

两个 issue 共享同一底层机制：终端原地重建（in-place rebuild）后，快照恢复期间容器处于 `visibility: hidden`，此时所有聚焦请求都被浏览器静默吞掉（`focus()` 对不可渲染元素是 no-op），恢复完成、容器显示后没有任何代码重试聚焦：

- **#603（重连）**：按回车重连后 `sessionId` 被替换，终端创建 effect 重新执行，旧的 xterm 实例被 dispose（textarea 从 DOM 移除，焦点掉到 `<body>`）。`useTerminalRefreshEffects` 中 "active" fit 的 `focus: true` 在 `terminalReady` 变 true 时触发，但此时仍在隐藏的恢复窗口内，静默失败。
- **#613（休眠唤醒）**：后台标签深度休眠 120s 后渲染器被释放；切回该标签时渲染器重建并走快照恢复。TabBar 发出的 `focus-terminal-<sessionId>` 事件和 "active" fit 的聚焦请求全部落在隐藏窗口内被吞掉。与 #603 不同的是，休眠的标签在释放前本就不持有焦点，因此不能靠"重建前是否持有焦点"来恢复。

## Changes

- **`src/components/terminal/useTerminalFocusRestore.ts`**（新增）：终端就绪且快照恢复完成（容器已显示）后重新聚焦，条件为重建前持有焦点（#603 路径）或该 pane 激活且可见（#613 路径，即 "active" fit `focus: true` 的既有意图）。带安全护栏：若重建期间其他元素（另一个 pane、搜索框、输入框等）已获得焦点，则不抢夺。
- **`src/components/terminal/XTerminal.tsx`**：终端创建 effect 的 cleanup 中，在 `terminal.dispose()` 前检测旧终端 textarea 是否持有焦点，记录到 `pendingFocusRestoreRef`；并接入新 hook。
- **`src/components/terminal/useTerminalFocusRestore.test.ts`**（新增）：6 个用例，覆盖恢复时序（ready 但仍隐藏时不聚焦 → 显示后才聚焦且仅一次）、休眠唤醒后无先前焦点也恢复、休眠期间保持挂起标志、不抢其他元素焦点、非激活/隐藏 pane 跳过、无快照恢复的重建。

## Test plan

- [x] `npx vitest run src/components/terminal/` —— 22 个文件 136 个用例全部通过
- [x] `npx tsc --noEmit` 无错误
- [x] `npx biome check` 新增文件无告警
- [x] `pnpm tauri dev` 手动验证：
  - SSH 输入 `exit` → 按回车重连 → 连接完成后直接打字可立即输入（#603）
  - 打开标签 a、b → 停留 b 超过 2 分钟（触发休眠）→ 切回 a → 直接打字可立即输入（#613）
  - 回归：切换标签焦点正常；点击其他 pane / 搜索框后焦点不被终端抢走