### PR TITLE
fix(sftp): 重试目录列表的临时连接错误

### DIFF
--- a/src-tauri/src/core/sftp/sftp_backend/config.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/config.rs
@@ -23,6 +23,7 @@ pub(super) const SFTP_LARGE_FILE_CONCURRENCY: usize = 2;
 pub(super) const SFTP_HANDLE_RESERVE: usize = 8;
 pub(super) const SFTP_DIRECTORY_STALL_TIMEOUT: Duration = Duration::from_secs(60);
 pub(super) const SFTP_SESSION_SETUP_TIMEOUT: Duration = Duration::from_secs(10);
+pub(super) const SFTP_DIRECTORY_LIST_MAX_RETRIES: usize = 1;
 pub(super) const SFTP_CHANNEL_OPEN_RETRY_DELAYS: [Duration; 3] = [
     Duration::from_millis(50),
     Duration::from_millis(150),
@@ -82,6 +83,23 @@ pub(super) fn is_retryable_sftp_channel_open_error(error: &russh::Error) -> bool
             ChannelOpenFailure::ConnectFailed | ChannelOpenFailure::ResourceShortage
         )
     )
+}
+
+pub(super) fn should_retry_sftp_directory_list(error: &AppError, retries_used: usize) -> bool {
+    if retries_used >= SFTP_DIRECTORY_LIST_MAX_RETRIES {
+        return false;
+    }
+
+    match error {
+        AppError::Sftp(
+            SftpError::IO(_) | SftpError::Timeout | SftpError::UnexpectedBehavior(_),
+        ) => true,
+        AppError::Sftp(SftpError::Status(status)) => matches!(
+            status.status_code,
+            StatusCode::NoConnection | StatusCode::ConnectionLost
+        ),
+        _ => false,
+    }
 }
 
 #[allow(dead_code)]

--- a/src-tauri/src/core/sftp/sftp_backend/fs.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/fs.rs
@@ -32,8 +32,6 @@ impl RemoteFs for SftpBackend {
     }
 
     async fn list_dir_ref(&self, path: &RemotePathRef) -> AppResult<Vec<FileEntry>> {
-        let sftp = self.open_sftp().await?;
-
         let path_bytes = normalize_remote_dir_path_bytes(&self.remote_path_bytes(path));
         if path.raw_path().is_some() {
             self.path_cache
@@ -41,7 +39,31 @@ impl RemoteFs for SftpBackend {
                 .await
                 .insert(path.display_path().to_string(), path_bytes.clone());
         }
-        let dir = sftp.read_dir_bytes(path_bytes.clone()).await?;
+        let mut retries_used = 0;
+        let (sftp, dir) = loop {
+            let sftp = match self.open_sftp().await {
+                Ok(sftp) => sftp,
+                Err(error) if should_retry_sftp_directory_list(&error, retries_used) => {
+                    retries_used += 1;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+
+            match sftp.read_dir_bytes(path_bytes.clone()).await {
+                Ok(dir) => break (sftp, dir),
+                Err(error) => {
+                    let error = AppError::Sftp(error);
+                    let should_retry = should_retry_sftp_directory_list(&error, retries_used);
+                    let _ = sftp.close().await;
+                    if should_retry {
+                        retries_used += 1;
+                        continue;
+                    }
+                    return Err(error);
+                }
+            }
+        };
 
         let mut pending = Vec::new();
         let mut uid_set = HashSet::new();

--- a/src-tauri/src/core/sftp/sftp_backend/tests.rs
+++ b/src-tauri/src/core/sftp/sftp_backend/tests.rs
@@ -173,6 +173,49 @@ fn sftp_channel_open_retry_rejects_policy_and_type_failures() {
 }
 
 #[test]
+fn sftp_directory_list_retry_accepts_transient_sftp_errors_on_first_failure() {
+    for error in [
+        sftp_status_error(StatusCode::NoConnection),
+        sftp_status_error(StatusCode::ConnectionLost),
+        SftpError::IO("connection reset".to_string()),
+        SftpError::Timeout,
+        SftpError::UnexpectedBehavior("session closed".to_string()),
+    ] {
+        let error = AppError::Sftp(error);
+        assert!(should_retry_sftp_directory_list(&error, 0));
+        assert!(!should_retry_sftp_directory_list(&error, 1));
+    }
+}
+
+#[test]
+fn sftp_directory_list_retry_rejects_remote_and_protocol_failures() {
+    for status_code in [
+        StatusCode::NoSuchFile,
+        StatusCode::PermissionDenied,
+        StatusCode::Failure,
+        StatusCode::BadMessage,
+        StatusCode::OpUnsupported,
+    ] {
+        assert!(!should_retry_sftp_directory_list(
+            &AppError::Sftp(sftp_status_error(status_code)),
+            0,
+        ));
+    }
+
+    for error in [
+        SftpError::Limited("limit".to_string()),
+        SftpError::UnexpectedPacket,
+    ] {
+        assert!(!should_retry_sftp_directory_list(&AppError::Sftp(error), 0,));
+    }
+
+    assert!(!should_retry_sftp_directory_list(
+        &AppError::Channel("SFTP session setup failed".to_string()),
+        0,
+    ));
+}
+
+#[test]
 fn write_text_permission_restore_preserves_posix_mode_bits() {
     assert_eq!(
         permissions_to_preserve_after_write(Some(0o100644)),


### PR DESCRIPTION
## 修复

- SFTP 目录列表首次遇到 `NoConnection`、`ConnectionLost`、`IO`、`Timeout` 或 `UnexpectedBehavior` 时，关闭失败会话并使用相同路径字节创建新会话重试一次。
- 第二次失败以及 `NoSuchFile`、`PermissionDenied`、`Failure`、`BadMessage`、`OpUnsupported`、`Limited`、`UnexpectedPacket` 等非目标错误继续原样返回，不会被自动重试隐藏。
- 保留现有 channel-open 重试、10 秒 SFTP 会话初始化超时及 raw path/非 UTF-8 路径处理；未修改前端、SSH keep-alive、SCP 或上传/下载重试策略。

## 验证

新增目录列表重试分类测试，并通过 SFTP 后端单元测试、Rust 格式检查和 Clippy。当前环境无法执行 Windows 11 下远程服务器空闲约 5 分钟后的真实端到端验证。

Fixes #585