### PR TITLE
fix(assets): combine asset filters by dimension

### DIFF
--- a/src/components/app/start-workspace/AssetView.test.tsx
+++ b/src/components/app/start-workspace/AssetView.test.tsx
@@ -111,6 +111,30 @@ describe("start workspace asset view", () => {
     expect(screen.queryByText("Ascend Edge")).toBeNull();
   });
 
+  it("combines filters with OR within a dimension and AND across dimensions", async () => {
+    const user = userEvent.setup();
+    renderAssetView();
+
+    await user.click(screen.getByRole("button", { name: "Linux" }));
+    await user.click(screen.getByRole("button", { name: "Windows" }));
+
+    expect(screen.getByText("GPU Lab")).not.toBeNull();
+    expect(screen.getByText("Windows VM")).not.toBeNull();
+    expect(screen.getByText("Ascend Edge")).not.toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "GPU" }));
+
+    expect(screen.getByText("GPU Lab")).not.toBeNull();
+    expect(screen.queryByText("Windows VM")).toBeNull();
+    expect(screen.queryByText("Ascend Edge")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "NPU" }));
+
+    expect(screen.getByText("GPU Lab")).not.toBeNull();
+    expect(screen.queryByText("Windows VM")).toBeNull();
+    expect(screen.getByText("Ascend Edge")).not.toBeNull();
+  });
+
   it("shows ancestor breadcrumbs after selecting a group", async () => {
     const user = userEvent.setup();
     renderAssetView();

--- a/src/components/app/start-workspace/AssetView.tsx
+++ b/src/components/app/start-workspace/AssetView.tsx
@@ -222,10 +222,26 @@ export default function AssetView({
 function matchesFilters(connection: SavedConnection, filters: Set<AssetFilterKey>): boolean {
   if (filters.size === 0) return true;
   const asset = connection.asset;
-  if (filters.has("linux") && !isLinuxAsset(asset)) return false;
-  if (filters.has("windows") && !isWindowsAsset(asset)) return false;
-  if (filters.has("gpu") && !hasGpu(asset)) return false;
-  if (filters.has("npu") && !hasNpu(asset)) return false;
+
+  const hasOsFilter = filters.has("linux") || filters.has("windows");
+  if (
+    hasOsFilter &&
+    !(
+      (filters.has("linux") && isLinuxAsset(asset)) ||
+      (filters.has("windows") && isWindowsAsset(asset))
+    )
+  ) {
+    return false;
+  }
+
+  const hasAcceleratorFilter = filters.has("gpu") || filters.has("npu");
+  if (
+    hasAcceleratorFilter &&
+    !((filters.has("gpu") && hasGpu(asset)) || (filters.has("npu") && hasNpu(asset)))
+  ) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Treat Linux and Windows as alternatives within the OS filter dimension.
- Treat GPU and NPU as alternatives within the accelerator filter dimension.
- Keep AND semantics between OS and accelerator dimensions.
- Add regression coverage for Linux + Windows, OS + GPU, and GPU + NPU combinations.

## Validation

- `pnpm vitest run src/components/app/start-workspace/AssetView.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint src/components/app/start-workspace/AssetView.tsx src/components/app/start-workspace/AssetView.test.tsx`
- `git diff --check`

Fixes #630
