### PR TITLE
fix(ai): 修复重连后历史会话被误判为占用

### DIFF
--- a/src/components/panel/ai/AIAssistantPanel.test.tsx
+++ b/src/components/panel/ai/AIAssistantPanel.test.tsx
@@ -1,0 +1,265 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_AI_SETTINGS } from "@/lib/aiSettings";
+import type {
+  AIMessage,
+  AISession,
+  AISessionScope,
+  Tab,
+  TerminalSessionPane,
+} from "@/types/global";
+import AIAssistantPanel from "./AIAssistantPanel";
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+let appState: {
+  appSettings: {
+    ai: typeof DEFAULT_AI_SETTINGS;
+    ui: { language: string };
+  };
+  updateAppSettings: ReturnType<typeof vi.fn>;
+  tabs: Tab[];
+  savedConnections: [];
+};
+
+vi.mock("@/context/AppContext", () => ({
+  useApp: () => appState,
+}));
+
+vi.mock("@/context/ThemeContext", () => ({
+  useTheme: () => ({ theme: { colors: {} } }),
+}));
+
+vi.mock("@/lib/invoke", () => ({ invoke: invokeMock }));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: vi.fn(),
+  listen: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+vi.mock("@/components/dialog/ai/AIAssistantDialogs", () => ({
+  AIAssistantDialogs: () => null,
+}));
+
+vi.mock("./ModelCombobox", () => ({
+  ModelCombobox: () => null,
+}));
+
+vi.mock("./utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./utils")>();
+  return { ...actual, buildPrismThemeFromColors: () => ({}) };
+});
+
+describe("AIAssistantPanel history scope ownership", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    appState = {
+      appSettings: {
+        ai: { ...DEFAULT_AI_SETTINGS },
+        ui: { language: "zh-CN" },
+      },
+      updateAppSettings: vi.fn(),
+      tabs: [],
+      savedConnections: [],
+    };
+  });
+
+  it("allows a history session to move after its terminal reconnects with a new session id", async () => {
+    const oldPane = terminalPane("old-session");
+    const newPane = terminalPane("new-session");
+    let historySession = aiSession("ai-session", oldPane.sessionId);
+    let messageLoadCount = 0;
+
+    invokeMock.mockImplementation(
+      (command: string, args?: Record<string, unknown>) => {
+        switch (command) {
+          case "get_ai_sessions":
+            return Promise.resolve([historySession]);
+          case "get_ai_messages": {
+            messageLoadCount += 1;
+            return Promise.resolve([
+              aiMessage(
+                historySession.id,
+                messageLoadCount === 1 ? "before reconnect" : "after reconnect",
+              ),
+            ]);
+          }
+          case "rebind_ai_session":
+            historySession = {
+              ...historySession,
+              scope: args?.ownerScope as AISessionScope,
+            };
+            return Promise.resolve(historySession);
+          default:
+            return Promise.reject(new Error(`Unexpected command: ${command}`));
+        }
+      },
+    );
+
+    appState.tabs = [tabWithPane(oldPane)];
+    const view = render(
+      <AIAssistantPanel activePane={oldPane} intent={null} />,
+    );
+
+    openHistory(view.container);
+    fireEvent.click(await historySessionButton(historySession.title));
+    await screen.findByText("before reconnect");
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "rebind_ai_session",
+      expect.anything(),
+    );
+
+    appState.tabs = [tabWithPane(newPane)];
+    view.rerender(<AIAssistantPanel activePane={newPane} intent={null} />);
+
+    openHistory(view.container);
+    const movableSessionButton = await historySessionButton(
+      historySession.title,
+    );
+    expect(movableSessionButton.disabled).toBe(false);
+    expect(screen.queryByText("ai.historyInUse")).toBeNull();
+    expect(screen.getByText("ai.historyMoveToCurrent")).not.toBeNull();
+
+    fireEvent.click(movableSessionButton);
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("rebind_ai_session", {
+        sessionId: historySession.id,
+        ownerScope: {
+          type: "terminal",
+          targetId: newPane.sessionId,
+          connectionIds: [newPane.connectionId],
+          label: newPane.name,
+        },
+      });
+    });
+    await screen.findByText("after reconnect");
+    expect(messageLoadCount).toBe(2);
+  });
+
+  it("keeps history locked while the owning terminal pane still exists", async () => {
+    const owningPane = terminalPane("owning-session", {
+      connectError: "connection lost",
+    });
+    const currentPane = terminalPane("current-session", {
+      id: "current-pane",
+      connectionId: "current-connection",
+      name: "Current terminal",
+    });
+    const historySession = aiSession("shared-ai-session", owningPane.sessionId);
+
+    invokeMock.mockImplementation((command: string) => {
+      switch (command) {
+        case "get_ai_sessions":
+          return Promise.resolve([historySession]);
+        case "get_ai_messages":
+          return Promise.resolve([]);
+        default:
+          return Promise.reject(new Error(`Unexpected command: ${command}`));
+      }
+    });
+
+    appState.tabs = [tabWithPane(owningPane, 0), tabWithPane(currentPane, 1)];
+    const view = render(
+      <AIAssistantPanel activePane={owningPane} intent={null} />,
+    );
+
+    openHistory(view.container);
+    fireEvent.click(await historySessionButton(historySession.title));
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("get_ai_messages", {
+        sessionId: historySession.id,
+      });
+    });
+
+    view.rerender(<AIAssistantPanel activePane={currentPane} intent={null} />);
+    openHistory(view.container);
+
+    const lockedSessionButton = await historySessionButton(
+      historySession.title,
+    );
+    expect(lockedSessionButton.disabled).toBe(true);
+    expect(screen.getByText("ai.historyInUse")).not.toBeNull();
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "rebind_ai_session",
+      expect.anything(),
+    );
+  });
+});
+
+function openHistory(container: HTMLElement) {
+  const button = container.querySelector<HTMLButtonElement>(
+    'button[aria-expanded]:not([aria-label]):not([role="combobox"])',
+  );
+  if (!button) throw new Error("History button not found");
+  fireEvent.click(button);
+}
+
+async function historySessionButton(title: string) {
+  const titleElement = await screen.findByText(title);
+  const button = titleElement.closest("button");
+  if (!(button instanceof HTMLButtonElement))
+    throw new Error("History session button not found");
+  return button;
+}
+
+function terminalPane(
+  sessionId: string,
+  overrides: Partial<TerminalSessionPane> = {},
+): TerminalSessionPane {
+  return {
+    id: "terminal-pane",
+    kind: "leaf",
+    paneKind: "terminal",
+    sessionId,
+    name: "SSH terminal",
+    type: "SSH",
+    connectionId: "connection-1",
+    ...overrides,
+  };
+}
+
+function tabWithPane(pane: TerminalSessionPane, persistOrder = 0): Tab {
+  return {
+    id: `tab-${pane.id}`,
+    persistOrder,
+    activePaneId: pane.id,
+    root: pane,
+  };
+}
+
+function aiSession(id: string, targetId: string): AISession {
+  return {
+    id,
+    title: "Reconnect chat",
+    createdAt: "2026-09-07T10:00:00Z",
+    updatedAt: "2026-09-07T10:05:00Z",
+    connectionId: "connection-1",
+    scope: {
+      type: "terminal",
+      targetId,
+      connectionIds: ["connection-1"],
+      label: "SSH terminal",
+    },
+  };
+}
+
+function aiMessage(sessionId: string, content: string): AIMessage {
+  return {
+    id: `message-${content}`,
+    sessionId,
+    role: "user",
+    content,
+    createdAt: "2026-09-07T10:01:00Z",
+  };
+}

--- a/src/components/panel/ai/AIAssistantPanel.test.tsx
+++ b/src/components/panel/ai/AIAssistantPanel.test.tsx
@@ -195,6 +195,75 @@ describe("AIAssistantPanel history scope ownership", () => {
       expect.anything(),
     );
   });
+
+  it("keeps history locked while its AI stream is still running after the terminal closes", async () => {
+    const owningPane = terminalPane("stream-owner");
+    const currentPane = terminalPane("current-session", {
+      id: "current-pane",
+      connectionId: "current-connection",
+      name: "Current terminal",
+    });
+    const historySession = aiSession("stream-ai-session", owningPane.sessionId);
+
+    appState.appSettings.ai = {
+      ...DEFAULT_AI_SETTINGS,
+      enabled: true,
+      default_model_id: "test-model",
+      models: [
+        {
+          id: "test-model",
+          name: "Test model",
+          provider_kind: "openai",
+          enabled: true,
+          source: "manual",
+        },
+      ],
+    };
+
+    invokeMock.mockImplementation((command: string) => {
+      switch (command) {
+        case "get_ai_sessions":
+          return Promise.resolve([historySession]);
+        case "start_ai_chat_stream":
+          return Promise.resolve({ sessionId: historySession.id });
+        case "append_ai_audit":
+          return Promise.resolve(null);
+        default:
+          return Promise.reject(new Error(`Unexpected command: ${command}`));
+      }
+    });
+
+    appState.tabs = [tabWithPane(owningPane)];
+    const intent = {
+      id: "stream-intent",
+      action: "generate_command" as const,
+      userInput: "keep streaming",
+    };
+    const view = render(
+      <AIAssistantPanel activePane={owningPane} intent={intent} />,
+    );
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        "start_ai_chat_stream",
+        expect.objectContaining({
+          request: expect.objectContaining({ sessionId: null }),
+        }),
+      );
+    });
+
+    appState.tabs = [tabWithPane(currentPane)];
+    view.rerender(<AIAssistantPanel activePane={currentPane} intent={intent} />);
+    openHistory(view.container);
+
+    const lockedSessionButton = await historySessionButton(historySession.title);
+    expect(lockedSessionButton.disabled).toBe(true);
+    expect(screen.getByText("ai.historyInUse")).not.toBeNull();
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "rebind_ai_session",
+      expect.anything(),
+    );
+  });
 });
 
 function openHistory(container: HTMLElement) {

--- a/src/components/panel/ai/AIAssistantPanel.tsx
+++ b/src/components/panel/ai/AIAssistantPanel.tsx
@@ -1208,11 +1208,12 @@ function AIAssistantPanel({ activePane, activeConnection, intent }: AIAssistantP
 
   const isSessionUsedByAnotherScope = useCallback(
     (sessionId: string) =>
+      !!streamRuntimeBySession[sessionId] ||
       Object.entries(activeSessionIdByScope).some(
         ([key, value]) =>
           key !== scopeKey && value === sessionId && openTerminalScopeKeys.has(key),
       ),
-    [activeSessionIdByScope, openTerminalScopeKeys, scopeKey],
+    [activeSessionIdByScope, openTerminalScopeKeys, scopeKey, streamRuntimeBySession],
   );
 
   const openHistorySession = useCallback(

--- a/src/components/panel/ai/AIAssistantPanel.tsx
+++ b/src/components/panel/ai/AIAssistantPanel.tsx
@@ -234,6 +234,16 @@ function AIAssistantPanel({ activePane, activeConnection, intent }: AIAssistantP
     });
   }, [aiSettings, configuredRunMode, runMode, updateAppSettings]);
 
+  const openTerminalScopeKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const tab of tabs) {
+      for (const pane of collectSessionPanes(tab.root)) {
+        if (pane.paneKind === "terminal") keys.add(buildAIScopeKey(pane));
+      }
+    }
+    return keys;
+  }, [tabs]);
+
   const allSessionPanes = useMemo(() => {
     const panes: SessionPane[] = [];
     for (const tab of tabs) {
@@ -1199,9 +1209,10 @@ function AIAssistantPanel({ activePane, activeConnection, intent }: AIAssistantP
   const isSessionUsedByAnotherScope = useCallback(
     (sessionId: string) =>
       Object.entries(activeSessionIdByScope).some(
-        ([key, value]) => key !== scopeKey && value === sessionId,
+        ([key, value]) =>
+          key !== scopeKey && value === sessionId && openTerminalScopeKeys.has(key),
       ),
-    [activeSessionIdByScope, scopeKey],
+    [activeSessionIdByScope, openTerminalScopeKeys, scopeKey],
   );
 
   const openHistorySession = useCallback(


### PR DESCRIPTION
## 修复
- AI 历史会话的占用判断只考虑当前工作区仍存在的 terminal scope，忽略 SSH 重连后遗留的旧 `terminal:<sessionId>` 映射。
- 选择重连前的历史会话时继续使用现有 `rebind_ai_session` 路径迁移到新的终端 scope 并重新加载原有消息，不修改历史持久化格式或后端 API。
- 保留真实终端占用保护，包括仍存在于工作区但处于连接错误状态的终端，并新增对应回归测试。

## 验证
定向回归测试、前端 lint 与生产构建均通过。Lint 仅报告本次修改范围外的既有提示，构建仅有既有的大 chunk 警告。

Fixes #582