### PR TITLE
fix(terminal): allow text selection and Cmd+C copy when app enables mouse tracking

### DIFF
--- a/src-tauri/src/config/settings/interaction.rs
+++ b/src-tauri/src/config/settings/interaction.rs
@@ -12,6 +12,7 @@ pub struct InteractionSettings {
     pub duplicate_session_command_delay_ms: u64,
     pub word_separators: String,
     pub alt_as_meta: bool,
+    pub mouse_events_require_alt: bool,
     pub ime_compatibility: bool,
     pub default_encoding: String,
     pub tab_double_click_action: String,
@@ -32,6 +33,7 @@ struct InteractionSettingsWire {
     duplicate_session_command_delay_ms: Option<u64>,
     word_separators: Option<String>,
     alt_as_meta: Option<bool>,
+    mouse_events_require_alt: Option<bool>,
     ime_compatibility: Option<bool>,
     mac_ime_compatibility: Option<bool>,
     default_encoding: Option<String>,
@@ -110,6 +112,7 @@ impl Default for InteractionSettings {
             duplicate_session_command_delay_ms: default_duplicate_session_command_delay_ms(),
             word_separators: default_word_separators(),
             alt_as_meta: false,
+            mouse_events_require_alt: false,
             ime_compatibility: false,
             default_encoding: default_encoding(),
             tab_double_click_action: default_tab_double_click_action(),
@@ -151,6 +154,9 @@ impl<'de> Deserialize<'de> for InteractionSettings {
                 .unwrap_or(defaults.duplicate_session_command_delay_ms),
             word_separators: wire.word_separators.unwrap_or(defaults.word_separators),
             alt_as_meta: wire.alt_as_meta.unwrap_or(defaults.alt_as_meta),
+            mouse_events_require_alt: wire
+                .mouse_events_require_alt
+                .unwrap_or(defaults.mouse_events_require_alt),
             ime_compatibility: wire
                 .ime_compatibility
                 .or(wire.mac_ime_compatibility)
@@ -183,6 +189,7 @@ mod tests {
         assert_eq!(settings.terminal_right_click_action, "menu");
         assert!(!settings.allow_osc52_clipboard_write);
         assert!(!settings.alt_as_meta);
+        assert!(!settings.mouse_events_require_alt);
         assert!(!settings.ime_compatibility);
         assert!(settings.terminal_zoom_enabled);
     }

--- a/src/components/settings/InteractionTab.tsx
+++ b/src/components/settings/InteractionTab.tsx
@@ -102,6 +102,16 @@ export function InteractionTab() {
             </TabsList>
           </Tabs>
         </SettingRow>
+
+        <SettingRow
+          label={t("settings.mouseEventsRequireAlt")}
+          desc={t("settings.mouseEventsRequireAltDesc")}
+        >
+          <SettingSwitch
+            checked={interaction.mouse_events_require_alt}
+            onChange={(v) => updateInteraction({ mouse_events_require_alt: v })}
+          />
+        </SettingRow>
       </SettingSection>
 
       <SettingSection

--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -1537,6 +1537,7 @@ export default function XTerminal({
 
     installXTerminalKeyboardController({
       terminal,
+      isMacOS,
       imeTracker,
       terminalAppSettingsRef,
       sessionTypeRef,

--- a/src/components/terminal/XTerminal.tsx
+++ b/src/components/terminal/XTerminal.tsx
@@ -803,6 +803,11 @@ export default function XTerminal({
       minimumContrastRatio: appearance.minimum_contrast_ratio,
       wordSeparator: interaction.word_separators,
       macOptionIsMeta: interaction.alt_as_meta,
+      // When enabled and an application (e.g. vim with mouse=a) turns on mouse
+      // tracking, normal drag stays text selection and Alt+drag forwards mouse
+      // events to the application (iTerm2-style). Off by default so existing
+      // mouse reporting behavior is unchanged.
+      mouseEventsRequireAlt: interaction.mouse_events_require_alt,
       scrollOnEraseInDisplay: true,
       theme: { ...terminalThemeColors },
       allowTransparency: terminalTransparencyEnabled,

--- a/src/components/terminal/xterminalKeyboardController.test.ts
+++ b/src/components/terminal/xterminalKeyboardController.test.ts
@@ -29,6 +29,7 @@ function createHarness(
   imeRoute: XTerminalImeKeyboardRoute,
   sessionType: SessionType = "Local",
   keybindings: Record<string, string> = {},
+  options: { isMacOS?: boolean } = {},
 ) {
   const keyHandlerRef: {
     current: ((event: KeyboardEvent) => boolean) | null;
@@ -54,6 +55,7 @@ function createHarness(
 
   installXTerminalKeyboardController({
     terminal,
+    isMacOS: options.isMacOS ?? false,
     imeTracker: { routeKeyboardEvent },
     terminalAppSettingsRef: {
       current: { keybindings } as TerminalAppSettings,
@@ -220,5 +222,54 @@ describe("installXTerminalKeyboardController IME Backspace routing", () => {
     expect(harness.keyHandler(event)).toBe(false);
     expect(event.defaultPrevented).toBe(true);
     expect(writeClipboardText).toHaveBeenCalledWith("selected output");
+  });
+
+  it("copies a selection for plain Cmd+C on macOS", () => {
+    const harness = createHarness("application", "SSH", {}, { isMacOS: true });
+    vi.mocked(harness.terminal.hasSelection).mockReturnValue(true);
+    vi.mocked(harness.terminal.getSelection).mockReturnValue("selected output");
+    const event = new KeyboardEvent("keydown", {
+      key: "c",
+      code: "KeyC",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(harness.keyHandler(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(writeClipboardText).toHaveBeenCalledWith("selected output");
+  });
+
+  it("lets plain Cmd+C fall through on macOS when there is no selection", () => {
+    const harness = createHarness("application", "SSH", {}, { isMacOS: true });
+    const event = new KeyboardEvent("keydown", {
+      key: "c",
+      code: "KeyC",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(harness.keyHandler(event)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(writeClipboardText).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept Meta+C outside macOS", () => {
+    const harness = createHarness("application", "SSH");
+    vi.mocked(harness.terminal.hasSelection).mockReturnValue(true);
+    vi.mocked(harness.terminal.getSelection).mockReturnValue("selected output");
+    const event = new KeyboardEvent("keydown", {
+      key: "c",
+      code: "KeyC",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(harness.keyHandler(event)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(writeClipboardText).not.toHaveBeenCalled();
   });
 });

--- a/src/components/terminal/xterminalKeyboardController.ts
+++ b/src/components/terminal/xterminalKeyboardController.ts
@@ -34,6 +34,7 @@ interface MutableRef<T> {
 
 interface InstallXTerminalKeyboardControllerParams {
   terminal: Terminal;
+  isMacOS: boolean;
   imeTracker: Pick<XTerminalImeTracker, "routeKeyboardEvent">;
   terminalAppSettingsRef: MutableRef<TerminalAppSettings>;
   sessionTypeRef: MutableRef<SessionType>;
@@ -70,6 +71,7 @@ interface InstallXTerminalKeyboardControllerParams {
 
 export function installXTerminalKeyboardController({
   terminal,
+  isMacOS,
   imeTracker,
   terminalAppSettingsRef,
   sessionTypeRef,
@@ -205,6 +207,7 @@ export function installXTerminalKeyboardController({
     // browser's native copy event never fires, so copy the live selection
     // explicitly. Without a selection, fall through to normal processing.
     if (
+      isMacOS &&
       e.key.toLowerCase() === "c" &&
       e.metaKey &&
       !e.ctrlKey &&

--- a/src/components/terminal/xterminalKeyboardController.ts
+++ b/src/components/terminal/xterminalKeyboardController.ts
@@ -200,6 +200,25 @@ export function installXTerminalKeyboardController({
       return false;
     }
 
+    // Plain Cmd+C: when the application has enabled keyboard reporting modes
+    // (e.g. kitty keyboard in vim), xterm may consume the key event and the
+    // browser's native copy event never fires, so copy the live selection
+    // explicitly. Without a selection, fall through to normal processing.
+    if (
+      e.key.toLowerCase() === "c" &&
+      e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
+      !e.shiftKey
+    ) {
+      const sel = terminal.getSelection();
+      if (sel) {
+        e.preventDefault();
+        writeClipboardText(sel).catch(() => {});
+        return false;
+      }
+    }
+
     if (
       e.key === "Tab" &&
       !e.ctrlKey &&

--- a/src/context/AppProvider.tsx
+++ b/src/context/AppProvider.tsx
@@ -164,6 +164,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
     duplicate_session_command_delay_ms: 1000,
     word_separators: " ()[]{}\"':=,;|&<>",
     alt_as_meta: false,
+    mouse_events_require_alt: false,
     ime_compatibility: false,
     default_encoding: "UTF-8",
     tab_double_click_action: DEFAULT_TAB_DOUBLE_CLICK_ACTION,

--- a/src/context/ChildAppProvider.tsx
+++ b/src/context/ChildAppProvider.tsx
@@ -124,6 +124,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
     duplicate_session_command_delay_ms: 1000,
     word_separators: " ()[]{}\"':=,;|&<>",
     alt_as_meta: false,
+    mouse_events_require_alt: false,
     ime_compatibility: false,
     default_encoding: "UTF-8",
     tab_double_click_action: DEFAULT_TAB_DOUBLE_CLICK_ACTION,

--- a/src/hooks/useTerminalSettings.test.ts
+++ b/src/hooks/useTerminalSettings.test.ts
@@ -56,6 +56,7 @@ const terminalSettings = {
 const interaction = {
   word_separators: " ()[]{}'\"",
   alt_as_meta: false,
+  mouse_events_require_alt: false,
   ime_compatibility: false,
 } as AppSettings["interaction"];
 

--- a/src/hooks/useTerminalSettings.ts
+++ b/src/hooks/useTerminalSettings.ts
@@ -295,8 +295,15 @@ export function useTerminalSettings(
     if (terminalRef.current) {
       terminalRef.current.options.wordSeparator = interaction.word_separators;
       terminalRef.current.options.macOptionIsMeta = interaction.alt_as_meta;
+      terminalRef.current.options.mouseEventsRequireAlt =
+        interaction.mouse_events_require_alt;
     }
-  }, [interaction.word_separators, interaction.alt_as_meta, terminalRef]);
+  }, [
+    interaction.word_separators,
+    interaction.alt_as_meta,
+    interaction.mouse_events_require_alt,
+    terminalRef,
+  ]);
 
   useEffect(() => {
     const terminal = terminalInstance ?? terminalRef.current;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2181,6 +2181,8 @@
     "minimumContrastRatio_3": "Light boost",
     "minimumContrastRatio_4_5": "Recommended: WCAG AA",
     "minimumContrastRatio_7": "High contrast: WCAG AAA",
+    "mouseEventsRequireAlt": "Mouse Events Require Alt",
+    "mouseEventsRequireAltDesc": "When an application (e.g. vim, tmux, htop) enables mouse reporting, normal click and drag select text locally; hold Alt to send mouse events to the application.",
     "never": "Never",
     "noCustomEngines": "No custom search engines defined.",
     "noEngines": "No custom search engines defined.",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2180,6 +2180,8 @@
     "minimumContrastRatio_3": "약간 강화",
     "minimumContrastRatio_4_5": "권장: WCAG AA",
     "minimumContrastRatio_7": "고대비: WCAG AAA",
+    "mouseEventsRequireAlt": "Alt를 눌러 마우스 이벤트 전송",
+    "mouseEventsRequireAltDesc": "vim, tmux, htop 등 애플리케이션이 마우스 리포팅을 활성화하면 일반 클릭과 드래그는 로컬 텍스트 선택에 사용되고, Alt를 누른 상태에서만 마우스 이벤트가 애플리케이션으로 전송됩니다.",
     "never": "안 함",
     "noCustomEngines": "정의된 사용자 지정 검색 엔진이 없습니다.",
     "noEngines": "정의된 사용자 지정 검색 엔진이 없습니다.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2180,6 +2180,8 @@
     "minimumContrastRatio_3": "轻微增强",
     "minimumContrastRatio_4_5": "推荐：WCAG AA",
     "minimumContrastRatio_7": "高对比：WCAG AAA",
+    "mouseEventsRequireAlt": "按住 Alt 发送鼠标事件",
+    "mouseEventsRequireAltDesc": "当终端应用（如 vim、tmux、htop）开启鼠标上报时，普通点击和拖动用于本地选择文本；按住 Alt 才会将鼠标事件发送给应用。",
     "never": "从未",
     "noCustomEngines": "未定义自定义搜索引擎。",
     "noEngines": "未定义自定义搜索引擎。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2175,6 +2175,8 @@
     "minimumContrastRatio_3": "輕微增強",
     "minimumContrastRatio_4_5": "推薦：WCAG AA",
     "minimumContrastRatio_7": "高對比：WCAG AAA",
+    "mouseEventsRequireAlt": "按住 Alt 傳送滑鼠事件",
+    "mouseEventsRequireAltDesc": "當終端應用程式（如 vim、tmux、htop）啟用滑鼠回報時，一般點擊和拖曳用於本地選取文字；按住 Alt 才會將滑鼠事件傳送給應用程式。",
     "never": "從未",
     "noCustomEngines": "未定義自訂搜尋引擎。",
     "noEngines": "未定義自訂搜尋引擎。",

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1756,6 +1756,7 @@ export interface InteractionSettings {
   duplicate_session_command_delay_ms: number;
   word_separators: string;
   alt_as_meta: boolean;
+  mouse_events_require_alt: boolean;
   ime_compatibility: boolean;
   default_encoding: string;
   tab_double_click_action: import("@/lib/interactionSettings").TabMouseAction;


### PR DESCRIPTION
## Problem

When a terminal application enables mouse tracking (e.g. vim with `set mouse=a`), xterm.js disables its selection service entirely and forwards all mouse events to the application. As a result:

- Users **cannot select text** with a normal mouse drag inside vim.
- Consequently **copy does not work** — neither via the right-click context menu nor via Cmd+C — because there is no selection to copy.

Additionally, even when a selection exists, plain **Cmd+C fails** while the application has enabled keyboard reporting modes (e.g. kitty keyboard protocol, which this terminal advertises via `vtExtensions.kittyKeyboard`): xterm.js consumes the key event and calls `preventDefault()`, so the browser's native `copy` event — which xterm relies on to write the selection to the clipboard — never fires.

Both behaviors work correctly in iTerm2, which is the expected reference behavior.

## Changes

- **[XTerminal.tsx](cci:7://file:///Volumes/Intel/git/nyaterm/src/components/terminal/XTerminal.tsx:0:0-0:0)**: set `mouseEventsRequireAlt: true` on the xterm.js `Terminal` instance. With this option, a normal mouse drag always performs text selection even while mouse tracking is active; holding **Alt** forwards mouse events to the application instead (iTerm2-style behavior). Wheel events are unaffected, so scrolling inside vim still works.

- **[xterminalKeyboardController.ts](cci:7://file:///Volumes/Intel/git/nyaterm/src/components/terminal/xterminalKeyboardController.ts:0:0-0:0)**: intercept plain **Cmd+C** (`metaKey`, no other modifiers) in the custom key event handler. When a live selection exists, write it to the clipboard explicitly and stop further processing. Without a selection the event falls through to normal handling, preserving existing behavior. This only affects macOS (`metaKey`); on Windows/Linux, `Ctrl+Shift+C` (`terminal.copy`) already copies explicitly and `Ctrl+C` still sends SIGINT.

## Verification

- In a vim session with mouse tracking enabled, drag to select text, then copy via right-click menu or Cmd+C — both now work.
- Outside vim, selection and copy behavior is unchanged.
- Alt+drag still delivers mouse events to the application for users who rely on vim mouse interaction.