### PR TITLE
  fix(ai): 修复 Windows 下 Codex CLI 登录启动失败

### DIFF
--- a/src-tauri/src/core/ai/codex.rs
+++ b/src-tauri/src/core/ai/codex.rs
@@ -180,7 +180,7 @@ impl CodexAppServerManager {
         }
 
         *self.state.write().await = CodexRuntimeState::Starting;
-        let executable = codex_executable(path.as_deref());
+        let executable = resolve_codex_executable(path).await?;
         let mut command = Command::new(&executable);
         hide_window(&mut command);
         let mut child = command
@@ -1017,6 +1017,19 @@ fn codex_executable(path: Option<&str>) -> String {
         .to_string()
 }
 
+async fn resolve_codex_executable(path: Option<String>) -> AppResult<String> {
+    let status = CodexAppServerManager::detect_cli(path).await;
+    if !status.installed {
+        return Err(AppError::Config(status.error.unwrap_or_else(|| {
+            "Codex CLI was not detected in PATH or common install locations".to_string()
+        })));
+    }
+
+    status
+        .path
+        .ok_or_else(|| AppError::Config("Codex CLI detection returned no executable path".into()))
+}
+
 async fn discover_codex_candidates(path: Option<&str>) -> Vec<CodexCliCandidate> {
     let mut candidates = Vec::new();
     let mut seen = HashSet::new();
@@ -1084,6 +1097,12 @@ fn add_common_codex_candidates(
             let npm = Path::new(&appdata).join("npm");
             for name in ["codex.cmd", "codex.exe", "codex"] {
                 add_existing_codex_candidate(candidates, seen, npm.join(name), "common");
+            }
+        }
+        if let Ok(nvm_symlink) = env::var("NVM_SYMLINK") {
+            let nodejs = Path::new(&nvm_symlink);
+            for name in ["codex.cmd", "codex.exe", "codex"] {
+                add_existing_codex_candidate(candidates, seen, nodejs.join(name), "common");
             }
         }
         if let Ok(local_appdata) = env::var("LOCALAPPDATA") {
@@ -1515,6 +1534,20 @@ pub async fn manager_from_app(app: &AppHandle) -> AppResult<Arc<CodexAppServerMa
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn resolves_windows_cmd_launcher_before_starting_app_server() {
+        let path = std::env::temp_dir().join(format!("nyaterm-codex-{}.cmd", uuid()));
+        std::fs::write(&path, "@echo off\r\necho codex-test\r\n").unwrap();
+
+        let resolved = resolve_codex_executable(Some(path.to_string_lossy().into_owned()))
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, path.to_string_lossy());
+        let _ = std::fs::remove_file(path);
+    }
 
     #[test]
     fn sanitizes_codex_auth_material_from_logs() {


### PR DESCRIPTION
## 问题

   Windows 下通过 npm 安装的 Codex CLI 通常由 `codex.cmd` 提供。

   NyaTerm 的 Codex 启动流程在 `ensure_started()` 中直接执行裸命令 `codex`，没有复用已有的 CLI 检测结果，导致点击 ChatGPT 登录时出现：

   `Failed to start codex app-server: program not found`

   在 NVM 环境下还可能错误命中无扩展名的 Unix shell shim。

   ## 修复内容

   - Codex App Server 启动前复用 `detect_cli()` 解析已验证的可执行路径；
   - 支持 Windows 下的 `codex.cmd` 启动方式；
   - 增加 `NVM_SYMLINK` 常见安装路径搜索；
   - CLI 不存在时返回更明确的检测错误；
   - 增加 Windows `.cmd` 启动回归测试。

   ## 验证

   - `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
   - `cargo check --manifest-path src-tauri/Cargo.toml`
   - Codex CLI 版本检测通过；
   - Codex App Server 初始化响应正常；
   - 相关测试通过。

   ## 影响范围

   仅修改 Codex CLI 的路径解析和启动流程，不改变 Codex 登录协议、Agent 工具或权限策略。