### PR TITLE
fix(terminal): 阻止右键粘贴触发终端鼠标输入

### DIFF
--- a/src/components/terminal/TerminalContextMenu.test.tsx
+++ b/src/components/terminal/TerminalContextMenu.test.tsx
@@ -79,6 +79,28 @@ describe("TerminalContextMenu right-click behavior", () => {
     expect(document.querySelector('[data-slot="context-menu-content"]')).toBeNull();
   });
 
+  it("pastes once for each consecutive context-menu event in paste mode", async () => {
+    rightClickAction = "paste";
+    const onPasteClipboard = vi.fn().mockResolvedValue(undefined);
+    const clearSelection = vi.fn();
+    const focus = vi.fn();
+    const { getByTestId } = renderTerminalContextMenu({
+      onPasteClipboard,
+      clearSelection,
+      focus,
+    });
+
+    fireEvent.contextMenu(getByTestId("terminal-child"));
+    fireEvent.contextMenu(getByTestId("terminal-child"));
+
+    await waitFor(() => {
+      expect(onPasteClipboard).toHaveBeenCalledTimes(2);
+      expect(clearSelection).toHaveBeenCalledTimes(2);
+      expect(focus).toHaveBeenCalledTimes(2);
+    });
+    expect(document.querySelector('[data-slot="context-menu-content"]')).toBeNull();
+  });
+
   it("opens the application context menu without pasting in menu mode", async () => {
     const onPasteClipboard = vi.fn();
     const { getByTestId } = renderTerminalContextMenu({ onPasteClipboard });

--- a/src/components/terminal/xterminalSelectionController.test.ts
+++ b/src/components/terminal/xterminalSelectionController.test.ts
@@ -1,13 +1,18 @@
 import type { Terminal } from "@xterm/xterm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TerminalAppSettings } from "@/context/AppContext";
+import type { TerminalRightClickAction } from "@/lib/interactionSettings";
 import type { TerminalInputState } from "@/lib/terminalInputTracker";
 import { installXTerminalSelectionController } from "./xterminalSelectionController";
 
 function createHarness(
-  options: { isMacOS?: boolean; isWindows?: boolean } = {},
+  options: {
+    isMacOS?: boolean;
+    isWindows?: boolean;
+    rightClickAction?: TerminalRightClickAction;
+  } = {},
 ) {
-  const { isMacOS = false, isWindows = true } = options;
+  const { isMacOS = false, isWindows = true, rightClickAction = "menu" } = options;
   const containerEl = document.createElement("div");
   const xtermTarget = document.createElement("div");
   const textarea = document.createElement("textarea");
@@ -35,7 +40,10 @@ function createHarness(
     activeRef: { current: true },
     visibleRef: { current: true },
     terminalAppSettingsRef: {
-      current: { keybindings: {} } as TerminalAppSettings,
+      current: {
+        interaction: { terminal_right_click_action: rightClickAction },
+        keybindings: {},
+      } as TerminalAppSettings,
     },
     pendingSearchSelectionRef: { current: false },
     searchSelectionTextRef: { current: null },
@@ -139,14 +147,58 @@ describe("installXTerminalSelectionController", () => {
     expect(afterDispose.defaultPrevented).toBe(false);
   });
 
-  it("keeps non-Windows middle mousedown and Windows primary mousedown visible to xterm", () => {
-    const nonWindows = createHarness({ isWindows: false });
+  it("blocks Windows right mousedown in paste mode without cancelling contextmenu", () => {
+    const {
+      clearSearchSelectionState,
+      controller,
+      removeLinkPopup,
+      terminal,
+      textarea,
+      xtermTarget,
+    } = createHarness({ rightClickAction: "paste" });
+    const xtermMouseDown = vi.fn();
+    xtermTarget.addEventListener("mousedown", xtermMouseDown);
+
+    const mouseDown = dispatchMouse(xtermTarget, "mousedown", 2);
+
+    expect(mouseDown.defaultPrevented).toBe(false);
+    expect(xtermMouseDown).not.toHaveBeenCalled();
+    expect(terminal.focus).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(textarea);
+    expect(removeLinkPopup).toHaveBeenCalledOnce();
+    expect(clearSearchSelectionState).toHaveBeenCalledOnce();
+    controller.dispose();
+  });
+
+  it.each([
+    "none",
+    "menu",
+  ] as const)("keeps Windows right mousedown visible to xterm in %s mode", (rightClickAction) => {
+    const { controller, terminal, xtermTarget } = createHarness({
+      rightClickAction,
+    });
+    const xtermMouseDown = vi.fn();
+    xtermTarget.addEventListener("mousedown", xtermMouseDown);
+
+    dispatchMouse(xtermTarget, "mousedown", 2);
+
+    expect(xtermMouseDown).toHaveBeenCalledOnce();
+    expect(terminal.focus).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("keeps non-Windows middle and paste-mode right mousedown plus Windows primary mousedown visible to xterm", () => {
+    const nonWindows = createHarness({
+      isWindows: false,
+      rightClickAction: "paste",
+    });
     const nonWindowsMouseDown = vi.fn();
     nonWindows.xtermTarget.addEventListener("mousedown", nonWindowsMouseDown);
 
     dispatchMouse(nonWindows.xtermTarget, "mousedown", 1);
+    dispatchMouse(nonWindows.xtermTarget, "mousedown", 2);
 
-    expect(nonWindowsMouseDown).toHaveBeenCalledOnce();
+    expect(nonWindowsMouseDown).toHaveBeenCalledTimes(2);
     nonWindows.controller.dispose();
 
     const windows = createHarness();

--- a/src/components/terminal/xterminalSelectionController.ts
+++ b/src/components/terminal/xterminalSelectionController.ts
@@ -121,8 +121,11 @@ export function installXTerminalSelectionController({
     if (e.button === 1) e.preventDefault();
   };
 
-  const handleWindowsMiddleMouseDownCapture = (e: MouseEvent) => {
-    if (e.button !== 1) return;
+  const handleWindowsMouseDownCapture = (e: MouseEvent) => {
+    const shouldBlockRightClickPaste =
+      e.button === 2 &&
+      terminalAppSettingsRef.current.interaction.terminal_right_click_action === "paste";
+    if (e.button !== 1 && !shouldBlockRightClickPaste) return;
     handleTerminalMouseDown(e);
     terminal.focus();
     e.stopPropagation();
@@ -289,7 +292,7 @@ export function installXTerminalSelectionController({
     document.addEventListener("mousemove", handleMacReleasedMouseMove, true);
   }
   if (isWindows) {
-    containerEl.addEventListener("mousedown", handleWindowsMiddleMouseDownCapture, true);
+    containerEl.addEventListener("mousedown", handleWindowsMouseDownCapture, true);
     terminal.textarea?.addEventListener("focus", handleTerminalFocus);
     terminal.textarea?.addEventListener("blur", handleTerminalBlur);
     window.addEventListener("keydown", handleSyntheticWinVPaste, true);
@@ -315,7 +318,7 @@ export function installXTerminalSelectionController({
         );
       }
       if (isWindows) {
-        containerEl.removeEventListener("mousedown", handleWindowsMiddleMouseDownCapture, true);
+        containerEl.removeEventListener("mousedown", handleWindowsMouseDownCapture, true);
         terminal.textarea?.removeEventListener("focus", handleTerminalFocus);
         terminal.textarea?.removeEventListener("blur", handleTerminalBlur);
         window.removeEventListener("keydown", handleSyntheticWinVPaste, true);


### PR DESCRIPTION
## 修复
- Windows 下仅在 `terminal_right_click_action` 为 `paste` 时，于 capture 阶段阻止右键 `mousedown` 进入 xterm/Vim；不取消默认行为，因此后续 `contextmenu` 仍按原有路径直接粘贴。
- 保留 `none`/`menu`、非 Windows 和既有中键粘贴行为，并增加连续右键每次仅执行一次剪贴板粘贴的回归测试。

## 验证
针对终端选择控制器和右键菜单的 19 个测试全部通过，TypeScript 类型检查和项目 lint 均通过。lint 仅保留与本次改动无关的现有提示。

Fixes #456