### PR TITLE
fix(sftp): 处理目录上传部分失败并限制会话初始化

### DIFF
--- a/src-tauri/src/core/sftp/sftp_backend/config.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/config.rs
@@ -22,6 +22,7 @@ pub(super) const SFTP_MAX_SESSION_POOL_SIZE: usize = 4;
 pub(super) const SFTP_LARGE_FILE_CONCURRENCY: usize = 2;
 pub(super) const SFTP_HANDLE_RESERVE: usize = 8;
 pub(super) const SFTP_DIRECTORY_STALL_TIMEOUT: Duration = Duration::from_secs(60);
+pub(super) const SFTP_SESSION_SETUP_TIMEOUT: Duration = Duration::from_secs(10);
 pub(super) const SFTP_CHANNEL_OPEN_RETRY_DELAYS: [Duration; 3] = [
     Duration::from_millis(50),
     Duration::from_millis(150),

--- a/src-tauri/src/core/sftp/sftp_backend/copy.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/copy.rs
@@ -1111,6 +1111,8 @@ impl SftpBackend {
                 total_files,
                 bytes: bytes_written,
                 small_file_concurrency: 1,
+                failure_count: 0,
+                first_failure: None,
             })
         }
         .await;
@@ -1279,6 +1281,8 @@ impl SftpBackend {
                 total_files,
                 bytes: bytes_written,
                 small_file_concurrency: 1,
+                failure_count: 0,
+                first_failure: None,
             })
         }
         .await;

--- a/src-tauri/src/core/sftp/sftp_backend/directory.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/directory.rs
@@ -33,12 +33,26 @@ pub(super) struct LocalDirectoryInventory {
     pub(super) max_open_handles: Option<u64>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(super) struct DirectoryTransferSummary {
     pub(super) completed: u64,
     pub(super) total_files: u64,
     pub(super) bytes: u64,
     pub(super) small_file_concurrency: usize,
+    pub(super) failure_count: u64,
+    pub(super) first_failure: Option<DirectoryTransferFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DirectoryTransferFailure {
+    pub(super) path: String,
+    pub(super) error: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct UploadDirectoryFailures {
+    pub(super) count: u64,
+    pub(super) first: Option<DirectoryTransferFailure>,
 }
 
 #[allow(dead_code)]
@@ -477,6 +491,8 @@ impl SftpBackend {
                 total_files: 0,
                 bytes: 0,
                 small_file_concurrency: concurrency.small_file_concurrency,
+                failure_count: 0,
+                first_failure: None,
             });
         }
 
@@ -518,6 +534,8 @@ impl SftpBackend {
                 total_files: 0,
                 bytes: 0,
                 small_file_concurrency: concurrency.small_file_concurrency,
+                failure_count: 0,
+                first_failure: None,
             });
         }
 
@@ -808,8 +826,34 @@ pub(super) async fn run_download_directory_workers(
             total_files,
             bytes: completed_bytes.load(Ordering::SeqCst),
             small_file_concurrency: concurrency.small_file_concurrency,
+            failure_count: 0,
+            first_failure: None,
         })
     }
+}
+
+pub(super) fn finish_upload_directory_file(
+    result: AppResult<u64>,
+    path: String,
+    failures: &StdMutex<UploadDirectoryFailures>,
+    completed_count: &AtomicU64,
+) -> AppResult<u64> {
+    match result {
+        Ok(_) => {}
+        Err(error @ AppError::Cancelled(_)) => return Err(error),
+        Err(error) => {
+            let mut failures = failures.lock().unwrap();
+            failures.count = failures.count.saturating_add(1);
+            if failures.first.is_none() {
+                failures.first = Some(DirectoryTransferFailure {
+                    path,
+                    error: error.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(completed_count.fetch_add(1, Ordering::SeqCst) + 1)
 }
 
 pub(super) async fn run_upload_directory_workers(
@@ -827,6 +871,7 @@ pub(super) async fn run_upload_directory_workers(
     let queue = Arc::new(StdMutex::new(VecDeque::from(inventory.files)));
     let completed_count = Arc::new(AtomicU64::new(0));
     let completed_bytes = Arc::new(AtomicU64::new(0));
+    let failures = Arc::new(StdMutex::new(UploadDirectoryFailures::default()));
     let large_lane = Arc::new(Semaphore::new(concurrency.large_file_concurrency));
     let mut join_set = tokio::task::JoinSet::new();
 
@@ -837,6 +882,7 @@ pub(super) async fn run_upload_directory_workers(
         let directory_controller = directory_controller.clone();
         let completed_count = completed_count.clone();
         let completed_bytes = completed_bytes.clone();
+        let failures = failures.clone();
         let large_lane = large_lane.clone();
         let transfer_settings = transfer_settings.clone();
         join_set.spawn(async move {
@@ -857,7 +903,8 @@ pub(super) async fn run_upload_directory_workers(
                     None
                 };
                 let session = pool.session_for(worker_index);
-                let _bytes = upload_directory_file_with_session(
+                let failure_path = file.remote_path.clone();
+                let result = upload_directory_file_with_session(
                     &app,
                     session,
                     file,
@@ -867,8 +914,13 @@ pub(super) async fn run_upload_directory_workers(
                     total_size,
                     request_kib,
                 )
-                .await?;
-                let completed = completed_count.fetch_add(1, Ordering::SeqCst) + 1;
+                .await;
+                let completed = finish_upload_directory_file(
+                    result,
+                    failure_path,
+                    &failures,
+                    &completed_count,
+                )?;
                 directory_controller.update_item_progress(completed, total_files);
                 let bytes_done = completed_bytes.load(Ordering::SeqCst);
                 directory_controller.update_progress(bytes_done, total_size);
@@ -928,11 +980,14 @@ pub(super) async fn run_upload_directory_workers(
     if let Some(error) = first_err {
         Err(error)
     } else {
+        let failures = failures.lock().unwrap().clone();
         Ok(DirectoryTransferSummary {
             completed: completed_count.load(Ordering::SeqCst),
             total_files,
             bytes: completed_bytes.load(Ordering::SeqCst),
             small_file_concurrency: concurrency.small_file_concurrency,
+            failure_count: failures.count,
+            first_failure: failures.first,
         })
     }
 }

--- a/src-tauri/src/core/sftp/sftp_backend/directory.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/directory.rs
@@ -55,6 +55,20 @@ pub(super) struct UploadDirectoryFailures {
     pub(super) first: Option<DirectoryTransferFailure>,
 }
 
+#[derive(Debug)]
+pub(super) enum UploadDirectoryFileError {
+    Recoverable(AppError),
+    Fatal(AppError),
+}
+
+pub(super) type UploadDirectoryFileResult<T> = Result<T, UploadDirectoryFileError>;
+
+impl From<AppError> for UploadDirectoryFileError {
+    fn from(error: AppError) -> Self {
+        Self::Fatal(error)
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(super) struct RemoteRemoveEntry {
@@ -833,15 +847,18 @@ pub(super) async fn run_download_directory_workers(
 }
 
 pub(super) fn finish_upload_directory_file(
-    result: AppResult<u64>,
+    result: UploadDirectoryFileResult<u64>,
     path: String,
     failures: &StdMutex<UploadDirectoryFailures>,
     completed_count: &AtomicU64,
 ) -> AppResult<u64> {
     match result {
         Ok(_) => {}
-        Err(error @ AppError::Cancelled(_)) => return Err(error),
-        Err(error) => {
+        Err(UploadDirectoryFileError::Fatal(error)) => return Err(error),
+        Err(UploadDirectoryFileError::Recoverable(error @ AppError::Cancelled(_))) => {
+            return Err(error);
+        }
+        Err(UploadDirectoryFileError::Recoverable(error)) => {
             let mut failures = failures.lock().unwrap();
             failures.count = failures.count.saturating_add(1);
             if failures.first.is_none() {
@@ -854,6 +871,71 @@ pub(super) fn finish_upload_directory_file(
     }
 
     Ok(completed_count.fetch_add(1, Ordering::SeqCst) + 1)
+}
+
+pub(super) fn is_recoverable_upload_sftp_error(error: &SftpError) -> bool {
+    matches!(
+        error,
+        SftpError::Status(status)
+            if matches!(
+                status.status_code,
+                StatusCode::NoSuchFile | StatusCode::PermissionDenied | StatusCode::Failure
+            )
+    )
+}
+
+fn classify_upload_sftp_error(error: SftpError, message: String) -> UploadDirectoryFileError {
+    let app_error = AppError::Channel(message);
+    if is_recoverable_upload_sftp_error(&error) {
+        UploadDirectoryFileError::Recoverable(app_error)
+    } else {
+        UploadDirectoryFileError::Fatal(app_error)
+    }
+}
+
+fn sftp_error_source(error: &std::io::Error) -> Option<&SftpError> {
+    let mut source = error
+        .get_ref()
+        .map(|source| source as &(dyn std::error::Error + 'static));
+    while let Some(current) = source {
+        if let Some(error) = current.downcast_ref::<SftpError>() {
+            return Some(error);
+        }
+        source = current.source();
+    }
+    None
+}
+
+pub(super) fn classify_upload_sftp_io_error(
+    error: std::io::Error,
+    message: String,
+) -> UploadDirectoryFileError {
+    let recoverable = sftp_error_source(&error).is_some_and(is_recoverable_upload_sftp_error);
+    let app_error = AppError::Channel(message);
+    if recoverable {
+        UploadDirectoryFileError::Recoverable(app_error)
+    } else {
+        UploadDirectoryFileError::Fatal(app_error)
+    }
+}
+
+async fn wait_for_directory_upload_io<T, F, M>(
+    controller: &Arc<TransferController>,
+    future: F,
+    error_message: M,
+) -> UploadDirectoryFileResult<T>
+where
+    F: Future<Output = std::io::Result<T>>,
+    M: FnOnce(&std::io::Error) -> String,
+{
+    match wait_for_sftp_upload_io(controller, None, future, AppError::Io).await {
+        Ok(value) => Ok(value),
+        Err(AppError::Io(error)) => {
+            let message = error_message(&error);
+            Err(classify_upload_sftp_io_error(error, message))
+        }
+        Err(error) => Err(UploadDirectoryFileError::Fatal(error)),
+    }
 }
 
 pub(super) async fn run_upload_directory_workers(
@@ -1097,21 +1179,19 @@ pub(super) async fn upload_directory_file_with_session(
     completed_bytes: &Arc<AtomicU64>,
     total_size: u64,
     request_kib: usize,
-) -> AppResult<u64> {
+) -> UploadDirectoryFileResult<u64> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     wait_for_transfer_ready(directory_controller).await?;
     let mut local_file = tokio::fs::File::open(&file.local_path).await.map_err(|e| {
-        AppError::Channel(format!(
+        UploadDirectoryFileError::Recoverable(AppError::Channel(format!(
             "Failed to open local file {}: {}",
             file.local_path, e
-        ))
+        )))
     })?;
     let mut remote_file = sftp.create(&file.remote_path).await.map_err(|e| {
-        AppError::Channel(format!(
-            "Failed to create remote file {}: {}",
-            file.remote_path, e
-        ))
+        let message = format!("Failed to create remote file {}: {}", file.remote_path, e);
+        classify_upload_sftp_error(e, message)
     })?;
 
     let mut buf = vec![0u8; sftp_payload_size(request_kib)];
@@ -1120,19 +1200,18 @@ pub(super) async fn upload_directory_file_with_session(
     loop {
         wait_for_transfer_ready(directory_controller).await?;
         let read = local_file.read(&mut buf).await.map_err(|e| {
-            AppError::Channel(format!(
+            UploadDirectoryFileError::Recoverable(AppError::Channel(format!(
                 "Failed to read local file {}: {}",
                 file.local_path, e
-            ))
+            )))
         })?;
         if read == 0 {
             break;
         }
-        wait_for_sftp_upload_io(
+        wait_for_directory_upload_io(
             directory_controller,
-            None,
             remote_file.write_all(&buf[..read]),
-            |e| AppError::Channel(format!("SFTP write failed for {}: {}", file.remote_path, e)),
+            |e| format!("SFTP write failed for {}: {}", file.remote_path, e),
         )
         .await?;
         bytes_transferred = bytes_transferred.saturating_add(read as u64);
@@ -1151,8 +1230,8 @@ pub(super) async fn upload_directory_file_with_session(
             );
         }
     }
-    wait_for_sftp_upload_io(directory_controller, None, remote_file.shutdown(), |e| {
-        AppError::Channel(format!("SFTP flush failed for {}: {}", file.remote_path, e))
+    wait_for_directory_upload_io(directory_controller, remote_file.shutdown(), |e| {
+        format!("SFTP flush failed for {}: {}", file.remote_path, e)
     })
     .await?;
 

--- a/src-tauri/src/core/sftp/sftp_backend/fs.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/fs.rs
@@ -965,6 +965,22 @@ impl RemoteFs for SftpBackend {
 
         match result {
             Ok(summary) => {
+                let first_failure = summary.first_failure.as_ref();
+                let failure_detail =
+                    first_failure.map(|failure| format!("{}: {}", failure.path, failure.error));
+                if summary.total_files > 0 && summary.failure_count == summary.total_files {
+                    let error = AppError::Channel(format!(
+                        "All {} files failed to upload; first failure: {}",
+                        summary.failure_count,
+                        failure_detail.as_deref().unwrap_or("unknown error")
+                    ));
+                    let _ = app.emit(
+                        "transfer-event",
+                        &directory_controller.build_event("error", 0, Some(error.to_string())),
+                    );
+                    unregister_transfer(&directory_controller.id());
+                    return Err(error);
+                }
                 log_transfer_performance(
                     "upload",
                     "directory",
@@ -977,9 +993,16 @@ impl RemoteFs for SftpBackend {
                 );
                 directory_controller.update_progress(summary.bytes, summary.bytes);
                 directory_controller.update_item_progress(summary.completed, summary.total_files);
+                let warning = (summary.failure_count > 0).then(|| {
+                    format!(
+                        "Skipped {} failed file(s); first failure: {}",
+                        summary.failure_count,
+                        failure_detail.as_deref().unwrap_or("unknown error")
+                    )
+                });
                 let _ = app.emit(
                     "transfer-event",
-                    &directory_controller.build_event("completed", 0, None),
+                    &directory_controller.build_event("completed", 0, warning),
                 );
                 unregister_transfer(&directory_controller.id());
                 Ok(())

--- a/src-tauri/src/core/sftp/sftp_backend/session.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/session.rs
@@ -69,8 +69,8 @@ impl SftpBackend {
         config: SftpClientConfig,
     ) -> AppResult<ManagedSftpSession> {
         for attempt in 0..=SFTP_CHANNEL_OPEN_RETRY_DELAYS.len() {
+            let permit = ssh_handle.acquire_sftp_channel_permit().await?;
             let setup_result = tokio::time::timeout(SFTP_SESSION_SETUP_TIMEOUT, async {
-                let permit = ssh_handle.acquire_sftp_channel_permit().await?;
                 let channel_result = {
                     let handle_mtx = ssh_handle.target_handle();
                     let handle = handle_mtx.lock().await;

--- a/src-tauri/src/core/sftp/sftp_backend/session.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/session.rs
@@ -69,39 +69,47 @@ impl SftpBackend {
         config: SftpClientConfig,
     ) -> AppResult<ManagedSftpSession> {
         for attempt in 0..=SFTP_CHANNEL_OPEN_RETRY_DELAYS.len() {
-            let permit = ssh_handle.acquire_sftp_channel_permit().await?;
-            let channel_result = {
-                let handle_mtx = ssh_handle.target_handle();
-                let handle = handle_mtx.lock().await;
-                handle.channel_open_session().await
-            };
+            let setup_result = tokio::time::timeout(SFTP_SESSION_SETUP_TIMEOUT, async {
+                let permit = ssh_handle.acquire_sftp_channel_permit().await?;
+                let channel_result = {
+                    let handle_mtx = ssh_handle.target_handle();
+                    let handle = handle_mtx.lock().await;
+                    handle.channel_open_session().await
+                };
+                let channel = match channel_result {
+                    Ok(channel) => channel,
+                    Err(error) => return Ok(Err(error)),
+                };
 
-            let channel = match channel_result {
-                Ok(channel) => channel,
+                channel.request_subsystem(true, "sftp").await.map_err(|e| {
+                    AppError::Channel(format!("Failed to start SFTP subsystem: {}", e))
+                })?;
+
+                let sftp =
+                    SftpSession::new_with_config(channel.into_stream(), config.clone()).await?;
+                AppResult::Ok(Ok(ManagedSftpSession::new(sftp, permit)))
+            })
+            .await
+            .map_err(|_| {
+                AppError::Channel("SFTP session setup timed out after 10 seconds".to_string())
+            })??;
+
+            match setup_result {
+                Ok(session) => return Ok(session),
                 Err(error)
                     if attempt < SFTP_CHANNEL_OPEN_RETRY_DELAYS.len()
                         && is_retryable_sftp_channel_open_error(&error) =>
                 {
-                    drop(permit);
                     tokio::time::sleep(SFTP_CHANNEL_OPEN_RETRY_DELAYS[attempt]).await;
                     continue;
                 }
                 Err(error) => {
-                    drop(permit);
                     return Err(AppError::Channel(format!(
                         "Failed to open SFTP channel: {}",
                         error
                     )));
                 }
-            };
-
-            channel
-                .request_subsystem(true, "sftp")
-                .await
-                .map_err(|e| AppError::Channel(format!("Failed to start SFTP subsystem: {}", e)))?;
-
-            let sftp = SftpSession::new_with_config(channel.into_stream(), config).await?;
-            return Ok(ManagedSftpSession::new(sftp, permit));
+            }
         }
 
         unreachable!("SFTP channel open retry loop always returns or continues");

--- a/src-tauri/src/core/sftp/sftp_backend/tests.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/tests.rs
@@ -387,13 +387,86 @@ fn directory_stall_watchdog_fires_only_while_running_without_progress() {
     ));
 }
 
+fn sftp_status_error(status_code: StatusCode) -> SftpError {
+    SftpError::Status(russh_sftp::protocol::Status {
+        id: 1,
+        status_code,
+        error_message: status_code.to_string(),
+        language_tag: "en-US".to_string(),
+    })
+}
+
 #[test]
-fn upload_directory_file_failure_is_recorded_and_counted_as_processed() {
+fn upload_directory_sftp_error_classification_keeps_only_file_statuses_recoverable() {
+    for status_code in [
+        StatusCode::NoSuchFile,
+        StatusCode::PermissionDenied,
+        StatusCode::Failure,
+    ] {
+        assert!(is_recoverable_upload_sftp_error(&sftp_status_error(
+            status_code
+        )));
+    }
+
+    for status_code in [
+        StatusCode::Eof,
+        StatusCode::BadMessage,
+        StatusCode::NoConnection,
+        StatusCode::ConnectionLost,
+        StatusCode::OpUnsupported,
+    ] {
+        assert!(!is_recoverable_upload_sftp_error(&sftp_status_error(
+            status_code
+        )));
+    }
+
+    for error in [
+        SftpError::IO("connection reset".to_string()),
+        SftpError::Timeout,
+        SftpError::Limited("limit".to_string()),
+        SftpError::UnexpectedPacket,
+        SftpError::UnexpectedBehavior("session closed".to_string()),
+    ] {
+        assert!(!is_recoverable_upload_sftp_error(&error));
+    }
+}
+
+#[test]
+fn upload_directory_io_error_uses_preserved_sftp_source_classification() {
+    let recoverable = classify_upload_sftp_io_error(
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            sftp_status_error(StatusCode::PermissionDenied),
+        ),
+        "write denied".to_string(),
+    );
+    assert!(matches!(
+        recoverable,
+        UploadDirectoryFileError::Recoverable(_)
+    ));
+
+    let fatal = classify_upload_sftp_io_error(
+        std::io::Error::new(std::io::ErrorKind::TimedOut, SftpError::Timeout),
+        "write timed out".to_string(),
+    );
+    assert!(matches!(fatal, UploadDirectoryFileError::Fatal(_)));
+
+    let untyped_io = classify_upload_sftp_io_error(
+        std::io::Error::new(std::io::ErrorKind::BrokenPipe, "session closed"),
+        "write failed".to_string(),
+    );
+    assert!(matches!(untyped_io, UploadDirectoryFileError::Fatal(_)));
+}
+
+#[test]
+fn recoverable_upload_directory_file_failure_is_recorded_and_counted_as_processed() {
     let failures = StdMutex::new(UploadDirectoryFailures::default());
     let completed_count = AtomicU64::new(0);
 
     let first_completed = finish_upload_directory_file(
-        Err(AppError::Channel("permission denied".to_string())),
+        Err(UploadDirectoryFileError::Recoverable(AppError::Channel(
+            "permission denied".to_string(),
+        ))),
         "/remote/locked.txt".to_string(),
         &failures,
         &completed_count,
@@ -438,12 +511,34 @@ fn upload_directory_file_failure_is_recorded_and_counted_as_processed() {
 }
 
 #[test]
+fn upload_directory_session_failure_remains_fatal() {
+    let failures = StdMutex::new(UploadDirectoryFailures::default());
+    let completed_count = AtomicU64::new(0);
+
+    let error = finish_upload_directory_file(
+        Err(UploadDirectoryFileError::Fatal(AppError::Channel(
+            "SFTP session closed".to_string(),
+        ))),
+        "/remote/file.txt".to_string(),
+        &failures,
+        &completed_count,
+    )
+    .expect_err("session failures must abort the directory transfer");
+
+    assert!(error.to_string().contains("SFTP session closed"));
+    assert_eq!(completed_count.load(Ordering::SeqCst), 0);
+    assert_eq!(failures.lock().unwrap().count, 0);
+}
+
+#[test]
 fn upload_directory_file_cancellation_remains_fatal() {
     let failures = StdMutex::new(UploadDirectoryFailures::default());
     let completed_count = AtomicU64::new(0);
 
     let error = finish_upload_directory_file(
-        Err(AppError::Cancelled("cancelled".to_string())),
+        Err(UploadDirectoryFileError::Fatal(AppError::Cancelled(
+            "cancelled".to_string(),
+        ))),
         "/remote/file.txt".to_string(),
         &failures,
         &completed_count,

--- a/src-tauri/src/core/sftp/sftp_backend/tests.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/tests.rs
@@ -387,6 +387,74 @@ fn directory_stall_watchdog_fires_only_while_running_without_progress() {
     ));
 }
 
+#[test]
+fn upload_directory_file_failure_is_recorded_and_counted_as_processed() {
+    let failures = StdMutex::new(UploadDirectoryFailures::default());
+    let completed_count = AtomicU64::new(0);
+
+    let first_completed = finish_upload_directory_file(
+        Err(AppError::Channel("permission denied".to_string())),
+        "/remote/locked.txt".to_string(),
+        &failures,
+        &completed_count,
+    )
+    .expect("ordinary file failures should be skipped");
+    let second_completed = finish_upload_directory_file(
+        Ok(12),
+        "/remote/ok.txt".to_string(),
+        &failures,
+        &completed_count,
+    )
+    .expect("later files should still be processed");
+
+    assert_eq!(first_completed, 1);
+    assert_eq!(second_completed, 2);
+    assert_eq!(completed_count.load(Ordering::SeqCst), 2);
+    let failures = failures.lock().unwrap();
+    assert_eq!(failures.count, 1);
+    assert_eq!(
+        failures.first,
+        Some(DirectoryTransferFailure {
+            path: "/remote/locked.txt".to_string(),
+            error: "permission denied".to_string(),
+        })
+    );
+
+    let previous = DirectoryProgressSnapshot {
+        bytes: 0,
+        completed: 1,
+    };
+    let current = DirectoryProgressSnapshot {
+        bytes: 0,
+        completed: 2,
+    };
+    assert!(!directory_transfer_stalled(
+        TransferControlState::Running,
+        previous,
+        current,
+        SFTP_DIRECTORY_STALL_TIMEOUT,
+        3,
+    ));
+}
+
+#[test]
+fn upload_directory_file_cancellation_remains_fatal() {
+    let failures = StdMutex::new(UploadDirectoryFailures::default());
+    let completed_count = AtomicU64::new(0);
+
+    let error = finish_upload_directory_file(
+        Err(AppError::Cancelled("cancelled".to_string())),
+        "/remote/file.txt".to_string(),
+        &failures,
+        &completed_count,
+    )
+    .expect_err("cancellation must abort the directory transfer");
+
+    assert!(matches!(error, AppError::Cancelled(_)));
+    assert_eq!(completed_count.load(Ordering::SeqCst), 0);
+    assert_eq!(failures.lock().unwrap().count, 0);
+}
+
 #[tokio::test]
 async fn directory_worker_error_aborts_remaining_workers() {
     let mut join_set = tokio::task::JoinSet::new();

--- a/src-tauri/vendor/russh-sftp/src/client/fs/file.rs
+++ b/src-tauri/vendor/russh-sftp/src/client/fs/file.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::VecDeque,
+    fmt,
     future::{self, Future},
     io::{self, SeekFrom},
     pin::Pin,
@@ -25,6 +26,33 @@ type StateFn<T> = Option<Pin<Box<dyn Future<Output = io::Result<T>> + Send + Syn
 const READ_OVERHEAD_LENGTH: u32 = 9;
 // write packet overhead excluding handle: type(1) + id(4) + handle_len(4) + offset(8) + data_len(4)
 const WRITE_OVERHEAD_LENGTH: u32 = 21;
+
+#[derive(Debug)]
+struct SftpIoError {
+    message: String,
+    source: Error,
+}
+
+impl fmt::Display for SftpIoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SftpIoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+fn io_error_with_sftp_source(kind: io::ErrorKind, message: String, source: Error) -> io::Error {
+    io::Error::new(kind, SftpIoError { message, source })
+}
+
+fn sftp_error_to_io(error: Error) -> io::Error {
+    let message = error.to_string();
+    io_error_with_sftp_source(io::ErrorKind::Other, message, error)
+}
 
 struct FileState {
     f_read: StateFn<Option<Vec<u8>>>,
@@ -128,13 +156,25 @@ impl File {
 fn check_write_result(result: SftpResult<Packet>) -> io::Result<()> {
     match result {
         Ok(Packet::Status(s)) if s.status_code == StatusCode::Ok => Ok(()),
-        Ok(Packet::Status(s)) => Err(io::Error::other(s.error_message)),
-        Ok(_) => Err(io::Error::other("unexpected response packet")),
-        Err(Error::Timeout) => Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "SFTP write acknowledgement timed out",
+        Ok(Packet::Status(s)) => {
+            let message = s.error_message.clone();
+            Err(io_error_with_sftp_source(
+                io::ErrorKind::Other,
+                message,
+                Error::Status(s),
+            ))
+        }
+        Ok(_) => Err(io_error_with_sftp_source(
+            io::ErrorKind::Other,
+            "unexpected response packet".to_string(),
+            Error::UnexpectedPacket,
         )),
-        Err(e) => Err(io::Error::other(e.to_string())),
+        Err(Error::Timeout) => Err(io_error_with_sftp_source(
+            io::ErrorKind::TimedOut,
+            "SFTP write acknowledgement timed out".to_string(),
+            Error::Timeout,
+        )),
+        Err(e) => Err(sftp_error_to_io(e)),
     }
 }
 
@@ -322,7 +362,7 @@ impl AsyncWrite for File {
                 self.state.write_acks.push_back(rx);
                 Poll::Ready(Ok(len))
             }
-            Err(e) => Poll::Ready(Err(io::Error::other(e.to_string()))),
+            Err(e) => Poll::Ready(Err(sftp_error_to_io(e))),
         }
     }
 
@@ -344,7 +384,7 @@ impl AsyncWrite for File {
                         .fsync(file_handle)
                         .await
                         .map(|_| ())
-                        .map_err(|e| io::Error::other(e.to_string()))
+                        .map_err(sftp_error_to_io)
                 }))
             }
         })
@@ -374,10 +414,7 @@ impl AsyncWrite for File {
                 let file_handle = self.handle.clone();
 
                 self.state.f_shutdown.get_or_insert(Box::pin(async move {
-                    session
-                        .close(file_handle)
-                        .await
-                        .map_err(|e| io::Error::other(e.to_string()))?;
+                    session.close(file_handle).await.map_err(sftp_error_to_io)?;
                     Ok(())
                 }))
             }
@@ -399,8 +436,20 @@ mod tests {
     use super::*;
     use crate::client::{Config, RawSftpSession};
     use crate::protocol::{FileAttributes, Handle, OpenFlags, Packet, StatusCode, Version};
+    use std::error::Error as StdError;
     use std::time::Duration;
     use tokio::io::{AsyncWriteExt, DuplexStream};
+
+    fn sftp_error_source(error: &io::Error) -> Option<&Error> {
+        let mut source = error.source();
+        while let Some(current) = source {
+            if let Some(error) = current.downcast_ref::<Error>() {
+                return Some(error);
+            }
+            source = current.source();
+        }
+        None
+    }
 
     async fn read_client_packet(server: &mut DuplexStream) -> Packet {
         let mut bytes = crate::utils::read_packet(server, u32::MAX)
@@ -486,6 +535,71 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
         assert_eq!(error.to_string(), "SFTP write acknowledgement timed out");
+        assert!(matches!(sftp_error_source(&error), Some(Error::Timeout)));
+    }
+
+    #[test]
+    fn write_status_preserves_message_kind_and_sftp_source() {
+        let error = check_write_result(Ok(Packet::status(
+            1,
+            StatusCode::PermissionDenied,
+            "write denied",
+            "en-US",
+        )))
+        .expect_err("non-OK write status should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "write denied");
+        assert!(matches!(
+            sftp_error_source(&error),
+            Some(Error::Status(status)) if status.status_code == StatusCode::PermissionDenied
+        ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_status_preserves_message_kind_and_sftp_source() {
+        let (client, mut server) = tokio::io::duplex(4096);
+        let session = Arc::new(RawSftpSession::new_with_config(
+            client,
+            Config {
+                request_timeout_secs: 10,
+                ..Config::default()
+            },
+        ));
+        initialize_session(&session, &mut server).await;
+        let handle = open_test_handle(&session, &mut server).await;
+        let mut file = File::new(session, handle.clone(), test_features());
+
+        let client = file.shutdown();
+        let server = async {
+            let close_id = match read_client_packet(&mut server).await {
+                Packet::Close(close) => {
+                    assert_eq!(close.handle, handle);
+                    close.id
+                }
+                packet => panic!("expected close packet, got {packet:?}"),
+            };
+            write_server_packet(
+                &mut server,
+                Packet::status(
+                    close_id,
+                    StatusCode::PermissionDenied,
+                    "close denied",
+                    "en-US",
+                ),
+            )
+            .await;
+        };
+
+        let (result, _) = tokio::join!(client, server);
+        let error = result.expect_err("non-OK close status should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "Permission denied: close denied");
+        assert!(matches!(
+            sftp_error_source(&error),
+            Some(Error::Status(status)) if status.status_code == StatusCode::PermissionDenied
+        ));
     }
 
     #[tokio::test]

--- a/src/context/TransferContext.test.tsx
+++ b/src/context/TransferContext.test.tsx
@@ -1,0 +1,158 @@
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TransferProvider } from "./TransferContext";
+
+interface TransferEventPayload {
+  id: string;
+  session_id: string;
+  file_name: string;
+  remote_path: string;
+  local_path: string;
+  direction: string;
+  kind?: string;
+  status: string;
+  size: number;
+  bytes_transferred: number;
+  total_size: number;
+  error_msg?: string;
+}
+
+const mocks = vi.hoisted(() => ({
+  listener: undefined as
+    | ((event: { payload: TransferEventPayload }) => void)
+    | undefined,
+  invoke: vi.fn().mockResolvedValue(undefined),
+  toastDismiss: vi.fn(),
+  toastError: vi.fn(),
+  toastMessage: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(
+    async (
+      _event: string,
+      listener: (event: { payload: TransferEventPayload }) => void,
+    ) => {
+      mocks.listener = listener;
+      return () => {
+        mocks.listener = undefined;
+      };
+    },
+  ),
+}));
+
+vi.mock("@/lib/invoke", () => ({ invoke: mocks.invoke }));
+
+vi.mock("@/context/AppContext", () => ({
+  useApp: () => ({
+    appSettings: {
+      transfer: {
+        download_threads: 2,
+        duplicate_strategy: "overwrite",
+        upload_threads: 2,
+      },
+    },
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { name?: string }) =>
+      options?.name ? `${key}:${options.name}` : key,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    dismiss: mocks.toastDismiss,
+    error: mocks.toastError,
+    message: mocks.toastMessage,
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning,
+  },
+}));
+
+const baseEvent: TransferEventPayload = {
+  id: "transfer-1",
+  session_id: "session-1",
+  file_name: "folder",
+  remote_path: "/remote/folder",
+  local_path: "/local/folder",
+  direction: "upload",
+  kind: "directory",
+  status: "completed",
+  size: 10,
+  bytes_transferred: 10,
+  total_size: 10,
+};
+
+async function emitTransferEvent(payload: TransferEventPayload) {
+  await waitFor(() => expect(mocks.listener).toBeDefined());
+  act(() => {
+    mocks.listener?.({ payload });
+  });
+}
+
+describe("TransferProvider transfer completion toasts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listener = undefined;
+    render(
+      <TransferProvider>
+        <div />
+      </TransferProvider>,
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("warns when a directory upload completes with skipped files", async () => {
+    await emitTransferEvent({
+      ...baseEvent,
+      error_msg:
+        "Skipped 1 failed file(s); first failure: /remote/folder/locked.txt",
+    });
+
+    expect(mocks.toastWarning).toHaveBeenCalledWith(
+      "fileTransfer.uploadFolderCompleted",
+      {
+        description:
+          "Skipped 1 failed file(s); first failure: /remote/folder/locked.txt",
+      },
+    );
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("keeps the success toast for a fully successful directory upload", async () => {
+    await emitTransferEvent(baseEvent);
+
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "fileTransfer.uploadFolderCompleted",
+      {
+        description: "/remote/folder",
+      },
+    );
+    expect(mocks.toastWarning).not.toHaveBeenCalled();
+  });
+
+  it("keeps the failure toast for an upload error", async () => {
+    await emitTransferEvent({
+      ...baseEvent,
+      error_msg: "permission denied",
+      status: "error",
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "fileTransfer.uploadFolderFailed:folder",
+      {
+        description: "permission denied",
+      },
+    );
+    expect(mocks.toastWarning).not.toHaveBeenCalled();
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/context/TransferContext.tsx
+++ b/src/context/TransferContext.tsx
@@ -410,6 +410,12 @@ export function TransferProvider({ children }: { children: ReactNode }) {
             toast.dismiss(folderToastId);
             uploadFolderToastIdsRef.current.delete(p.id);
           }
+          if (kind === "directory" && p.error_msg) {
+            toast.warning(t("fileTransfer.uploadFolderCompleted"), {
+              description: p.error_msg,
+            });
+            return;
+          }
           toast.success(
             kind === "directory"
               ? t("fileTransfer.uploadFolderCompleted")


### PR DESCRIPTION
## 修复

- SFTP 目录上传仅对本地单文件打开/读取失败以及远端 `NoSuchFile`、`PermissionDenied`、`Failure` 等可恢复文件级错误记录失败并继续处理；失败项仍计入处理进度，部分完成保留失败数量和首个失败详情，session、transport、timeout 或协议层错误会立即终止整个目录上传。
- 为 SFTP channel permit、SSH handle lock、channel open、subsystem 请求及协议初始化增加统一的 10 秒初始化上限，同时保留原有可重试 channel-open 错误的短 backoff；部分完成的上传在前端改为 warning 提示。
- 未修改 SCP Enhanced 或 SCP Normal 的传输逻辑。

## 验证

SFTP 目录上传错误分类、worker 终止边界及 russh-sftp write/close 错误来源保留的回归测试通过，TransferContext 的部分完成提示回归测试也通过。TypeScript 类型检查、Rust 格式检查和前端 lint 均通过。

Fixes #578