### PR TITLE
fix(ui): avoid duplicate password reveal buttons on Windows

### DIFF
--- a/src/components/dialog/connections/SshAuthDialog.tsx
+++ b/src/components/dialog/connections/SshAuthDialog.tsx
@@ -603,6 +603,7 @@ function SecretInput({
       <div className="relative mt-1">
         <Input
           ref={inputRef}
+          data-custom-password-reveal
           type={showValue ? "text" : "password"}
           value={value}
           onChange={(event) => onChange(event.target.value)}

--- a/src/components/dialog/docker/DockerSudoPasswordDialog.tsx
+++ b/src/components/dialog/docker/DockerSudoPasswordDialog.tsx
@@ -111,6 +111,7 @@ export default function DockerSudoPasswordDialog({
           <div className="relative">
             <Input
               ref={inputRef}
+              data-custom-password-reveal
               type={showPassword ? "text" : "password"}
               value={password}
               onChange={(event) => setPassword(event.target.value)}

--- a/src/components/dialog/security-auth/CredentialEditorDialog.tsx
+++ b/src/components/dialog/security-auth/CredentialEditorDialog.tsx
@@ -174,6 +174,7 @@ export function CredentialEditorDialog({
                   </Label>
                   <div className="relative">
                     <Input
+                      data-custom-password-reveal
                       type={showPassword ? "text" : "password"}
                       placeholder={
                         passwordLoading

--- a/src/components/dialog/security-auth/KeyEditorDialog.tsx
+++ b/src/components/dialog/security-auth/KeyEditorDialog.tsx
@@ -259,6 +259,7 @@ export function KeyEditorDialog({
             )}
             <div className="relative">
               <Input
+                data-custom-password-reveal
                 type={editShowPassphrase ? "text" : "password"}
                 placeholder={passphraseLoading ? t("common.loading") : t("settings.passphrase")}
                 className="h-8 pr-8 text-xs"

--- a/src/components/panel/security-auth/PasswordManagementTab.tsx
+++ b/src/components/panel/security-auth/PasswordManagementTab.tsx
@@ -67,6 +67,7 @@ function PasswordEditor({
       />
       <div className="relative">
         <Input
+          data-custom-password-reveal
           type={showPassword ? "text" : "password"}
           placeholder={
             passwordLoading

--- a/src/components/sessions/RdpForm.tsx
+++ b/src/components/sessions/RdpForm.tsx
@@ -252,6 +252,7 @@ export function RdpForm({
             <div className="relative mt-1">
               <Input
                 className="h-8 pr-16 text-xs"
+                data-custom-password-reveal
                 type={showPassword ? "text" : "password"}
                 value={password}
                 placeholder={

--- a/src/components/sessions/SshForm.tsx
+++ b/src/components/sessions/SshForm.tsx
@@ -917,6 +917,7 @@ export function SshForm({
                 </Label>
                 <div className="relative mt-1">
                   <Input
+                    data-custom-password-reveal
                     type={showDirectPassword ? "text" : "password"}
                     className="text-xs h-8 pr-16"
                     placeholder={

--- a/src/components/sessions/TelnetForm.tsx
+++ b/src/components/sessions/TelnetForm.tsx
@@ -328,6 +328,7 @@ export function TelnetForm({
                 </Label>
                 <div className="relative mt-1">
                   <Input
+                    data-custom-password-reveal
                     type={showDirectPassword ? "text" : "password"}
                     className="text-xs h-8 pr-16"
                     placeholder={

--- a/src/components/sessions/VncForm.tsx
+++ b/src/components/sessions/VncForm.tsx
@@ -208,6 +208,7 @@ export function VncForm({
             <div className="relative mt-1">
               <Input
                 className="h-8 pr-16 text-xs"
+                data-custom-password-reveal
                 type={showPassword ? "text" : "password"}
                 value={password}
                 placeholder={

--- a/src/index.css
+++ b/src/index.css
@@ -305,6 +305,12 @@ textarea,
   user-select: text;
 }
 
+/* Edge/WebView2 adds a native reveal button to password inputs. Hide it only
+   when NyaTerm renders its own password visibility control. */
+input[data-custom-password-reveal]::-ms-reveal {
+  display: none;
+}
+
 .nyaterm-wallpaper-shell[data-wallpaper-enabled="true"] .xterm,
 .nyaterm-wallpaper-shell[data-wallpaper-enabled="true"] .xterm .xterm-viewport,
 .nyaterm-wallpaper-shell[data-wallpaper-enabled="true"] .xterm .xterm-screen,


### PR DESCRIPTION
## Summary

- hide the Edge/WebView2 native `::-ms-reveal` control only for password fields that already render a NyaTerm visibility toggle
- mark SSH, Telnet, RDP, VNC, runtime auth, Docker sudo, credential, key passphrase, and password-management inputs that use custom reveal buttons
- keep native reveal behavior unchanged for password inputs without a custom NyaTerm control

## Validation

- `pnpm exec tsc --noEmit`
- `git diff --check`
- verified all custom reveal inputs opt in via `data-custom-password-reveal`

Formatting checks still report pre-existing whole-file formatting/import-order differences in the touched legacy files, so this PR intentionally avoids unrelated reformatting.

Closes #620
