### PR TITLE
fix(window): avoid Linux X11 modal crash

### DIFF
--- a/src/lib/windowManager.test.ts
+++ b/src/lib/windowManager.test.ts
@@ -62,6 +62,8 @@ const mocks = vi.hoisted(() => {
     ]),
     createMockWindow,
     currentWindow,
+    isLinux: false,
+    isMacOS: false,
     emit: vi.fn(async () => {}),
     getAll: vi.fn(async () => Array.from(windows.values())),
     getByLabel: vi.fn(async (label: string) => windows.get(label) ?? null),
@@ -118,10 +120,20 @@ vi.mock("./logger", () => ({
     warn: vi.fn(),
   },
 }));
+vi.mock("./platform", () => ({
+  get isLinux() {
+    return mocks.isLinux;
+  },
+  get isMacOS() {
+    return mocks.isMacOS;
+  },
+}));
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.resetModules();
+  mocks.isLinux = false;
+  mocks.isMacOS = false;
   mocks.listeners.clear();
   mocks.windows.clear();
 });
@@ -184,6 +196,46 @@ describe("child window work-area helpers", () => {
       x: 560,
       y: 240,
     });
+  });
+});
+
+describe("modal window raising", () => {
+  it("does not pulse always-on-top for ordinary modal windows on Linux", async () => {
+    mocks.isLinux = true;
+    const settingsWindow = mocks.createMockWindow("settings", mocks.windows);
+    mocks.windows.set("settings", settingsWindow);
+    const { raiseModalChildWindowGroup } = await importWindowManager();
+
+    await raiseModalChildWindowGroup({ reason: "open" });
+
+    expect(settingsWindow.show).toHaveBeenCalledOnce();
+    expect(settingsWindow.setFocus).toHaveBeenCalledOnce();
+    expect(settingsWindow.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it("preserves required always-on-top state for auto-upload windows on Linux", async () => {
+    mocks.isLinux = true;
+    const autoUploadWindow = mocks.createMockWindow(
+      "auto-upload-bWFpbg--tmp-upload",
+      mocks.windows,
+    );
+    mocks.windows.set(autoUploadWindow.label, autoUploadWindow);
+    const { raiseModalChildWindowGroup } = await importWindowManager();
+
+    await raiseModalChildWindowGroup({ reason: "open" });
+
+    expect(autoUploadWindow.setAlwaysOnTop).toHaveBeenCalledOnce();
+    expect(autoUploadWindow.setAlwaysOnTop).toHaveBeenCalledWith(true);
+  });
+
+  it("retains the topmost pulse for modal windows on non-Linux platforms", async () => {
+    const settingsWindow = mocks.createMockWindow("settings", mocks.windows);
+    mocks.windows.set("settings", settingsWindow);
+    const { raiseModalChildWindowGroup } = await importWindowManager();
+
+    await raiseModalChildWindowGroup({ reason: "open" });
+
+    expect(settingsWindow.setAlwaysOnTop).toHaveBeenCalledWith(true);
   });
 });
 

--- a/src/lib/windowManager.ts
+++ b/src/lib/windowManager.ts
@@ -19,7 +19,7 @@ import {
 } from "./childWindowProtocol";
 import { invoke } from "./invoke";
 import { logger } from "./logger";
-import { isMacOS } from "./platform";
+import { isLinux, isMacOS } from "./platform";
 
 type ChildWindowStateKey =
   | "settings"
@@ -404,13 +404,23 @@ export async function raiseModalChildWindowGroup(options: ModalGroupRaiseOptions
     );
     if (!topModalWindow) return;
 
-    modalTopmostPulseId += 1;
-    const pulseId = modalTopmostPulseId;
+    // On Linux, setAlwaysOnTop maps to GTK keep-above/window-manager hints. Some X11
+    // environments can fail fatally while GTK processes those hints, and transient modal
+    // children are already raised via show/focus. Keep the pulse on Windows/macOS, while
+    // preserving the real always-on-top requirement for auto-upload windows on Linux.
+    const shouldPulseTopmost = !isLinux;
+    let pulseId: number | undefined;
+    if (shouldPulseTopmost) {
+      modalTopmostPulseId += 1;
+      pulseId = modalTopmostPulseId;
+    }
 
     await Promise.all(
       orderedWindows.map(async (modalWindow) => {
         await modalWindow.show().catch(() => {});
-        await modalWindow.setAlwaysOnTop(true).catch(() => {});
+        if (shouldPulseTopmost || needsAlwaysOnTop(modalWindow.label)) {
+          await modalWindow.setAlwaysOnTop(true).catch(() => {});
+        }
       }),
     );
 
@@ -422,7 +432,9 @@ export async function raiseModalChildWindowGroup(options: ModalGroupRaiseOptions
       await topModalWindow.requestUserAttention(UserAttentionType.Critical).catch(() => {});
     }
 
-    restoreModalTopmostStates(orderedWindows, pulseId);
+    if (pulseId !== undefined) {
+      restoreModalTopmostStates(orderedWindows, pulseId);
+    }
   } finally {
     window.setTimeout(() => {
       modalGroupRaiseInFlight = false;


### PR DESCRIPTION
## Summary

- stop pulsing `setAlwaysOnTop(true)` for ordinary modal child windows on Linux
- keep the existing show/focus modal raising path and preserve always-on-top for auto-upload windows that explicitly require it
- retain the existing topmost pulse behavior on Windows and macOS
- add regression coverage for Linux modal and auto-upload behavior

## Why

Issue #534 reports a fatal GDK/X11 `BadImplementation` error on Ubuntu 22.04 Xorg when opening Settings or editing a connection. Both actions share the modal child-window path. That path briefly toggled every modal window to always-on-top, which maps to GTK/window-manager keep-above hints on Linux even though ordinary transient dialogs do not require that state.

Avoiding that Linux-only hint pulse removes the unnecessary X11 window-manager operation while keeping the existing transient parent, show, focus, and modal-blocking behavior intact.

## Validation

- `pnpm vitest run src/lib/windowManager.test.ts`: 14/14 passed
- `pnpm exec tsc --noEmit`: passed
- `pnpm exec biome lint src/lib/windowManager.ts src/lib/windowManager.test.ts`: passed
- `git diff --check`: passed

Fixes #534
