### PR TITLE
fix(terminal): 修复 macOS 第三方输入法 Shift 首字符丢失

### DIFF
--- a/src/lib/xtermImeCompatibility.test.ts
+++ b/src/lib/xtermImeCompatibility.test.ts
@@ -1,0 +1,123 @@
+import type { Terminal } from "@xterm/xterm";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/platform", () => ({
+  isLinux: false,
+  isMacOS: true,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { installImeCompatibilityPatch } from "./xtermImeCompatibility";
+
+interface FakeCompositionHelper {
+  _isComposing: boolean;
+  _isSendingComposition: boolean;
+  _textareaChangeTimer?: number;
+  compositionstart: () => void;
+}
+
+interface FakeCore {
+  _inputEvent: (event: InputEvent) => unknown;
+  _keyDownSeen: boolean;
+  _compositionHelper: FakeCompositionHelper;
+  textarea: HTMLTextAreaElement;
+}
+
+function createHarness() {
+  const textarea = document.createElement("textarea");
+  const observedKeyDownSeen: boolean[] = [];
+  const originalInputEvent = vi.fn(function (this: FakeCore) {
+    observedKeyDownSeen.push(this._keyDownSeen);
+    return true;
+  });
+  const core: FakeCore = {
+    _inputEvent: originalInputEvent,
+    _keyDownSeen: false,
+    _compositionHelper: {
+      _isComposing: false,
+      _isSendingComposition: false,
+      compositionstart: vi.fn(),
+    },
+    textarea,
+  };
+  const terminal = { _core: core } as unknown as Terminal;
+
+  return { core, observedKeyDownSeen, originalInputEvent, terminal, textarea };
+}
+
+function dispatchKeydown(
+  textarea: HTMLTextAreaElement,
+  key: string,
+  keyCode: number,
+) {
+  const event = new KeyboardEvent("keydown", { bubbles: true, key });
+  Object.defineProperty(event, "keyCode", { value: keyCode });
+  textarea.dispatchEvent(event);
+}
+
+function inputEvent(data: string): InputEvent {
+  return {
+    data,
+    inputType: "insertText",
+    isComposing: false,
+  } as InputEvent;
+}
+
+describe("xterm IME compatibility", () => {
+  it("forces the first direct-commit character after a held modifier", () => {
+    const { core, observedKeyDownSeen, terminal, textarea } = createHarness();
+    const patch = installImeCompatibilityPatch(terminal, true);
+
+    dispatchKeydown(textarea, "Shift", 16);
+    core._keyDownSeen = true;
+    core._inputEvent(inputEvent("$"));
+
+    expect(observedKeyDownSeen).toEqual([false]);
+    expect(core._keyDownSeen).toBe(true);
+    patch.dispose();
+  });
+
+  it("keeps the existing keyCode 229 compatibility path", () => {
+    const { core, observedKeyDownSeen, terminal, textarea } = createHarness();
+    const patch = installImeCompatibilityPatch(terminal, true);
+
+    dispatchKeydown(textarea, "a", 229);
+    core._keyDownSeen = true;
+    core._inputEvent(inputEvent("a"));
+
+    expect(observedKeyDownSeen).toEqual([false]);
+    patch.dispose();
+  });
+
+  it("does not force normal Shift plus physical-key input", () => {
+    const { core, observedKeyDownSeen, terminal, textarea } = createHarness();
+    const patch = installImeCompatibilityPatch(terminal, true);
+
+    dispatchKeydown(textarea, "Shift", 16);
+    dispatchKeydown(textarea, "$", 52);
+    core._keyDownSeen = true;
+    core._inputEvent(inputEvent("$"));
+
+    expect(observedKeyDownSeen).toEqual([true]);
+    patch.dispose();
+  });
+
+  it("does not force direct commits while composition is active", () => {
+    const { core, observedKeyDownSeen, terminal, textarea } = createHarness();
+    const patch = installImeCompatibilityPatch(terminal, true);
+
+    core._compositionHelper._isComposing = true;
+    dispatchKeydown(textarea, "Shift", 16);
+    core._keyDownSeen = true;
+    core._inputEvent(inputEvent("$"));
+
+    expect(observedKeyDownSeen).toEqual([true]);
+    patch.dispose();
+  });
+});

--- a/src/lib/xtermImeCompatibility.ts
+++ b/src/lib/xtermImeCompatibility.ts
@@ -26,6 +26,15 @@ interface TerminalWithCoreInternals extends Terminal {
 
 const PRINTABLE_ASCII = /^[\x20-\x7E]$/;
 
+function isModifierOnlyKeydown(event: KeyboardEvent): boolean {
+  return (
+    event.key === "Shift" ||
+    event.key === "Control" ||
+    event.key === "Alt" ||
+    event.key === "Meta"
+  );
+}
+
 const noopDisposable: Disposable = {
   dispose() {},
 };
@@ -100,10 +109,12 @@ export function installImeCompatibilityPatch(
   let patchedInputEvent: XtermCoreInternals["_inputEvent"] | undefined;
   let textarea: HTMLTextAreaElement | null | undefined;
   let latestKeydownWas229 = false;
+  let latestKeydownWasModifierOnly = false;
   let keydownInstalled = false;
 
   const handleKeyDown = (event: KeyboardEvent) => {
     latestKeydownWas229 = event.keyCode === 229;
+    latestKeydownWasModifierOnly = isModifierOnlyKeydown(event);
   };
 
   if (isMacOS) {
@@ -119,7 +130,9 @@ export function installImeCompatibilityPatch(
       textarea = core.textarea;
       patchedInputEvent = function patchedInputEvent(this: XtermCoreInternals, ev: InputEvent) {
         const was229 = latestKeydownWas229;
+        const wasModifierOnly = latestKeydownWasModifierOnly;
         latestKeydownWas229 = false;
+        latestKeydownWasModifierOnly = false;
 
         const shouldPatch =
           ev.inputType === "insertText" &&
@@ -127,7 +140,7 @@ export function installImeCompatibilityPatch(
           PRINTABLE_ASCII.test(ev.data) &&
           !ev.isComposing &&
           !isCompositionActive(this._compositionHelper) &&
-          was229 &&
+          (was229 || wasModifierOnly) &&
           this._keyDownSeen === true;
 
         if (!shouldPatch) {


### PR DESCRIPTION
## Summary

- 修复 macOS 百度/豆包等第三方 IME 下，开启输入法兼容模式后按住 Shift 输入时首字符丢失的问题。
- 保留现有 `keyCode=229` 兼容路径，并避免影响正常的 Shift + 物理字符键输入。
- 为 modifier-first、229、正常物理键和 composition 场景补充回归测试。

## Root cause

macOS WKWebView 下部分第三方 IME 会先提交 `input`，随后才发送字符对应的 `keydown(229)`。此时前一个纯修饰键（例如 Shift）的 `keydown` 已让 xterm 将 `_keyDownSeen` 设为 `true`，导致 `_inputEvent` 把第一个 direct-commit 字符当作重复输入丢弃。

现有 NyaTerm IME 兼容补丁只在最近一次 keydown 为 `229` 时强制处理 `input`，因此覆盖不了 `Shift keydown -> input -> keydown(229)` 这一顺序。

## Fix

- 在 macOS IME 兼容路径中记录最近一次 keydown 是否为纯 `Shift` / `Control` / `Alt` / `Meta`。
- 对非 composition 的单字符 printable ASCII `insertText`，当 `_keyDownSeen` 为 `true` 且最近事件来自 `229` 或纯修饰键时，复用现有 forced-input 路径。
- 任意后续物理字符 keydown 会覆盖 modifier 状态，因此正常 `Shift + key` 路径不会被强制处理，避免重复输入。

这与 xterm.js #5887 / PR #6054 识别出的 modifier 污染 `_keyDownSeen` 根因一致，同时保持修改限定在 NyaTerm 已有的可选 IME 兼容层。

## Validation

- `pnpm exec vitest run src/lib/xtermImeCompatibility.test.ts` — 4 tests passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm exec biome lint src/lib/xtermImeCompatibility.ts src/lib/xtermImeCompatibility.test.ts` — passed
- `pnpm lint` — passed；仅报告两处与本 PR 无关的既有 Biome warning/info
- `git diff --check` — passed

Fixes #412
