### PR TITLE
feat(file-explorer): 悬停显示完整文件信息

### DIFF
--- a/src/components/panel/file-explorer/FileListItem.tsx
+++ b/src/components/panel/file-explorer/FileListItem.tsx
@@ -35,6 +35,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "../../ui/context-menu";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "../../ui/hover-card";
 
 interface FileListItemProps {
   entry: FileEntry;
@@ -148,9 +149,6 @@ export function FileListItem({
   const permissions = isParentDirectoryEntry ? "" : entry.permissions || "-";
   const owner = isParentDirectoryEntry ? "" : entry.owner || "-";
   const group = isParentDirectoryEntry ? "" : entry.group || "-";
-  const itemTitle = isParentDirectoryEntry
-    ? t("fileExplorer.goUp")
-    : `${permissions} ${fileSize} ${modifiedTime} ${owner}:${group}`;
   const isRenaming = !!inlineRename;
   const isFile = !entry.is_dir;
   const showOpenInternal = isFile && editorType === "external";
@@ -272,7 +270,7 @@ export function FileListItem({
             }
             onContextMenuSelect(entry, e);
           }}
-          title={itemTitle}
+          title={isParentDirectoryEntry ? t("fileExplorer.goUp") : undefined}
         >
           <div className="flex min-w-0 items-center gap-2 px-2">
             <entryIcon.icon
@@ -320,9 +318,43 @@ export function FileListItem({
               />
             ) : (
               <>
-                <span className="min-w-0 flex-1 truncate text-xs" onClick={handleNameClick}>
-                  {entry.name}
-                </span>
+                {isParentDirectoryEntry ? (
+                  <span className="min-w-0 flex-1 truncate text-xs" onClick={handleNameClick}>
+                    {entry.name}
+                  </span>
+                ) : (
+                  <HoverCard openDelay={450} closeDelay={100}>
+                    <HoverCardTrigger asChild>
+                      <span
+                        className="min-w-0 flex-1 truncate text-xs"
+                        onClick={handleNameClick}
+                      >
+                        {entry.name}
+                      </span>
+                    </HoverCardTrigger>
+                    <HoverCardContent
+                      side="top"
+                      align="start"
+                      className="w-80 max-w-[calc(100vw-2rem)] p-3"
+                    >
+                      <div className="mb-2 break-all text-sm font-medium leading-snug">
+                        {entry.name}
+                      </div>
+                      <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-1 text-xs">
+                        <span className="text-muted-foreground">{t("fileExplorer.mtime")}</span>
+                        <span className="min-w-0 break-words font-mono">{modifiedTime}</span>
+                        <span className="text-muted-foreground">{t("fileExplorer.size")}</span>
+                        <span className="min-w-0 break-words">{fileSize}</span>
+                        <span className="text-muted-foreground">{t("fileExplorer.permissions")}</span>
+                        <span className="min-w-0 break-all font-mono">{permissions}</span>
+                        <span className="text-muted-foreground">{t("fileExplorer.owner")}</span>
+                        <span className="min-w-0 break-all">{owner}</span>
+                        <span className="text-muted-foreground">{t("fileExplorer.group")}</span>
+                        <span className="min-w-0 break-all">{group}</span>
+                      </div>
+                    </HoverCardContent>
+                  </HoverCard>
+                )}
                 {showPeerSendAction && !isParentDirectoryEntry && onSendToPeer && (
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

- 为文件列表中的文件名增加结构化 HoverCard，悬停时可查看完整文件名
- 分组展示修改时间、大小、权限、所有者和用户组信息
- 保留“返回上级”条目的原生提示，并移除普通文件行旧的一行式 `title` 提示
- 使用延迟打开，避免鼠标快速经过文件列表时频繁弹出

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint src/components/panel/file-explorer/FileListItem.tsx`
- `pnpm exec vitest run src/components/panel/file-explorer/editorOpenMode.test.ts src/components/panel/file-explorer/FileDocumentEditor.test.tsx src/components/panel/file-explorer/FilePreviewContent.test.tsx src/components/panel/file-explorer/model.test.ts` (29 tests passed)
- `git diff --check`

Closes #602
