### PR TITLE
fix(settings): apply theme designer changes immediately

### DIFF
--- a/src/components/dialog/theme/ThemeDesignerDialog.tsx
+++ b/src/components/dialog/theme/ThemeDesignerDialog.tsx
@@ -31,13 +31,16 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   ALL_THEME_COLOR_FIELDS,
+  appendCustomThemePatch,
   cloneThemeAsCustom,
   getThemeColor,
   isHexColor,
   normalizeImportedTheme,
+  removeCustomThemePatch,
   setThemeColor,
   structuredCloneTheme,
   UI_THEME_COLOR_FIELDS,
+  upsertCustomThemePatch,
   validateTheme,
 } from "@/lib/customThemes";
 import { invoke } from "@/lib/invoke";
@@ -50,7 +53,16 @@ interface ThemeDesignerDialogProps {
   onClose: () => void;
   appearance: AppearanceSettings;
   availableThemes: Theme[];
-  updateAppearance: (patch: Partial<AppearanceSettings>) => void;
+  /**
+   * Applies an appearance patch immediately: updates the settings draft and
+   * the committed app settings (persisting the change across windows).
+   * The function form receives the previous appearance of each target state.
+   */
+  applyAppearance: (
+    patch:
+      | Partial<AppearanceSettings>
+      | ((prev: AppearanceSettings) => Partial<AppearanceSettings>),
+  ) => void;
 }
 
 function hexToRgb(hex: string) {
@@ -93,7 +105,7 @@ export function ThemeDesignerDialog({
   onClose,
   appearance,
   availableThemes,
-  updateAppearance,
+  applyAppearance,
 }: ThemeDesignerDialogProps) {
   const { t } = useTranslation();
   const customThemes = appearance.custom_themes ?? [];
@@ -139,10 +151,7 @@ export function ThemeDesignerDialog({
       return false;
     }
     const nextTheme = structuredCloneTheme(draft);
-    const nextThemes = customThemes.some((theme) => theme.id === nextTheme.id)
-      ? customThemes.map((theme) => (theme.id === nextTheme.id ? nextTheme : theme))
-      : [...customThemes, nextTheme];
-    updateAppearance({ custom_themes: nextThemes });
+    applyAppearance((prev) => upsertCustomThemePatch(prev, nextTheme));
     setSelectedThemeId(nextTheme.id);
     toast.success(t("settings.themeDesignerSaved"));
     return true;
@@ -164,13 +173,10 @@ export function ThemeDesignerDialog({
 
   function deleteSelected() {
     if (!draft || !customThemes.some((theme) => theme.id === draft.id)) return;
-    const nextThemes = customThemes.filter((theme) => theme.id !== draft.id);
-    const patch: Partial<AppearanceSettings> = { custom_themes: nextThemes };
-    if (appearance.theme === draft.id) patch.theme = DEFAULT_THEME_ID;
-    if (appearance.terminal_theme === draft.id) patch.terminal_theme = null;
-    updateAppearance(patch);
-    const next = nextThemes[0]
-      ? structuredCloneTheme(nextThemes[0])
+    applyAppearance((prev) => removeCustomThemePatch(prev, draft.id, DEFAULT_THEME_ID));
+    const remaining = customThemes.filter((theme) => theme.id !== draft.id);
+    const next = remaining[0]
+      ? structuredCloneTheme(remaining[0])
       : cloneThemeAsCustom(sourceTheme);
     setSelectedThemeId(next.id);
     setDraft(next);
@@ -215,7 +221,7 @@ export function ThemeDesignerDialog({
         toast.error(t("settings.themeDesignerImportInvalid"));
         return;
       }
-      updateAppearance({ custom_themes: [...customThemes, next] });
+      applyAppearance((prev) => appendCustomThemePatch(prev, next));
       setSelectedThemeId(next.id);
       setDraft(structuredCloneTheme(next));
       toast.success(t("settings.themeDesignerImportSuccess"));

--- a/src/components/settings/AppearanceTab.tsx
+++ b/src/components/settings/AppearanceTab.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useApp } from "@/context/AppContext";
+import { useSettingsDraft } from "@/context/SettingsDraftContext";
 import { useTheme } from "@/context/ThemeContext";
 import {
   BACKGROUND_IMAGE_FITS,
@@ -886,12 +887,41 @@ export function AppearanceTab() {
   }, []);
 
   const updateAppearance = useCallback(
-    (patch: Partial<AppearanceSettings>) => {
+    (
+      patch:
+        | Partial<AppearanceSettings>
+        | ((prev: AppearanceSettings) => Partial<AppearanceSettings>),
+    ) => {
       updateAppSettings((prev) => ({
-        appearance: { ...prev.appearance, ...patch },
+        appearance: {
+          ...prev.appearance,
+          ...(typeof patch === "function" ? patch(prev.appearance) : patch),
+        },
       }));
     },
     [updateAppSettings],
+  );
+
+  const { updateCommittedAppSettings } = useSettingsDraft();
+
+  // Theme designer operations (import/save/delete) have immediate-effect
+  // semantics: apply them to the settings draft AND the committed app settings
+  // so they persist and appear in every theme list without restarting.
+  const applyAppearance = useCallback(
+    (
+      patch:
+        | Partial<AppearanceSettings>
+        | ((prev: AppearanceSettings) => Partial<AppearanceSettings>),
+    ) => {
+      updateAppearance(patch);
+      updateCommittedAppSettings((prev) => ({
+        appearance: {
+          ...prev.appearance,
+          ...(typeof patch === "function" ? patch(prev.appearance) : patch),
+        },
+      }));
+    },
+    [updateAppearance, updateCommittedAppSettings],
   );
   const updateUiFontFamily = useCallback(
     (uiFontFamily: string) => updateAppearance({ ui_font_family: uiFontFamily }),
@@ -1107,7 +1137,7 @@ export function AppearanceTab() {
         onClose={() => setThemeDesignerOpen(false)}
         appearance={appearance}
         availableThemes={themeNames}
-        updateAppearance={updateAppearance}
+        applyAppearance={applyAppearance}
       />
     </div>
   );

--- a/src/context/SettingsDraftContext.tsx
+++ b/src/context/SettingsDraftContext.tsx
@@ -1,10 +1,18 @@
 import { createContext, useContext } from "react";
+import type { DraftSettingsUpdate } from "@/hooks/useSettingsDraftState";
 import type { AppSettings } from "@/types/global";
 
 interface SettingsDraftContextValue {
   committedSettings: AppSettings;
   isDirty: boolean;
   isSaving: boolean;
+  /**
+   * Updates the committed app settings (bypassing the settings draft) and
+   * schedules persistence. Use for operations with immediate-effect semantics
+   * (e.g. theme designer import/save/delete) so changes apply across windows
+   * without waiting for the user to click Apply.
+   */
+  updateCommittedAppSettings: (updates: DraftSettingsUpdate<AppSettings>) => void;
 }
 
 export const SettingsDraftContext = createContext<SettingsDraftContextValue | null>(null);

--- a/src/lib/customThemes.test.ts
+++ b/src/lib/customThemes.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { AppearanceSettings } from "@/types/global";
+import { DEFAULT_THEME_ID, themes, type Theme } from "./themes";
+import { appendCustomThemePatch, removeCustomThemePatch, upsertCustomThemePatch } from "./customThemes";
+
+function makeTheme(id: string, name = id): Theme {
+  return { ...structuredClone(themes[DEFAULT_THEME_ID]), id, name, label: name };
+}
+
+function makeAppearance(overrides: Partial<AppearanceSettings> = {}): AppearanceSettings {
+  return {
+    theme: DEFAULT_THEME_ID,
+    terminal_theme: null,
+    custom_themes: [],
+    ...overrides,
+  } as AppearanceSettings;
+}
+
+describe("upsertCustomThemePatch", () => {
+  it("appends the theme when the list does not contain it", () => {
+    const existing = makeTheme("custom-1");
+    const incoming = makeTheme("custom-2");
+    const patch = upsertCustomThemePatch(makeAppearance({ custom_themes: [existing] }), incoming);
+    expect(patch.custom_themes).toEqual([existing, incoming]);
+  });
+
+  it("replaces the theme with the same id", () => {
+    const existing = makeTheme("custom-1");
+    const updated = { ...existing, name: "renamed" };
+    const patch = upsertCustomThemePatch(makeAppearance({ custom_themes: [existing] }), updated);
+    expect(patch.custom_themes).toEqual([updated]);
+  });
+
+  it("treats a missing custom_themes list as empty", () => {
+    const incoming = makeTheme("custom-1");
+    const patch = upsertCustomThemePatch(
+      makeAppearance({ custom_themes: undefined }),
+      incoming,
+    );
+    expect(patch.custom_themes).toEqual([incoming]);
+  });
+});
+
+describe("appendCustomThemePatch", () => {
+  it("appends the theme to the existing list", () => {
+    const existing = makeTheme("custom-1");
+    const incoming = makeTheme("custom-2");
+    const patch = appendCustomThemePatch(makeAppearance({ custom_themes: [existing] }), incoming);
+    expect(patch.custom_themes).toEqual([existing, incoming]);
+  });
+
+  it("treats a missing custom_themes list as empty", () => {
+    const incoming = makeTheme("custom-1");
+    const patch = appendCustomThemePatch(makeAppearance({ custom_themes: undefined }), incoming);
+    expect(patch.custom_themes).toEqual([incoming]);
+  });
+});
+
+describe("removeCustomThemePatch", () => {
+  it("removes the theme and keeps unrelated active themes", () => {
+    const first = makeTheme("custom-1");
+    const second = makeTheme("custom-2");
+    const patch = removeCustomThemePatch(
+      makeAppearance({ theme: DEFAULT_THEME_ID, custom_themes: [first, second] }),
+      "custom-1",
+      DEFAULT_THEME_ID,
+    );
+    expect(patch.custom_themes).toEqual([second]);
+    expect(patch.theme).toBeUndefined();
+    expect(patch.terminal_theme).toBeUndefined();
+  });
+
+  it("resets the active UI theme when the removed theme is active", () => {
+    const first = makeTheme("custom-1");
+    const patch = removeCustomThemePatch(
+      makeAppearance({ theme: "custom-1", custom_themes: [first] }),
+      "custom-1",
+      DEFAULT_THEME_ID,
+    );
+    expect(patch.theme).toBe(DEFAULT_THEME_ID);
+  });
+
+  it("resets the active terminal theme when the removed theme is active", () => {
+    const first = makeTheme("custom-1");
+    const patch = removeCustomThemePatch(
+      makeAppearance({ terminal_theme: "custom-1", custom_themes: [first] }),
+      "custom-1",
+      DEFAULT_THEME_ID,
+    );
+    expect(patch.terminal_theme).toBeNull();
+  });
+});

--- a/src/lib/customThemes.ts
+++ b/src/lib/customThemes.ts
@@ -1,3 +1,4 @@
+import type { AppearanceSettings } from "@/types/global";
 import { isBuiltinThemeId, type TerminalColors, type Theme, type ThemeColors } from "./themes";
 
 export type ThemeColorPath =
@@ -86,6 +87,42 @@ export function cloneThemeAsCustom(source: Theme, name?: string): Theme {
 
 export function structuredCloneTheme(theme: Theme): Theme {
   return JSON.parse(JSON.stringify(theme)) as Theme;
+}
+
+/** Appearance patch that inserts or updates a custom theme in the list. */
+export function upsertCustomThemePatch(
+  prev: AppearanceSettings,
+  theme: Theme,
+): Partial<AppearanceSettings> {
+  const prevThemes = prev.custom_themes ?? [];
+  const nextThemes = prevThemes.some((item) => item.id === theme.id)
+    ? prevThemes.map((item) => (item.id === theme.id ? theme : item))
+    : [...prevThemes, theme];
+  return { custom_themes: nextThemes };
+}
+
+/** Appearance patch that appends a custom theme to the list. */
+export function appendCustomThemePatch(
+  prev: AppearanceSettings,
+  theme: Theme,
+): Partial<AppearanceSettings> {
+  return { custom_themes: [...(prev.custom_themes ?? []), theme] };
+}
+
+/**
+ * Appearance patch that removes a custom theme, resetting the active UI/terminal
+ * theme when it pointed at the removed theme.
+ */
+export function removeCustomThemePatch(
+  prev: AppearanceSettings,
+  themeId: string,
+  defaultThemeId: string,
+): Partial<AppearanceSettings> {
+  const nextThemes = (prev.custom_themes ?? []).filter((item) => item.id !== themeId);
+  const patch: Partial<AppearanceSettings> = { custom_themes: nextThemes };
+  if (prev.theme === themeId) patch.theme = defaultThemeId;
+  if (prev.terminal_theme === themeId) patch.terminal_theme = null;
+  return patch;
 }
 
 export function isHexColor(value: string) {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -476,6 +476,7 @@ export default function SettingsPage() {
           committedSettings,
           isDirty,
           isSaving,
+          updateCommittedAppSettings: app.updateAppSettings,
         }}
       >
         <AppContext.Provider value={nestedAppContextValue}>


### PR DESCRIPTION
Fixes #608

## 问题

在主题设计器中导入/保存主题后，主题不会出现在主题列表（设置窗口的主题下拉框、主窗口的 视图 → 主题 菜单）中，只能重启 NyaTerm 后才能看到。

## 根因

设置窗口采用草稿（draft）设置架构：所有设置页的修改先写入本地草稿，只有点击「应用/确定」后才通过 `save_app_settings` 持久化。

主题设计器的导入/保存/删除操作走的是 `updateAppearance` → 草稿更新，但：

1. **不会持久化** —— 草稿只有点「应用」才会保存；
2. **主题列表看不到** —— 主题下拉框和主窗口主题菜单读取的是已提交（committed）设置，而不是草稿。

而操作反馈的 toast 却显示「导入成功/主题已保存」，让用户误以为已生效。

## 修复

主题设计器的操作是明确的即时生效语义（按钮文案就是「保存主题/导入/删除主题」），因此让其同时更新草稿与已提交设置（与 AI 标签页「刷新模型」的既有即时生效模式一致）：

- `SettingsDraftContext` 新增 `updateCommittedAppSettings`，由 `SettingsPage` 提供真实的 `updateAppSettings`（带防抖持久化）
- `AppearanceTab` 新增 `applyAppearance` 双更新器：同时更新草稿（保持设计器 UI 同步）和已提交设置（持久化 + 跨窗口传播）
- `ThemeDesignerDialog` 的 prop 改为 `applyAppearance`，支持函数形式按各自状态计算 patch（删除主题时按各自状态的当前主题正确重置）
- 三个 patch 计算提取为纯函数 `upsertCustomThemePatch` / `appendCustomThemePatch` / `removeCustomThemePatch` 并补充单元测试

已提交设置的更新会触发防抖保存 → `settings-changed` 事件 → 各窗口重载，因此导入的主题立即出现在所有主题列表中。

## 测试

- [x] `src/lib/customThemes.test.ts`：8 个新单元测试
- [x] 全量测试套件通过（102 文件 / 599 测试）
- [x] `tsc --noEmit` 通过
- [x] 端到端验证（`pnpm tauri dev` + CDP 驱动 UI）：
  - 设计器保存主题后 ~800ms 内后端已持久化
  - 设置窗口主题下拉框立即显示新主题
  - 主窗口 视图 → 主题 菜单立即显示新主题