### PR TITLE
fix(docker): allow stopping restarting containers

### DIFF
--- a/src/components/panel/DockerManager.tsx
+++ b/src/components/panel/DockerManager.tsx
@@ -31,6 +31,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useApp } from "@/context/AppContext";
 import { useVirtualList } from "@/hooks/useVirtualList";
+import { canStartDockerContainer, canStopDockerContainer } from "@/lib/dockerContainerActions";
 import { getErrorMessage } from "@/lib/errors";
 import { invoke } from "@/lib/invoke";
 import { buildTerminalCommandInput, sendSessionInput } from "@/lib/sessionInput";
@@ -1420,6 +1421,8 @@ function ContainerRow({
 }) {
   const stateKind = getDockerStateKind(container.state);
   const running = stateKind === "running";
+  const startable = canStartDockerContainer(container.state);
+  const stoppable = canStopDockerContainer(container.state);
   const pending = Boolean(pendingAction);
   return (
     <div
@@ -1455,6 +1458,8 @@ function ContainerRow({
         <DockerActionMenu
           pending={pending}
           running={running}
+          startable={startable}
+          stoppable={stoppable}
           onEnter={onEnter}
           onLogs={onLogs}
           onAction={onAction}
@@ -1467,12 +1472,16 @@ function ContainerRow({
 function DockerActionMenu({
   pending,
   running,
+  startable,
+  stoppable,
   onEnter,
   onLogs,
   onAction,
 }: {
   pending: boolean;
   running: boolean;
+  startable: boolean;
+  stoppable: boolean;
   onEnter: () => void;
   onLogs: () => void;
   onAction: (action: string) => void;
@@ -1501,10 +1510,10 @@ function DockerActionMenu({
           {t("dockerManager.enter")}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem disabled={pending || running} onSelect={() => onAction("start")}>
+        <DropdownMenuItem disabled={pending || !startable} onSelect={() => onAction("start")}>
           {t("dockerManager.start")}
         </DropdownMenuItem>
-        <DropdownMenuItem disabled={pending || !running} onSelect={() => onAction("stop")}>
+        <DropdownMenuItem disabled={pending || !stoppable} onSelect={() => onAction("stop")}>
           {t("dockerManager.stop")}
         </DropdownMenuItem>
         <DropdownMenuItem disabled={pending} onSelect={() => onAction("restart")}>

--- a/src/lib/dockerContainerActions.test.ts
+++ b/src/lib/dockerContainerActions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { canStartDockerContainer, canStopDockerContainer } from "./dockerContainerActions";
+
+describe("docker container action availability", () => {
+  it.each(["created", "exited", " EXITED "])("allows starting %s containers", (state) => {
+    expect(canStartDockerContainer(state)).toBe(true);
+  });
+
+  it.each(["running", "restarting", "paused", "removing", "dead", "unknown"])(
+    "does not allow starting %s containers",
+    (state) => {
+      expect(canStartDockerContainer(state)).toBe(false);
+    },
+  );
+
+  it.each(["running", "restarting", " RESTARTING "])("allows stopping %s containers", (state) => {
+    expect(canStopDockerContainer(state)).toBe(true);
+  });
+
+  it.each(["created", "exited", "paused", "removing", "dead", "unknown"])(
+    "does not allow stopping %s containers",
+    (state) => {
+      expect(canStopDockerContainer(state)).toBe(false);
+    },
+  );
+});

--- a/src/lib/dockerContainerActions.ts
+++ b/src/lib/dockerContainerActions.ts
@@ -1,0 +1,13 @@
+function normalizeDockerContainerState(state: string) {
+  return state.trim().toLowerCase();
+}
+
+export function canStartDockerContainer(state: string) {
+  const normalized = normalizeDockerContainerState(state);
+  return normalized === "created" || normalized === "exited";
+}
+
+export function canStopDockerContainer(state: string) {
+  const normalized = normalizeDockerContainerState(state);
+  return normalized === "running" || normalized === "restarting";
+}


### PR DESCRIPTION
## Summary

- Allow `restarting` containers to use Stop so restart loops can be interrupted.
- Only enable Start for `created` and `exited` containers instead of every non-running state.
- Keep remove behavior unchanged; no implicit force removal.
- Add focused tests for Docker container action availability across known states.

## Validation

- `pnpm exec vitest run src/lib/dockerContainerActions.test.ts`: 18 tests passed
- `pnpm exec biome lint src/components/panel/DockerManager.tsx src/lib/dockerContainerActions.ts src/lib/dockerContainerActions.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`

Closes #633
