### PR TITLE
fix(terminal): prevent IME Backspace double deletion

### DIFF
--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -113,6 +113,7 @@ import {
   quotePosixPath,
 } from "./xterminalClipboard";
 import { createXTerminalHibernationController } from "./xterminalHibernationController";
+import { createXTerminalImeTracker } from "./xterminalIme";
 import { installXTerminalKeyboardController } from "./xterminalKeyboardController";
 import { createXTerminalOutputController } from "./xterminalOutputController";
 import { installXTerminalSelectionController } from "./xterminalSelectionController";
@@ -861,6 +862,7 @@ export default function XTerminal({
     terminal.loadAddon(unicodeGraphemesAddon);
     installTerminalImageAddon(terminal, { sessionId, sessionType });
     terminal.open(containerRef.current);
+    const imeTracker = createXTerminalImeTracker(terminal.textarea);
 
     const coreService = (terminal as Terminal & XTermInternalTrimSource)._core
       ?.coreService;
@@ -1530,6 +1532,7 @@ export default function XTerminal({
 
     installXTerminalKeyboardController({
       terminal,
+      imeTracker,
       terminalAppSettingsRef,
       sessionTypeRef,
       inputStateRef,
@@ -2400,6 +2403,7 @@ export default function XTerminal({
           });
       }
       setTerminalReady(false);
+      imeTracker.dispose();
       selectionController.dispose();
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
       inputStateRef.current = createTerminalInputState();

--- a/src/components/terminal/xterminalIme.test.ts
+++ b/src/components/terminal/xterminalIme.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createXTerminalImeTracker, resolveXTerminalImeKeyboardRoute } from "./xterminalIme";
+
+function keyboardEvent(keyCode: number, isComposing = false): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "a",
+    code: "KeyA",
+  });
+  Object.defineProperties(event, {
+    isComposing: { value: isComposing },
+    keyCode: { value: keyCode },
+  });
+  return event;
+}
+
+describe("xterm IME ownership tracking", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("routes active, legacy, and ordinary keyboard events", () => {
+    expect(resolveXTerminalImeKeyboardRoute({ keyCode: 65, isComposing: true }, "idle")).toBe(
+      "native-ime",
+    );
+    expect(resolveXTerminalImeKeyboardRoute({ keyCode: 65 }, "composing")).toBe("native-ime");
+    expect(resolveXTerminalImeKeyboardRoute({ keyCode: 65 }, "ending")).toBe("native-ime");
+    expect(resolveXTerminalImeKeyboardRoute({ keyCode: 229 }, "idle")).toBe("xterm");
+    expect(resolveXTerminalImeKeyboardRoute({ keyCode: 65 }, "idle")).toBe("application");
+  });
+
+  it("keeps an ending boundary until the next task", async () => {
+    vi.useFakeTimers();
+    const textarea = document.createElement("textarea");
+    const tracker = createXTerminalImeTracker(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    expect(tracker.phase).toBe("composing");
+
+    textarea.dispatchEvent(new CompositionEvent("compositionend"));
+    expect(tracker.phase).toBe("ending");
+    expect(tracker.routeKeyboardEvent(keyboardEvent(229))).toBe("native-ime");
+
+    await vi.runAllTimersAsync();
+    expect(tracker.phase).toBe("idle");
+    expect(tracker.routeKeyboardEvent(keyboardEvent(65))).toBe("application");
+
+    tracker.dispose();
+  });
+
+  it("tracks composition input when lifecycle events are missing", async () => {
+    vi.useFakeTimers();
+    const textarea = document.createElement("textarea");
+    const tracker = createXTerminalImeTracker(textarea);
+
+    textarea.dispatchEvent(
+      new InputEvent("beforeinput", {
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }),
+    );
+    expect(tracker.phase).toBe("composing");
+
+    textarea.dispatchEvent(
+      new InputEvent("input", {
+        inputType: "insertFromComposition",
+        isComposing: false,
+      }),
+    );
+    expect(tracker.phase).toBe("ending");
+
+    await vi.runAllTimersAsync();
+    expect(tracker.phase).toBe("idle");
+
+    tracker.dispose();
+  });
+
+  it("recognizes a non-composing composition input as a boundary", async () => {
+    vi.useFakeTimers();
+    const textarea = document.createElement("textarea");
+    const tracker = createXTerminalImeTracker(textarea);
+
+    textarea.dispatchEvent(
+      new InputEvent("input", {
+        inputType: "deleteCompositionText",
+        isComposing: false,
+      }),
+    );
+    expect(tracker.phase).toBe("ending");
+
+    await vi.runAllTimersAsync();
+    expect(tracker.phase).toBe("idle");
+
+    tracker.dispose();
+  });
+
+  it("uses ordinary committed input as a missing compositionend fallback", async () => {
+    vi.useFakeTimers();
+    const textarea = document.createElement("textarea");
+    const tracker = createXTerminalImeTracker(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    textarea.dispatchEvent(
+      new InputEvent("input", {
+        inputType: "insertText",
+        isComposing: false,
+      }),
+    );
+    expect(tracker.phase).toBe("ending");
+
+    await vi.runAllTimersAsync();
+    expect(tracker.phase).toBe("idle");
+
+    tracker.dispose();
+  });
+
+  it("does not expire a valid paused composition and resets on blur", () => {
+    vi.useFakeTimers();
+    const textarea = document.createElement("textarea");
+    const tracker = createXTerminalImeTracker(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    vi.advanceTimersByTime(60_000);
+    expect(tracker.phase).toBe("composing");
+
+    textarea.dispatchEvent(new FocusEvent("blur"));
+    expect(tracker.phase).toBe("idle");
+
+    tracker.dispose();
+  });
+
+  it("removes listeners and resets phase and timer on dispose", async () => {
+    vi.useFakeTimers();
+    const textarea = document.createElement("textarea");
+    const tracker = createXTerminalImeTracker(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    textarea.dispatchEvent(new CompositionEvent("compositionend"));
+    tracker.dispose();
+
+    expect(tracker.phase).toBe("idle");
+    textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    expect(tracker.phase).toBe("idle");
+    await vi.runAllTimersAsync();
+    expect(tracker.phase).toBe("idle");
+  });
+});

--- a/src/components/terminal/xterminalIme.ts
+++ b/src/components/terminal/xterminalIme.ts
@@ -1,0 +1,128 @@
+export type XTerminalImePhase = "idle" | "composing" | "ending";
+
+export type XTerminalImeKeyboardRoute = "application" | "xterm" | "native-ime";
+
+export interface XTerminalImeKeyboardEventLike {
+  keyCode?: number;
+  isComposing?: boolean;
+}
+
+export interface XTerminalImeTracker {
+  readonly phase: XTerminalImePhase;
+  routeKeyboardEvent(event: KeyboardEvent): XTerminalImeKeyboardRoute;
+  dispose(): void;
+}
+
+// keyCode is deprecated, but 229 remains necessary for WebKit and legacy IMEs
+// whose boundary keydown can arrive after compositionend with isComposing=false.
+const IME_PROCESS_KEY_CODE = 229;
+
+function isCompositionInputType(inputType: string | undefined): boolean {
+  return inputType?.includes("Composition") === true;
+}
+
+/**
+ * Chooses whether an event belongs to the native IME, xterm's legacy fallback,
+ * or normal application keyboard handling. Callers decide which keys need this
+ * ownership boundary.
+ */
+export function resolveXTerminalImeKeyboardRoute(
+  event: XTerminalImeKeyboardEventLike,
+  phase: XTerminalImePhase,
+): XTerminalImeKeyboardRoute {
+  if (phase !== "idle" || event.isComposing === true) {
+    return "native-ime";
+  }
+  if (event.keyCode === IME_PROCESS_KEY_CODE) {
+    return "xterm";
+  }
+  return "application";
+}
+
+export function createXTerminalImeTracker(
+  textarea: HTMLTextAreaElement | undefined,
+): XTerminalImeTracker {
+  let phase: XTerminalImePhase = "idle";
+  let endingTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearEndingTimer = () => {
+    if (endingTimer !== null) {
+      clearTimeout(endingTimer);
+      endingTimer = null;
+    }
+  };
+
+  const markComposing = () => {
+    clearEndingTimer();
+    phase = "composing";
+  };
+
+  const markEnding = () => {
+    clearEndingTimer();
+    phase = "ending";
+    endingTimer = setTimeout(() => {
+      endingTimer = null;
+      phase = "idle";
+    }, 0);
+  };
+
+  const reset = () => {
+    clearEndingTimer();
+    phase = "idle";
+  };
+
+  const handleCompositionStart = () => {
+    markComposing();
+  };
+
+  const handleCompositionUpdate = () => {
+    markComposing();
+  };
+
+  const handleCompositionEnd = () => {
+    markEnding();
+  };
+
+  const handleInput = (rawEvent: Event) => {
+    const event = rawEvent as InputEvent;
+    if (event.isComposing) {
+      markComposing();
+      return;
+    }
+
+    // Some engines omit compositionstart/end or finish composition with a
+    // plain committed input. These are semantic composition boundaries.
+    if (phase === "composing" || isCompositionInputType(event.inputType)) {
+      markEnding();
+    }
+  };
+
+  if (textarea) {
+    textarea.addEventListener("compositionstart", handleCompositionStart, true);
+    textarea.addEventListener("compositionupdate", handleCompositionUpdate, true);
+    textarea.addEventListener("compositionend", handleCompositionEnd, true);
+    textarea.addEventListener("blur", reset, true);
+    textarea.addEventListener("beforeinput", handleInput, true);
+    textarea.addEventListener("input", handleInput, true);
+  }
+
+  return {
+    get phase() {
+      return phase;
+    },
+    routeKeyboardEvent(event: KeyboardEvent): XTerminalImeKeyboardRoute {
+      return resolveXTerminalImeKeyboardRoute(event, phase);
+    },
+    dispose() {
+      reset();
+      if (textarea) {
+        textarea.removeEventListener("compositionstart", handleCompositionStart, true);
+        textarea.removeEventListener("compositionupdate", handleCompositionUpdate, true);
+        textarea.removeEventListener("compositionend", handleCompositionEnd, true);
+        textarea.removeEventListener("blur", reset, true);
+        textarea.removeEventListener("beforeinput", handleInput, true);
+        textarea.removeEventListener("input", handleInput, true);
+      }
+    },
+  };
+}

--- a/src/components/terminal/xterminalKeyboardController.test.ts
+++ b/src/components/terminal/xterminalKeyboardController.test.ts
@@ -1,0 +1,134 @@
+import type { Terminal } from "@xterm/xterm";
+import { describe, expect, it, vi } from "vitest";
+import type { TerminalAppSettings } from "@/context/AppContext";
+import { createTerminalInputState } from "@/lib/terminalInputTracker";
+import type { SessionType } from "@/types/global";
+import type { XTerminalImeKeyboardRoute } from "./xterminalIme";
+import { installXTerminalKeyboardController } from "./xterminalKeyboardController";
+
+function backspaceEvent(keyCode: number, isComposing = false): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "Backspace",
+    code: "Backspace",
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperties(event, {
+    isComposing: { value: isComposing },
+    keyCode: { value: keyCode },
+  });
+  return event;
+}
+
+function createHarness(imeRoute: XTerminalImeKeyboardRoute, sessionType: SessionType = "Local") {
+  const keyHandlerRef: {
+    current: ((event: KeyboardEvent) => boolean) | null;
+  } = { current: null };
+  const terminal = {
+    attachCustomKeyEventHandler: vi.fn((handler: (event: KeyboardEvent) => boolean) => {
+      keyHandlerRef.current = handler;
+    }),
+    getSelection: vi.fn(() => ""),
+    hasSelection: vi.fn(() => false),
+  } as unknown as Terminal;
+  const routeKeyboardEvent = vi.fn(() => imeRoute);
+  const sendRawInput = vi.fn(async () => {});
+  const syncSuggestionsWithInputState = vi.fn();
+  const inputStateRef = {
+    current: {
+      ...createTerminalInputState(),
+      value: "a",
+      cursor: 1,
+    },
+  };
+
+  installXTerminalKeyboardController({
+    terminal,
+    imeTracker: { routeKeyboardEvent },
+    terminalAppSettingsRef: {
+      current: { keybindings: {} } as TerminalAppSettings,
+    },
+    sessionTypeRef: { current: sessionType },
+    inputStateRef,
+    disconnectedRef: { current: false },
+    onDisconnectedCloseRequestedRef: { current: undefined },
+    showSuggestionsRef: { current: false },
+    suggestionsRef: { current: [] },
+    doFindRef: { current: vi.fn() },
+    pasteClipboard: vi.fn(async () => {}),
+    pasteText: vi.fn(),
+    sendRawInput,
+    triggerSearch: vi.fn(),
+    dismissSuggestions: vi.fn(),
+    moveCredentialSelection: vi.fn(() => false),
+    isCredentialPanelActive: vi.fn(() => false),
+    moveCommandSuggestionSelection: vi.fn(() => false),
+    acceptCommandSuggestion: vi.fn(() => false),
+    isCredentialPromptInputMode: vi.fn(() => false),
+    clearSearchSelectionBeforeInput: vi.fn(() => false),
+    getSmartCursorSelectedInputRange: vi.fn(() => null),
+    deleteInputSelection: vi.fn(),
+    collapseInputSelection: vi.fn(),
+    replaceInputSelection: vi.fn(),
+    syncSuggestionsWithInputState,
+    lastSelectionRef: { current: "" },
+  });
+
+  const keyHandler = keyHandlerRef.current;
+  if (!keyHandler) {
+    throw new Error("keyboard handler was not installed");
+  }
+
+  return {
+    inputStateRef,
+    keyHandler,
+    routeKeyboardEvent,
+    sendRawInput,
+    syncSuggestionsWithInputState,
+  };
+}
+
+describe("installXTerminalKeyboardController IME Backspace routing", () => {
+  it("leaves IME Backspace native without preventing default", () => {
+    const harness = createHarness("native-ime");
+    const event = backspaceEvent(229, true);
+
+    expect(harness.keyHandler(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+    expect(harness.sendRawInput).not.toHaveBeenCalled();
+    expect(harness.syncSuggestionsWithInputState).not.toHaveBeenCalled();
+    expect(harness.inputStateRef.current.value).toBe("a");
+  });
+
+  it("delegates idle keyCode 229 Backspace to xterm", () => {
+    const harness = createHarness("xterm");
+    const event = backspaceEvent(229);
+
+    expect(harness.keyHandler(event)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(harness.sendRawInput).not.toHaveBeenCalled();
+    expect(harness.inputStateRef.current.value).toBe("a");
+  });
+
+  it("preserves the existing non-IME Local Backspace behavior", () => {
+    const harness = createHarness("application");
+    const event = backspaceEvent(8);
+
+    expect(harness.keyHandler(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(harness.sendRawInput).toHaveBeenCalledOnce();
+    expect(harness.sendRawInput).toHaveBeenCalledWith("\x7f", null);
+    expect(harness.syncSuggestionsWithInputState).toHaveBeenCalledOnce();
+    expect(harness.inputStateRef.current.value).toBe("");
+    expect(harness.inputStateRef.current.cursor).toBe(0);
+  });
+
+  it("does not apply the IME guard outside Local Backspace handling", () => {
+    const harness = createHarness("native-ime", "SSH");
+    const event = backspaceEvent(8, true);
+
+    expect(harness.keyHandler(event)).toBe(true);
+    expect(harness.routeKeyboardEvent).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/src/components/terminal/xterminalKeyboardController.ts
+++ b/src/components/terminal/xterminalKeyboardController.ts
@@ -20,6 +20,7 @@ import {
   type InputSelectionRange,
   isShiftInsertPasteEvent,
 } from "./terminalInputSelection";
+import type { XTerminalImeTracker } from "./xterminalIme";
 import {
   getCtrlPrintableCsiuInput,
   isLocalBackspaceEvent,
@@ -33,6 +34,7 @@ interface MutableRef<T> {
 
 interface InstallXTerminalKeyboardControllerParams {
   terminal: Terminal;
+  imeTracker: Pick<XTerminalImeTracker, "routeKeyboardEvent">;
   terminalAppSettingsRef: MutableRef<TerminalAppSettings>;
   sessionTypeRef: MutableRef<SessionType>;
   inputStateRef: MutableRef<TerminalInputState>;
@@ -68,6 +70,7 @@ interface InstallXTerminalKeyboardControllerParams {
 
 export function installXTerminalKeyboardController({
   terminal,
+  imeTracker,
   terminalAppSettingsRef,
   sessionTypeRef,
   inputStateRef,
@@ -196,6 +199,15 @@ export function installXTerminalKeyboardController({
     }
 
     if (isLocalBackspaceEvent(e, sessionTypeRef.current)) {
+      const imeRoute = imeTracker.routeKeyboardEvent(e);
+      if (imeRoute === "native-ime") {
+        // Stop xterm without preventDefault so the native IME can edit its preedit.
+        return false;
+      }
+      if (imeRoute === "xterm") {
+        return true;
+      }
+
       e.preventDefault();
       if (isCredentialPromptInputMode()) {
         sendRawInput(BACKSPACE_INPUT, null);


### PR DESCRIPTION
## 问题

macOS 的 Local Terminal 使用 IME 组合输入时，按下 `Backspace` 会同时删除 IME 预编辑文本和已输入的终端命令。

根因是 NyaTerm 的 Local Backspace custom handler 在 IME 处理预编辑文本的同时，仍直接向 PTY 发送了 `DEL (0x7f)`。

## 修复

- 基于 xterm textarea 的公开 composition/input events 跟踪 IME ownership，不依赖操作系统或输入法名称。
- 仅在现有的无 modifier Local Backspace 分支中应用该判断：
  - active/ending composition：阻止 xterm 发送终端数据，但不调用 `preventDefault()`，让原生 IME 继续修改 preedit；
  - idle `keyCode=229`：交回 xterm 的 textarea-diff fallback；
  - 普通 Backspace：继续执行原有 Local handler。
- terminal cleanup 时移除 listeners 并取消 pending timer。

本 PR 不调整其他按键、快捷键或非 Local session 的输入行为。

## 验证

- `pnpm exec tsc --noEmit`
- focused Vitest：4 files / 16 tests
- 全量 Vitest：102 files / 612 tests
- `pnpm lint`
- `pnpm build`

Lint 仅保留两个与本次修改无关的既有提示。

<!-- 最终 commit 完成 macOS/Sogou 复测后补充：
- macOS 26.6.2 + Sogou Pinyin 6.18.2：IME preedit Backspace、composition 结束后的普通 Backspace、English 模式均验证通过。
-->

Fixes #619