### PR TITLE
feat: 移除 RDP 悬浮操作并支持 macOS 透明度

### DIFF
--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,12 +1,13 @@
 {
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "label": "main",
         "title": "NyaTerm",
         "width": 1280,
         "height": 800,
-        "transparent": false,
+        "transparent": true,
         "visible": false,
         "decorations": true,
         "titleBarStyle": "Overlay",

--- a/src/components/app/AppLayout.tsx
+++ b/src/components/app/AppLayout.tsx
@@ -42,7 +42,7 @@ import {
   isWindowTransparencyEnabled,
   loadBackgroundImageDataUrl,
 } from "@/lib/backgroundImage";
-import { isMacOS } from "@/lib/platform";
+import { isMacOS, isWindows } from "@/lib/platform";
 import type { SendCommandPanelDraft } from "@/lib/sendCommandPanelEvents";
 import type { UpdateInfo } from "@/lib/updater";
 import { bounceTopModalWindow } from "@/lib/windowManager";
@@ -309,6 +309,7 @@ export default function AppLayout({
       data-window-transparency={windowTransparencyEnabled ? "true" : "false"}
       data-window-transparency-blur={
         windowTransparencyEnabled &&
+        isWindows &&
         effectiveAppearance.window_transparency_blur
           ? "true"
           : "false"

--- a/src/components/rdp/RdpPaneHost.test.tsx
+++ b/src/components/rdp/RdpPaneHost.test.tsx
@@ -113,24 +113,12 @@ describe("RdpPaneHost", () => {
     });
   });
 
-  it("keeps reconnect and disconnect controls wired to their existing actions", async () => {
-    const onDisconnectedCloseRequested = vi.fn();
-    render(
-      <RdpPaneHost
-        pane={rdpPane()}
-        active
-        visible
-        onDisconnectedCloseRequested={onDisconnectedCloseRequested}
-      />,
-    );
+  it("keeps session metadata without rendering interactive hover actions", () => {
+    render(<RdpPaneHost pane={rdpPane()} active visible />);
 
-    const controls = screen.getAllByRole("button");
-    expect(controls).toHaveLength(3);
-    fireEvent.click(controls[1]);
-    fireEvent.click(controls[2]);
-
-    expect(invokeMock).toHaveBeenCalledWith("rdp_reconnect", { sessionId: "rdp-session" });
-    expect(onDisconnectedCloseRequested).toHaveBeenCalledOnce();
+    expect(screen.getByText("Windows Desktop")).not.toBeNull();
+    expect(screen.getByText("1920x1080")).not.toBeNull();
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
   });
 });
 

--- a/src/components/rdp/RdpPaneHost.tsx
+++ b/src/components/rdp/RdpPaneHost.tsx
@@ -1,6 +1,6 @@
 import { Channel } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { Maximize2, Monitor, Power, RotateCcw, Send, ShieldAlert } from "lucide-react";
+import { Monitor, ShieldAlert } from "lucide-react";
 import {
   memo,
   type FocusEvent as ReactFocusEvent,
@@ -16,7 +16,6 @@ import {
   createRemoteDesktopRenderer,
   type RemoteDesktopRenderer,
 } from "@/components/remote-desktop/renderer";
-import { Button } from "@/components/ui/button";
 import { invoke } from "@/lib/invoke";
 import { decodeRdpFramePatch } from "@/lib/rdpFrame";
 import {
@@ -82,7 +81,6 @@ interface RdpPaneHostProps {
   pane: RdpSessionPane;
   active: boolean;
   visible: boolean;
-  onDisconnectedCloseRequested?: () => void;
   onConnectionError?: (sessionId: string, error: string) => void;
 }
 
@@ -139,13 +137,7 @@ function statusLabel(state: RdpSessionState, message?: string | null) {
   }
 }
 
-function RdpPaneHost({
-  pane,
-  active,
-  visible,
-  onDisconnectedCloseRequested,
-  onConnectionError,
-}: RdpPaneHostProps) {
+function RdpPaneHost({ pane, active, visible, onConnectionError }: RdpPaneHostProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const imeRef = useRef<HTMLTextAreaElement | null>(null);
@@ -549,10 +541,6 @@ function RdpPaneHost({
     [],
   );
 
-  const sendShortcut = (events: RdpInputEvent[]) => {
-    void sendInputBatch(events);
-  };
-
   return (
     <div
       ref={containerRef}
@@ -657,40 +645,6 @@ function RdpPaneHost({
         <span className="text-white/55">
           {desktopSize.width}x{desktopSize.height}
         </span>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          className="h-6 w-6 text-white"
-          onClick={() =>
-            sendShortcut([
-              { type: "key-down", scanCode: 0x1d, extended: false, repeat: false },
-              { type: "key-down", scanCode: 0x38, extended: false, repeat: false },
-              { type: "key-down", scanCode: 0x53, extended: true, repeat: false },
-              { type: "key-up", scanCode: 0x53, extended: true, repeat: false },
-              { type: "key-up", scanCode: 0x38, extended: false, repeat: false },
-              { type: "key-up", scanCode: 0x1d, extended: false, repeat: false },
-            ])
-          }
-        >
-          <Send className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          className="h-6 w-6 text-white"
-          onClick={() => void invoke("rdp_reconnect", { sessionId: pane.sessionId })}
-        >
-          <RotateCcw className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          className="h-6 w-6 text-white"
-          onClick={onDisconnectedCloseRequested}
-        >
-          <Power className="h-3.5 w-3.5" />
-        </Button>
-        <Maximize2 className="h-3.5 w-3.5 text-white/50" />
       </div>
 
       {state !== "active" && (

--- a/src/components/settings/AppearanceTab.tsx
+++ b/src/components/settings/AppearanceTab.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/lib/backgroundImage";
 import { invoke } from "@/lib/invoke";
 import { logger } from "@/lib/logger";
-import { isWindows } from "@/lib/platform";
+import { isMacOS, isWindows } from "@/lib/platform";
 import {
   DEFAULT_TERMINAL_FONT_SIZE,
   MAX_TERMINAL_FONT_SIZE,
@@ -971,7 +971,7 @@ export function AppearanceTab() {
         </SettingRow>
       </SettingSection>
 
-      {isWindows && (
+      {(isWindows || isMacOS) && (
         <SettingSection
           title={t("settings.windowTransparency")}
           desc={t("settings.windowTransparencyDesc")}
@@ -988,15 +988,17 @@ export function AppearanceTab() {
               })
             }
           />
-          <SettingRow
-            label={t("settings.windowTransparencyBlur")}
-            desc={t("settings.windowTransparencyBlurDesc")}
-          >
-            <SettingSwitch
-              checked={appearance.window_transparency_blur ?? false}
-              onChange={(v) => updateAppearance({ window_transparency_blur: v })}
-            />
-          </SettingRow>
+          {isWindows && (
+            <SettingRow
+              label={t("settings.windowTransparencyBlur")}
+              desc={t("settings.windowTransparencyBlurDesc")}
+            >
+              <SettingSwitch
+                checked={appearance.window_transparency_blur ?? false}
+                onChange={(v) => updateAppearance({ window_transparency_blur: v })}
+              />
+            </SettingRow>
+          )}
         </SettingSection>
       )}
 

--- a/src/components/terminal/PaneWorkspace.test.tsx
+++ b/src/components/terminal/PaneWorkspace.test.tsx
@@ -56,7 +56,6 @@ describe("PaneWorkspace RDP routing", () => {
 
   it("routes RDP leaves to RdpPaneHost with active and visible state", () => {
     const onActivatePane = vi.fn();
-    const onDisconnectedCloseRequested = vi.fn();
     const onConnectionError = vi.fn();
     const tab = tabWithRoot(rdpPane(), "rdp-pane");
 
@@ -66,7 +65,6 @@ describe("PaneWorkspace RDP routing", () => {
         visible
         onActivatePane={onActivatePane}
         onUpdateSplitRatio={vi.fn()}
-        onDisconnectedCloseRequested={onDisconnectedCloseRequested}
         onConnectionError={onConnectionError}
       />,
     );
@@ -85,12 +83,10 @@ describe("PaneWorkspace RDP routing", () => {
     expect(onActivatePane).toHaveBeenCalledWith("rdp-pane");
 
     const rdpProps = rdpPaneHostMock.mock.lastCall?.[0] as {
-      onDisconnectedCloseRequested: () => void;
       onConnectionError: (sessionId: string, error: string) => void;
     };
-    rdpProps.onDisconnectedCloseRequested();
+    expect(rdpProps).not.toHaveProperty("onDisconnectedCloseRequested");
     rdpProps.onConnectionError("rdp-session", "RDP failed");
-    expect(onDisconnectedCloseRequested).toHaveBeenCalledWith("tab-1", "rdp-pane");
     expect(onConnectionError).toHaveBeenCalledWith(
       "tab-1",
       "rdp-pane",

--- a/src/components/terminal/PaneWorkspace.tsx
+++ b/src/components/terminal/PaneWorkspace.tsx
@@ -367,9 +367,6 @@ function PaneNodeView({
             pane={node}
             active={isActive}
             visible={visible}
-            onDisconnectedCloseRequested={() =>
-              void onDisconnectedCloseRequested?.(tab.id, node.id)
-            }
             onConnectionError={(sessionId, error) =>
               onConnectionError?.(tab.id, node.id, sessionId, error)
             }

--- a/src/lib/backgroundImage.test.ts
+++ b/src/lib/backgroundImage.test.ts
@@ -124,4 +124,49 @@ describe("terminal surface background variables", () => {
     expect(terminalColors.foreground).toBe("#abcdef");
     expect(terminalColors.red).toBe("#ff0000");
   });
+
+  it("enables transparent window surfaces on macOS below full opacity", async () => {
+    setNavigator(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+      "MacIntel",
+    );
+    const { buildSurfaceCssVariables, buildTerminalThemeColors, isWindowTransparencyEnabled } =
+      await importBackgroundImage();
+    const transparentWindow = appearance({
+      window_transparency: "transparent",
+      window_transparency_tint: 0.6,
+    });
+
+    const cssVars = buildSurfaceCssVariables(themeColors, transparentWindow);
+    const terminalColors = buildTerminalThemeColors(themeColors.terminal, transparentWindow);
+
+    expect(isWindowTransparencyEnabled(transparentWindow)).toBe(true);
+    expect(
+      isWindowTransparencyEnabled(
+        appearance({ window_transparency: "none", window_transparency_tint: 1 }),
+      ),
+    ).toBe(false);
+    expect(cssVars["--df-bg-terminal"]).toBe("rgba(13, 17, 23, 0.6)");
+    expect(cssVars["--df-terminal-surface-bg"]).toBe("transparent");
+    expect(terminalColors.background).toBe("rgba(0, 0, 0, 0)");
+  });
+
+  it("does not enable native window transparency on Linux", async () => {
+    const { buildSurfaceCssVariables, buildTerminalThemeColors, isWindowTransparencyEnabled } =
+      await importBackgroundImage();
+    const transparentWindow = appearance({
+      window_transparency: "transparent",
+      window_transparency_tint: 0.6,
+    });
+
+    const cssVars = buildSurfaceCssVariables(themeColors, transparentWindow);
+    const terminalColors = buildTerminalThemeColors(themeColors.terminal, transparentWindow);
+
+    expect(isWindowTransparencyEnabled(transparentWindow)).toBe(false);
+    expect(cssVars["--df-bg-terminal"]).toBe(themeColors.bgTerminal);
+    expect(cssVars["--df-terminal-surface-bg"]).toBe(
+      "var(--df-terminal-bg, var(--df-bg-terminal))",
+    );
+    expect(terminalColors.background).toBe(themeColors.terminal.background);
+  });
 });

--- a/src/lib/backgroundImage.ts
+++ b/src/lib/backgroundImage.ts
@@ -2,7 +2,7 @@ import type { CSSProperties } from "react";
 import type { AppearanceSettings, BackgroundImageFit } from "@/types/global";
 import { invoke } from "./invoke";
 import { logger } from "./logger";
-import { isWindows } from "./platform";
+import { isMacOS, isWindows } from "./platform";
 import type { TerminalColors, ThemeColors } from "./themes";
 
 export const BACKGROUND_IMAGE_FITS = ["cover", "contain", "stretch", "tile"] as const;
@@ -60,7 +60,7 @@ export function windowTransparencyModeForOpacity(opacity: number): "none" | "tra
 export function isWindowTransparencyEnabled(
   appearance: Pick<AppearanceSettings, "window_transparency" | "window_transparency_tint">,
 ) {
-  return isWindows && getWindowTransparencyOpacity(appearance) < 1;
+  return (isWindows || isMacOS) && getWindowTransparencyOpacity(appearance) < 1;
 }
 
 function quoteCssUrl(url: string) {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1163,7 +1163,7 @@ export interface GeneralSettings {
 
 export type BackgroundImageFit = "cover" | "contain" | "stretch" | "tile";
 
-/** Internal native transparency marker. Windows 11 only; other platforms no-op. */
+/** Internal native transparency marker. Supported on Windows and macOS; other platforms no-op. */
 export type WindowTransparency = "none" | "transparent";
 
 export interface TerminalThemeColors {


### PR DESCRIPTION
## 修复

- 移除 RDP 面板悬浮层中的 Ctrl+Alt+Del、重连、关闭和最大化样式操作，同时保留会话信息、远程桌面输入/渲染、状态提示及连接错误处理；VNC 和连接失败后的 workspace 重连路径不受影响。
- 将现有窗口透明度支持扩展到 macOS，复用不透明度设置和透明 surface，并为 macOS 窗口启用 Tauri transparent/private API；Acrylic 开关及 blur 行为仍仅限 Windows，Linux 行为保持不变。

## 验证

针对 RDP、workspace 和透明度的 17 个回归测试全部通过，同时 lint、前端生产构建和 Rust `cargo check` 通过。当前执行环境为 Linux，缺少 Xcode/macOS SDK，因此 ARM64 macOS Tauri 打包及最终 `.dmg` 透明度 smoke test 无法在本机完成。

Fixes #624