### PR TITLE
fix(ssh): import IdentityFile private keys from SSH config

### DIFF
--- a/src-tauri/src/core/ssh_config.rs
+++ b/src-tauri/src/core/ssh_config.rs
@@ -5,14 +5,15 @@
 //! IdentityFile, ProxyJump (single/multi-hop), HostKeyAlias, and Include
 //! directives (recursive with cycle detection and glob support).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::{ConnectionAuth, ConnectionType, SavedConnection};
+use crate::config::{ConnectionAuth, ConnectionType, SavedConnection, SshKey};
 use crate::error::{AppError, AppResult};
+use crate::utils::crypto;
 
 /// One parsed `Host` block from the SSH config file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -549,35 +550,29 @@ fn default_config_path() -> PathBuf {
 }
 
 /// Converts an SshConfigEntry into a SavedConnection for nyaterm.
-/// Uses `agent` auth by default. When an identity file is present, we still
-/// use `agent` because the key file would need to be registered in nyaterm's
-/// key store (which requires reading the file content). The identity file path
-/// is noted as a manual setup requirement rather than claiming the key was
-/// imported.
 fn entry_to_saved_connection(
     entry: &SshConfigEntry,
     proxy_jump_id: Option<String>,
+    key_id: Option<String>,
 ) -> SavedConnection {
-    let description = if entry.proxy_jump.is_some() {
-        format!(
-            "Imported from ~/.ssh/config (ProxyJump: {}{})",
-            entry.proxy_jump.as_ref().unwrap(),
-            if entry.identity_file.is_some() {
-                format!(
-                    ", IdentityFile recognized (configure manually): {}",
-                    entry.identity_file.as_ref().unwrap()
-                )
-            } else {
-                String::new()
-            }
-        )
-    } else if entry.identity_file.is_some() {
-        format!(
-            "Imported from ~/.ssh/config (IdentityFile recognized; configure manually: {})",
-            entry.identity_file.as_ref().unwrap()
-        )
-    } else {
+    let uses_key = key_id.is_some();
+    let mut details = Vec::new();
+    if let Some(proxy_jump) = entry.proxy_jump.as_deref() {
+        details.push(format!("ProxyJump: {proxy_jump}"));
+    }
+    if let Some(identity_file) = entry.identity_file.as_deref() {
+        if uses_key {
+            details.push(format!("IdentityFile: {identity_file}"));
+        } else {
+            details.push(format!(
+                "IdentityFile unavailable; using SSH agent: {identity_file}"
+            ));
+        }
+    }
+    let description = if details.is_empty() {
         "Imported from ~/.ssh/config".to_string()
+    } else {
+        format!("Imported from ~/.ssh/config ({})", details.join(", "))
     };
 
     SavedConnection {
@@ -601,10 +596,10 @@ fn entry_to_saved_connection(
         icon: None,
         icon_auto_detect: None,
         auth: Some(ConnectionAuth {
-            mode: "agent".to_string(),
+            mode: if uses_key { "key" } else { "agent" }.to_string(),
             password_id: None,
             password: None,
-            key_id: None,
+            key_id,
             otp_id: None,
             auto_fill_otp: false,
             has_password: false,
@@ -626,6 +621,81 @@ fn entry_to_saved_connection(
     }
 }
 
+fn identity_file_path(identity_file: &str) -> Option<PathBuf> {
+    let value = identity_file.trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("none") {
+        return None;
+    }
+    let value = if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    };
+    Some(PathBuf::from(expand_tilde(value)))
+}
+
+fn import_identity_key_with_encrypt<F>(
+    entry: &SshConfigEntry,
+    keys: &mut Vec<SshKey>,
+    imported_paths: &mut HashMap<PathBuf, String>,
+    encrypt: F,
+) -> AppResult<Option<String>>
+where
+    F: FnOnce(&str) -> AppResult<String>,
+{
+    let Some(identity_file) = entry.identity_file.as_deref() else {
+        return Ok(None);
+    };
+    let Some(path) = identity_file_path(identity_file) else {
+        return Ok(None);
+    };
+    let dedupe_path = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    if let Some(key_id) = imported_paths.get(&dedupe_path) {
+        return Ok(Some(key_id.clone()));
+    }
+
+    let content = match fs::read_to_string(&path) {
+        Ok(content) if !content.trim().is_empty() => content,
+        Ok(_) | Err(_) => return Ok(None),
+    };
+    let key_id = uuid::Uuid::new_v4().to_string();
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty());
+    let name = file_name.map_or_else(
+        || format!("{} SSH key", entry.alias),
+        |file_name| format!("{} ({file_name})", entry.alias),
+    );
+
+    keys.push(SshKey {
+        id: key_id.clone(),
+        name,
+        key: Some(encrypt(&content)?),
+        cert: None,
+        passphrase: None,
+        key_data: None,
+        cert_data: None,
+        key_file_path: None,
+        cert_file_path: None,
+        has_key_data: false,
+        has_cert_data: false,
+    });
+    imported_paths.insert(dedupe_path, key_id.clone());
+    Ok(Some(key_id))
+}
+
+fn import_identity_key(
+    entry: &SshConfigEntry,
+    keys: &mut Vec<SshKey>,
+    imported_paths: &mut HashMap<PathBuf, String>,
+) -> AppResult<Option<String>> {
+    import_identity_key_with_encrypt(entry, keys, imported_paths, crypto::encrypt)
+}
+
 /// Imports SSH config hosts as saved connections, skipping existing names.
 /// Each ProxyJump list is materialized in reverse linkage order because the
 /// runtime recursively follows `proxy_jump_id` from a target to the previous
@@ -634,11 +704,22 @@ fn entry_to_saved_connection(
 pub fn import_ssh_config_connections(app: &tauri::AppHandle) -> AppResult<usize> {
     let config = SshConfig::load_default()?;
     let mut cfg = crate::config::load_config(app)?;
-    let connections = build_imported_connections(&config, &cfg.connections)?;
+    let mut keys = crate::config::load_keys(app)?;
+    let initial_key_count = keys.keys.len();
+    let mut imported_identity_paths = HashMap::new();
+    let connections =
+        build_imported_connections_with_key_resolver(&config, &cfg.connections, |entry| {
+            import_identity_key(entry, &mut keys.keys, &mut imported_identity_paths)
+        })?;
     let count = connections.len();
     cfg.connections.extend(connections);
 
     if count > 0 {
+        if keys.keys.len() != initial_key_count {
+            // Persist keys first so a config write can never leave a connection
+            // pointing at a key that was not stored successfully.
+            crate::config::save_keys(app, &keys)?;
+        }
         crate::config::save_config(app, &cfg)?;
     }
 
@@ -967,20 +1048,71 @@ mod tests {
     }
 
     #[test]
-    fn identity_file_is_manual_agent_setup_not_key_import() {
+    fn identity_file_uses_imported_key_when_available() {
         let ssh_config = parse_test_config("Host prod\n    IdentityFile ~/.ssh/id_ed25519\n");
         let entry = ssh_config.resolve("prod").unwrap();
-        let connection = entry_to_saved_connection(&entry, None);
+        let connection = entry_to_saved_connection(&entry, None, Some("key-1".to_string()));
+        let auth = connection.auth.as_ref().unwrap();
 
-        assert_eq!(connection.auth.as_ref().unwrap().mode, "agent");
-        assert!(connection.auth.as_ref().unwrap().key_id.is_none());
+        assert_eq!(auth.mode, "key");
+        assert_eq!(auth.key_id.as_deref(), Some("key-1"));
         assert!(
             connection
                 .description
                 .as_deref()
                 .unwrap()
-                .contains("configure manually")
+                .contains("IdentityFile:")
         );
+    }
+
+    #[test]
+    fn unavailable_identity_file_falls_back_to_agent() {
+        let ssh_config = parse_test_config("Host prod\n    IdentityFile ~/.ssh/missing-key\n");
+        let entry = ssh_config.resolve("prod").unwrap();
+        let connection = entry_to_saved_connection(&entry, None, None);
+        let auth = connection.auth.as_ref().unwrap();
+
+        assert_eq!(auth.mode, "agent");
+        assert!(auth.key_id.is_none());
+        assert!(
+            connection
+                .description
+                .as_deref()
+                .unwrap()
+                .contains("using SSH agent")
+        );
+    }
+
+    #[test]
+    fn identity_file_import_reads_and_deduplicates_private_key() {
+        let root = test_temp_dir("identity_import");
+        let key_path = root.join("id_ed25519");
+        fs::write(&key_path, "private-key-data\n").unwrap();
+        let ssh_config = parse_test_config(&format!(
+            "Host prod\n    IdentityFile {}\n",
+            key_path.to_string_lossy()
+        ));
+        let entry = ssh_config.resolve("prod").unwrap();
+        let mut keys = Vec::new();
+        let mut imported_paths = HashMap::new();
+
+        let first =
+            import_identity_key_with_encrypt(&entry, &mut keys, &mut imported_paths, |content| {
+                Ok(format!("encrypted:{content}"))
+            })
+            .unwrap()
+            .unwrap();
+        let second =
+            import_identity_key_with_encrypt(&entry, &mut keys, &mut imported_paths, |_| {
+                panic!("deduplicated key should not be encrypted twice")
+            })
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key.as_deref(), Some("encrypted:private-key-data\n"));
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
@@ -1239,12 +1371,14 @@ struct ImportNode {
 
 /// Builds the connection graph before it is persisted. Kept separate from the
 /// Tauri/storage boundary so the exact runtime graph can be tested.
-fn build_imported_connections(
+fn build_imported_connections_with_key_resolver<F>(
     config: &SshConfig,
     existing: &[SavedConnection],
-) -> AppResult<Vec<SavedConnection>> {
-    use std::collections::HashMap;
-
+    mut resolve_key: F,
+) -> AppResult<Vec<SavedConnection>>
+where
+    F: FnMut(&SshConfigEntry) -> AppResult<Option<String>>,
+{
     let entries = config.to_entries()?;
     let mut nodes: HashMap<String, ImportNode> = HashMap::new();
     let mut links: HashMap<String, String> = HashMap::new();
@@ -1311,13 +1445,22 @@ fn build_imported_connections(
             continue;
         }
 
-        let mut connection = entry_to_saved_connection(&node.entry, expected_jump_id);
+        let key_id = resolve_key(&node.entry)?;
+        let mut connection = entry_to_saved_connection(&node.entry, expected_jump_id, key_id);
         connection.id = ids.get(&node.key).expect("generated ID exists").clone();
         connection.name = node.name;
         imported.push(connection);
     }
 
     Ok(imported)
+}
+
+#[cfg(test)]
+fn build_imported_connections(
+    config: &SshConfig,
+    existing: &[SavedConnection],
+) -> AppResult<Vec<SavedConnection>> {
+    build_imported_connections_with_key_resolver(config, existing, |_| Ok(None))
 }
 
 fn set_import_link(

--- a/src-tauri/src/core/ssh_config.rs
+++ b/src-tauri/src/core/ssh_config.rs
@@ -25,6 +25,8 @@ pub struct SshConfigHost {
     pub port: Option<u16>,
     pub user: Option<String>,
     pub identity_file: Option<String>,
+    #[serde(default)]
+    pub identity_files: Vec<String>,
     pub proxy_jump: Option<String>,
     pub host_key_alias: Option<String>,
 }
@@ -38,6 +40,8 @@ pub struct SshConfigEntry {
     pub port: u16,
     pub user: String,
     pub identity_file: Option<String>,
+    #[serde(default)]
+    pub identity_files: Vec<String>,
     pub proxy_jump: Option<String>,
     pub hops: Vec<SshConfigHop>,
     pub host_key_alias: Option<String>,
@@ -81,7 +85,8 @@ impl SshConfig {
         let host_name = resolved.host_name.unwrap_or_else(|| alias.to_string());
         let port = resolved.port.unwrap_or(22);
         let user = resolved.user.unwrap_or_else(whoami::username);
-        let identity_file = resolved.identity_file;
+        let identity_files = resolved.identity_files;
+        let identity_file = identity_files.first().cloned().or(resolved.identity_file);
         // `ProxyJump none` explicitly disables a value that may have matched
         // earlier (for example from `Host *`). It is not a host named `none`.
         let proxy_jump = resolved
@@ -128,6 +133,7 @@ impl SshConfig {
             port,
             user,
             identity_file,
+            identity_files,
             proxy_jump,
             hops,
             host_key_alias: resolved.host_key_alias,
@@ -160,8 +166,16 @@ impl SshConfig {
                 if resolved.user.is_none() {
                     resolved.user = host.user.clone();
                 }
-                if resolved.identity_file.is_none() {
-                    resolved.identity_file = host.identity_file.clone();
+                let host_identity_files = if host.identity_files.is_empty() {
+                    host.identity_file.iter().cloned().collect::<Vec<_>>()
+                } else {
+                    host.identity_files.clone()
+                };
+                for identity_file in host_identity_files {
+                    if resolved.identity_file.is_none() {
+                        resolved.identity_file = Some(identity_file.clone());
+                    }
+                    resolved.identity_files.push(identity_file);
                 }
                 if resolved.proxy_jump.is_none() {
                     resolved.proxy_jump = host.proxy_jump.clone();
@@ -189,6 +203,7 @@ struct ResolvedOptions {
     port: Option<u16>,
     user: Option<String>,
     identity_file: Option<String>,
+    identity_files: Vec<String>,
     proxy_jump: Option<String>,
     host_key_alias: Option<String>,
 }
@@ -365,10 +380,13 @@ fn parse_string_into(
                 }
             }
             "identityfile" => {
+                let identity_file = expand_tilde(value);
                 if let Some(ref mut block) = state.current {
-                    set_if_missing(&mut block.identity_file, expand_tilde(value));
+                    set_if_missing(&mut block.identity_file, identity_file.clone());
+                    block.identity_files.push(identity_file);
                 } else {
-                    set_if_missing(&mut state.global.identity_file, expand_tilde(value));
+                    set_if_missing(&mut state.global.identity_file, identity_file.clone());
+                    state.global.identity_files.push(identity_file);
                 }
             }
             "proxyjump" => {
@@ -416,6 +434,7 @@ fn has_options(block: &SshConfigHost) -> bool {
         || block.port.is_some()
         || block.user.is_some()
         || block.identity_file.is_some()
+        || !block.identity_files.is_empty()
         || block.proxy_jump.is_some()
         || block.host_key_alias.is_some()
 }
@@ -560,12 +579,17 @@ fn entry_to_saved_connection(
     if let Some(proxy_jump) = entry.proxy_jump.as_deref() {
         details.push(format!("ProxyJump: {proxy_jump}"));
     }
-    if let Some(identity_file) = entry.identity_file.as_deref() {
+    if entry.identity_files.len() > 1 {
+        details.push(format!(
+            "{} IdentityFile entries; using SSH agent",
+            entry.identity_files.len()
+        ));
+    } else if let Some(identity_file) = entry.identity_file.as_deref() {
         if uses_key {
             details.push(format!("IdentityFile: {identity_file}"));
         } else {
             details.push(format!(
-                "IdentityFile unavailable; using SSH agent: {identity_file}"
+                "IdentityFile not importable; using SSH agent: {identity_file}"
             ));
         }
     }
@@ -637,6 +661,21 @@ fn identity_file_path(identity_file: &str) -> Option<PathBuf> {
     Some(PathBuf::from(expand_tilde(value)))
 }
 
+fn missing_private_key_passphrase_error(error: &russh::keys::Error) -> bool {
+    let message = error.to_string().to_lowercase();
+    message.contains("encrypted")
+        || message.contains("passphrase")
+        || message.contains("password")
+        || message.contains("cipher")
+}
+
+fn private_key_content_is_importable(content: &str) -> bool {
+    match russh::keys::decode_secret_key(content, None) {
+        Ok(_) => true,
+        Err(error) => missing_private_key_passphrase_error(&error),
+    }
+}
+
 fn import_identity_key_with_encrypt<F>(
     entry: &SshConfigEntry,
     keys: &mut Vec<SshKey>,
@@ -646,10 +685,15 @@ fn import_identity_key_with_encrypt<F>(
 where
     F: FnOnce(&str) -> AppResult<String>,
 {
-    let Some(identity_file) = entry.identity_file.as_deref() else {
-        return Ok(None);
+    let identity_files = if entry.identity_files.is_empty() {
+        entry.identity_file.iter().collect::<Vec<_>>()
+    } else {
+        entry.identity_files.iter().collect::<Vec<_>>()
     };
-    let Some(path) = identity_file_path(identity_file) else {
+    if identity_files.len() != 1 {
+        return Ok(None);
+    }
+    let Some(path) = identity_file_path(identity_files[0]) else {
         return Ok(None);
     };
     let dedupe_path = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
@@ -661,6 +705,9 @@ where
         Ok(content) if !content.trim().is_empty() => content,
         Ok(_) | Err(_) => return Ok(None),
     };
+    if !private_key_content_is_importable(&content) {
+        return Ok(None);
+    }
 
     if let Some(existing_id) = keys.iter().find_map(|key| {
         crate::config::decrypt_key_pem(key)
@@ -751,6 +798,9 @@ pub fn import_ssh_config_connections(app: &tauri::AppHandle) -> AppResult<usize>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TEST_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC\n-----END PRIVATE KEY-----";
+    const TEST_ENCRYPTED_PRIVATE_KEY: &str = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jYmMAAAAGYmNyeXB0AAAAGAAAABDLGyfA39\nJ2FcJygtYqi5ISAAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIN+Wjn4+4Fcvl2Jl\nKpggT+wCRxpSvtqqpVrQrKN1/A22AAAAkOHDLnYZvYS6H9Q3S3Nk4ri3R2jAZlQlBbUos5\nFkHpYgNw65KCWCTXtP7ye2czMC3zjn2r98pJLobsLYQgRiHIv/CUdAdsqbvMPECB+wl/UQ\ne+JpiSq66Z6GIt0801skPh20jxOO3F52SoX1IeO5D5PXfZrfSZlw6S8c7bwyp2FHxDewRx\n7/wNsnDM0T7nLv/Q==\n-----END OPENSSH PRIVATE KEY-----";
 
     #[test]
     fn glob_matches_basic_patterns() {
@@ -1114,10 +1164,89 @@ mod tests {
     }
 
     #[test]
+    fn multiple_identity_files_are_preserved_in_order() {
+        let ssh_config = parse_test_config(
+            "Host prod\n    IdentityFile ~/.ssh/id_ed25519\n    IdentityFile ~/.ssh/id_rsa\n",
+        );
+        let entry = ssh_config.resolve("prod").unwrap();
+
+        assert_eq!(entry.identity_files.len(), 2);
+        assert!(entry.identity_files[0].ends_with("id_ed25519"));
+        assert!(entry.identity_files[1].ends_with("id_rsa"));
+        assert_eq!(
+            entry.identity_file.as_deref(),
+            Some(entry.identity_files[0].as_str())
+        );
+    }
+
+    #[test]
+    fn multiple_identity_files_keep_agent_auth() {
+        let ssh_config = parse_test_config(
+            "Host prod\n    IdentityFile ~/.ssh/id_ed25519\n    IdentityFile ~/.ssh/id_rsa\n",
+        );
+        let entry = ssh_config.resolve("prod").unwrap();
+        let mut keys = Vec::new();
+        let mut imported_paths = HashMap::new();
+
+        let key_id =
+            import_identity_key_with_encrypt(&entry, &mut keys, &mut imported_paths, |_| {
+                panic!("multiple identities must not select key auth")
+            })
+            .unwrap();
+        let connection = entry_to_saved_connection(&entry, None, key_id);
+
+        assert!(keys.is_empty());
+        assert_eq!(connection.auth.as_ref().unwrap().mode, "agent");
+        assert!(
+            connection
+                .description
+                .as_deref()
+                .unwrap()
+                .contains("IdentityFile entries; using SSH agent")
+        );
+    }
+
+    #[test]
+    fn readable_public_key_file_falls_back_to_agent() {
+        let root = test_temp_dir("public_identity");
+        let key_path = root.join("id_ed25519.pub");
+        fs::write(
+            &key_path,
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBogusPublicKey test\n",
+        )
+        .unwrap();
+        let ssh_config = parse_test_config(&format!(
+            "Host prod\n    IdentityFile {}\n",
+            key_path.to_string_lossy()
+        ));
+        let entry = ssh_config.resolve("prod").unwrap();
+        let mut keys = Vec::new();
+        let mut imported_paths = HashMap::new();
+
+        let key_id =
+            import_identity_key_with_encrypt(&entry, &mut keys, &mut imported_paths, |_| {
+                panic!("public key content must not be imported as a private key")
+            })
+            .unwrap();
+        let connection = entry_to_saved_connection(&entry, None, key_id);
+
+        assert!(keys.is_empty());
+        assert_eq!(connection.auth.as_ref().unwrap().mode, "agent");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn encrypted_private_key_without_passphrase_is_importable() {
+        assert!(private_key_content_is_importable(
+            TEST_ENCRYPTED_PRIVATE_KEY
+        ));
+    }
+
+    #[test]
     fn identity_file_import_reads_and_deduplicates_private_key() {
         let root = test_temp_dir("identity_import");
         let key_path = root.join("id_ed25519");
-        fs::write(&key_path, "private-key-data\n").unwrap();
+        fs::write(&key_path, TEST_PRIVATE_KEY).unwrap();
         let ssh_config = parse_test_config(&format!(
             "Host prod\n    IdentityFile {}\n",
             key_path.to_string_lossy()
@@ -1141,7 +1270,10 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(keys.len(), 1);
-        assert_eq!(keys[0].key.as_deref(), Some("encrypted:private-key-data\n"));
+        assert_eq!(
+            keys[0].key.as_deref(),
+            Some(format!("encrypted:{TEST_PRIVATE_KEY}").as_str())
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/src-tauri/src/core/ssh_config.rs
+++ b/src-tauri/src/core/ssh_config.rs
@@ -499,7 +499,7 @@ fn derive_display_name(patterns: &[String]) -> String {
 }
 
 fn expand_tilde(path: &str) -> String {
-    if let Some(rest) = path.strip_prefix("~/") {
+    if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest).to_string_lossy().into_owned();
         }
@@ -661,6 +661,18 @@ where
         Ok(content) if !content.trim().is_empty() => content,
         Ok(_) | Err(_) => return Ok(None),
     };
+
+    if let Some(existing_id) = keys.iter().find_map(|key| {
+        crate::config::decrypt_key_pem(key)
+            .ok()
+            .flatten()
+            .filter(|existing| existing == &content)
+            .map(|_| key.id.clone())
+    }) {
+        imported_paths.insert(dedupe_path, existing_id.clone());
+        return Ok(Some(existing_id));
+    }
+
     let key_id = uuid::Uuid::new_v4().to_string();
     let file_name = path
         .file_name()
@@ -705,7 +717,8 @@ pub fn import_ssh_config_connections(app: &tauri::AppHandle) -> AppResult<usize>
     let config = SshConfig::load_default()?;
     let mut cfg = crate::config::load_config(app)?;
     let mut keys = crate::config::load_keys(app)?;
-    let initial_key_count = keys.keys.len();
+    let original_keys = keys.clone();
+    let initial_key_count = original_keys.keys.len();
     let mut imported_identity_paths = HashMap::new();
     let connections =
         build_imported_connections_with_key_resolver(&config, &cfg.connections, |entry| {
@@ -720,7 +733,16 @@ pub fn import_ssh_config_connections(app: &tauri::AppHandle) -> AppResult<usize>
             // pointing at a key that was not stored successfully.
             crate::config::save_keys(app, &keys)?;
         }
-        crate::config::save_config(app, &cfg)?;
+        if let Err(error) = crate::config::save_config(app, &cfg) {
+            if keys.keys.len() != initial_key_count {
+                if let Err(rollback_error) = crate::config::save_keys(app, &original_keys) {
+                    return Err(AppError::Config(format!(
+                        "failed to save imported SSH connections ({error}); also failed to roll back imported SSH keys ({rollback_error})"
+                    )));
+                }
+            }
+            return Err(error);
+        }
     }
 
     Ok(count)
@@ -1081,6 +1103,14 @@ mod tests {
                 .unwrap()
                 .contains("using SSH agent")
         );
+    }
+
+    #[test]
+    fn identity_file_path_expands_windows_style_tilde_prefix() {
+        let home = dirs::home_dir().expect("home directory");
+        let path = identity_file_path(r#"~\.ssh\id_ed25519"#).expect("identity path");
+
+        assert_eq!(path, home.join(r#".ssh\id_ed25519"#));
     }
 
     #[test]

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1952,6 +1952,7 @@ export interface SshConfigEntry {
   port: number;
   user: string;
   identityFile?: string | null;
+  identityFiles?: string[];
   proxyJump?: string | null;
   hops: SshConfigHop[];
   hostKeyAlias?: string | null;


### PR DESCRIPTION
## Summary

- import readable `IdentityFile` private keys from `~/.ssh/config` into NyaTerm's encrypted SSH key store
- bind imported connections to `key` authentication and reuse the same key for repeated paths in one import
- reuse an existing stored key when its decrypted private-key content already matches the configured `IdentityFile`
- fall back to SSH Agent when an identity file is missing or unreadable instead of failing the whole import
- handle quoted identity paths, `IdentityFile none`, and Windows-style `~\\...` paths
- roll back newly persisted keys if saving the imported connections fails, avoiding orphaned key records

## Validation

- `cargo fmt --check` in `src-tauri`
- `cargo test core::ssh_config::tests --lib` in `src-tauri` — 24 passed
- `cargo check --lib` in `src-tauri`
- `git diff --check`

Closes #631
