### PR TITLE
fix: 按层级创建 WebDAV 同步目录

### DIFF
--- a/src-tauri/src/core/cloud_sync/operator.rs
+++ b/src-tauri/src/core/cloud_sync/operator.rs
@@ -437,10 +437,26 @@ fn storage_timeout_layer() -> TimeoutLayer {
 }
 
 pub(super) async fn ensure_remote_layout(remote: &CloudRemote, base_root: &str) -> AppResult<()> {
-    remote
-        .create_dir(&remote_path(base_root, super::remote::SYNC_SNAPSHOTS_DIR))
-        .await?;
+    for path in remote_layout_paths(remote, base_root) {
+        remote.create_dir(&path).await?;
+    }
     Ok(())
+}
+
+fn remote_layout_paths(remote: &CloudRemote, base_root: &str) -> Vec<String> {
+    let snapshots_dir = remote_path(base_root, super::remote::SYNC_SNAPSHOTS_DIR);
+    let is_webdav = matches!(
+        remote,
+        CloudRemote::OpenDal(operator) if operator.info().scheme() == "webdav"
+    );
+    if !is_webdav {
+        return vec![snapshots_dir];
+    }
+
+    snapshots_dir
+        .match_indices('/')
+        .map(|(index, _)| snapshots_dir[..=index].to_string())
+        .collect()
 }
 
 pub(super) fn map_storage_error(error: opendal::Error) -> AppError {
@@ -1226,6 +1242,59 @@ fn escape_digest_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn webdav_remote() -> CloudRemote {
+        let mut settings = CloudSyncSettings::default();
+        settings.provider = "webdav".to_string();
+        settings.webdav.endpoint = "https://dav.example.com".to_string();
+        build_remote(&settings).expect("build WebDAV remote")
+    }
+
+    #[test]
+    fn remote_layout_paths_expand_only_for_webdav() {
+        let webdav = webdav_remote();
+        assert_eq!(
+            remote_layout_paths(&webdav, "nyaterm"),
+            vec![
+                "nyaterm/".to_string(),
+                "nyaterm/sync/".to_string(),
+                "nyaterm/sync/snapshots/".to_string(),
+            ]
+        );
+
+        let memory = CloudRemote::Memory(MemoryRemote::default());
+        assert_eq!(
+            remote_layout_paths(&memory, "nyaterm"),
+            vec!["nyaterm/sync/snapshots/".to_string()]
+        );
+    }
+
+    #[test]
+    fn webdav_remote_layout_paths_support_empty_and_nested_roots() {
+        let webdav = webdav_remote();
+
+        assert_eq!(
+            remote_layout_paths(&webdav, ""),
+            vec!["sync/".to_string(), "sync/snapshots/".to_string()]
+        );
+        assert_eq!(
+            remote_layout_paths(&webdav, "/nyaterm/"),
+            vec![
+                "nyaterm/".to_string(),
+                "nyaterm/sync/".to_string(),
+                "nyaterm/sync/snapshots/".to_string(),
+            ]
+        );
+        assert_eq!(
+            remote_layout_paths(&webdav, "team/nyaterm"),
+            vec![
+                "team/".to_string(),
+                "team/nyaterm/".to_string(),
+                "team/nyaterm/sync/".to_string(),
+                "team/nyaterm/sync/snapshots/".to_string(),
+            ]
+        );
+    }
 
     #[test]
     fn webdav_401_error_reports_generic_auth_hint() {


### PR DESCRIPTION
## 问题

部分 WebDAV 服务在父目录尚不存在时，直接创建 `nyaterm/sync/snapshots/` 会返回 409 `AncestorsNotFound`。

## 修复

- 仅对 WebDAV 按从浅到深依次创建同步目录前缀，继续沿用现有 `remote_path` 规范化和错误传播。
- 非 WebDAV provider 仍只创建最终 `sync/snapshots/` 目录，不修改认证、重试、provider root 或同步数据格式。
- 增加默认、空、带首尾斜杠及嵌套 remote root 的回归测试。

## 验证

新增回归测试及现有 cloud sync operator 测试均通过，Rust 格式检查和 Clippy 全 targets 检查通过。Clippy 仍会报告未修改代码中的现有警告。

Fixes #611