### PR TITLE
fix(terminal): 自定义快捷键：修复终端自定义快捷键 Ctrl+C  复制与任务中断冲突

### DIFF
--- a/src/components/terminal/xterminalKeyboardController.test.ts
+++ b/src/components/terminal/xterminalKeyboardController.test.ts
@@ -1,10 +1,15 @@
 import type { Terminal } from "@xterm/xterm";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TerminalAppSettings } from "@/context/AppContext";
+import { writeClipboardText } from "@/lib/clipboard";
 import { createTerminalInputState } from "@/lib/terminalInputTracker";
 import type { SessionType } from "@/types/global";
 import type { XTerminalImeKeyboardRoute } from "./xterminalIme";
 import { installXTerminalKeyboardController } from "./xterminalKeyboardController";
+
+vi.mock("@/lib/clipboard", () => ({
+  writeClipboardText: vi.fn(() => Promise.resolve()),
+}));
 
 function backspaceEvent(keyCode: number, isComposing = false): KeyboardEvent {
   const event = new KeyboardEvent("keydown", {
@@ -20,7 +25,11 @@ function backspaceEvent(keyCode: number, isComposing = false): KeyboardEvent {
   return event;
 }
 
-function createHarness(imeRoute: XTerminalImeKeyboardRoute, sessionType: SessionType = "Local") {
+function createHarness(
+  imeRoute: XTerminalImeKeyboardRoute,
+  sessionType: SessionType = "Local",
+  keybindings: Record<string, string> = {},
+) {
   const keyHandlerRef: {
     current: ((event: KeyboardEvent) => boolean) | null;
   } = { current: null };
@@ -32,6 +41,7 @@ function createHarness(imeRoute: XTerminalImeKeyboardRoute, sessionType: Session
     hasSelection: vi.fn(() => false),
   } as unknown as Terminal;
   const routeKeyboardEvent = vi.fn(() => imeRoute);
+  const pasteClipboard = vi.fn(async () => {});
   const sendRawInput = vi.fn(async () => {});
   const syncSuggestionsWithInputState = vi.fn();
   const inputStateRef = {
@@ -46,7 +56,7 @@ function createHarness(imeRoute: XTerminalImeKeyboardRoute, sessionType: Session
     terminal,
     imeTracker: { routeKeyboardEvent },
     terminalAppSettingsRef: {
-      current: { keybindings: {} } as TerminalAppSettings,
+      current: { keybindings } as TerminalAppSettings,
     },
     sessionTypeRef: { current: sessionType },
     inputStateRef,
@@ -55,7 +65,7 @@ function createHarness(imeRoute: XTerminalImeKeyboardRoute, sessionType: Session
     showSuggestionsRef: { current: false },
     suggestionsRef: { current: [] },
     doFindRef: { current: vi.fn() },
-    pasteClipboard: vi.fn(async () => {}),
+    pasteClipboard,
     pasteText: vi.fn(),
     sendRawInput,
     triggerSearch: vi.fn(),
@@ -82,11 +92,17 @@ function createHarness(imeRoute: XTerminalImeKeyboardRoute, sessionType: Session
   return {
     inputStateRef,
     keyHandler,
+    pasteClipboard,
     routeKeyboardEvent,
     sendRawInput,
     syncSuggestionsWithInputState,
+    terminal,
   };
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("installXTerminalKeyboardController IME Backspace routing", () => {
   it("leaves IME Backspace native without preventing default", () => {
@@ -130,5 +146,79 @@ describe("installXTerminalKeyboardController IME Backspace routing", () => {
     expect(harness.keyHandler(event)).toBe(true);
     expect(harness.routeKeyboardEvent).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("honors a custom copy shortcut while terminal text is selected", () => {
+    const harness = createHarness("application", "SSH", {
+      "terminal.copy": "ctrl+c",
+    });
+    vi.mocked(harness.terminal.hasSelection).mockReturnValue(true);
+    vi.mocked(harness.terminal.getSelection).mockReturnValue("selected output");
+    const event = new KeyboardEvent("keydown", {
+      key: "c",
+      code: "KeyC",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(harness.keyHandler(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(writeClipboardText).toHaveBeenCalledWith("selected output");
+    expect(harness.sendRawInput).not.toHaveBeenCalled();
+  });
+
+  it("passes a custom Ctrl+C through to the shell when there is no selection", () => {
+    const harness = createHarness("application", "SSH", {
+      "terminal.copy": "ctrl+c",
+    });
+    const event = new KeyboardEvent("keydown", {
+      key: "c",
+      code: "KeyC",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(harness.keyHandler(event)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(writeClipboardText).not.toHaveBeenCalled();
+  });
+
+  it("honors a custom paste shortcut while terminal text is selected", () => {
+    const harness = createHarness("application", "SSH", {
+      "terminal.paste": "ctrl+v",
+    });
+    vi.mocked(harness.terminal.hasSelection).mockReturnValue(true);
+    const event = new KeyboardEvent("keydown", {
+      key: "v",
+      code: "KeyV",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(harness.keyHandler(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(harness.pasteClipboard).toHaveBeenCalledOnce();
+    expect(harness.sendRawInput).not.toHaveBeenCalled();
+  });
+
+  it("keeps the default Ctrl+Shift+C copy shortcut available", () => {
+    const harness = createHarness("application", "SSH");
+    vi.mocked(harness.terminal.hasSelection).mockReturnValue(true);
+    vi.mocked(harness.terminal.getSelection).mockReturnValue("selected output");
+    const event = new KeyboardEvent("keydown", {
+      key: "C",
+      code: "KeyC",
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(harness.keyHandler(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(writeClipboardText).toHaveBeenCalledWith("selected output");
   });
 });

--- a/src/components/terminal/xterminalKeyboardController.ts
+++ b/src/components/terminal/xterminalKeyboardController.ts
@@ -153,6 +153,53 @@ export function installXTerminalKeyboardController({
       return false;
     }
 
+    // 终端操作快捷键必须先于选中文本时的 Shell 输入处理，否则 Ctrl 组合键
+    // 会被当作控制字符发送到终端，导致自定义终端操作失效。
+    if (matchesKeyEvent(resolveShortcutKeys("terminal.copy", kb), e)) {
+      const sel = terminal.getSelection();
+      // Ctrl+C 没有选区时保留 Shell 的中断语义（例如终止 python main.py）。
+      if (
+        !sel &&
+        e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        !e.shiftKey &&
+        e.code === "KeyC"
+      ) {
+        return true;
+      }
+
+      e.preventDefault();
+      if (sel) writeClipboardText(sel).catch(() => {});
+      return false;
+    }
+    if (matchesKeyEvent(resolveShortcutKeys("terminal.paste", kb), e)) {
+      e.preventDefault();
+      pasteClipboard().catch(() => {});
+      return false;
+    }
+    if (matchesKeyEvent(resolveShortcutKeys("terminal.find", kb), e)) {
+      e.preventDefault();
+      doFindRef.current();
+      return false;
+    }
+    if (matchesKeyEvent(resolveShortcutKeys("terminal.clear", kb), e)) {
+      e.preventDefault();
+      sendTerminalClearInput(terminal);
+      return false;
+    }
+    if (matchesKeyEvent(resolveShortcutKeys("terminal.pasteSelected", kb), e)) {
+      e.preventDefault();
+      const sel = terminal.getSelection() || lastSelectionRef.current;
+      pasteText(sel);
+      return false;
+    }
+    if (matchesKeyEvent(resolveShortcutKeys("terminal.selectAll", kb), e)) {
+      e.preventDefault();
+      terminal.selectAll();
+      return false;
+    }
+
     if (
       e.key === "Tab" &&
       !e.ctrlKey &&
@@ -452,39 +499,6 @@ export function installXTerminalKeyboardController({
           return false;
         }
       }
-    }
-
-    if (matchesKeyEvent(resolveShortcutKeys("terminal.copy", kb), e)) {
-      e.preventDefault();
-      const sel = terminal.getSelection();
-      if (sel) writeClipboardText(sel).catch(() => {});
-      return false;
-    }
-    if (matchesKeyEvent(resolveShortcutKeys("terminal.paste", kb), e)) {
-      e.preventDefault();
-      pasteClipboard().catch(() => {});
-      return false;
-    }
-    if (matchesKeyEvent(resolveShortcutKeys("terminal.find", kb), e)) {
-      e.preventDefault();
-      doFindRef.current();
-      return false;
-    }
-    if (matchesKeyEvent(resolveShortcutKeys("terminal.clear", kb), e)) {
-      e.preventDefault();
-      sendTerminalClearInput(terminal);
-      return false;
-    }
-    if (matchesKeyEvent(resolveShortcutKeys("terminal.pasteSelected", kb), e)) {
-      e.preventDefault();
-      const sel = terminal.getSelection() || lastSelectionRef.current;
-      pasteText(sel);
-      return false;
-    }
-    if (matchesKeyEvent(resolveShortcutKeys("terminal.selectAll", kb), e)) {
-      e.preventDefault();
-      terminal.selectAll();
-      return false;
     }
 
     const swallowIds = [


### PR DESCRIPTION
## 问题说明

   用户将终端复制快捷键自定义为 Ctrl+C 后，选中文本按下 Ctrl+C 会被终端当作中断信号处理，无法复制内容，并可能产生 `^C`。

   同时，Ctrl+C 被自定义为复制后，运行 `python main.py` 等任务时无法正常使用 Ctrl+C 终止任务。

   ## 修复内容

   - 终端快捷键优先于选区输入处理。
   - 有选中文本时，Ctrl+C 执行复制。
   - 没有选中文本时，Ctrl+C 放行给 Shell，保留任务中断能力。
   - 保持自定义 Ctrl+V 粘贴功能不变。
   - 新增自定义复制、粘贴及 Ctrl+C 中断行为测试。
  
   ## 验证结果

   - `pnpm exec vitest run`
   - `pnpm lint`
   - `pnpm build`

   共 619 个测试全部通过。