### PR TITLE
fix(terminal): clear stale Linux IME composition text

### DIFF
--- a/src/lib/xtermImeCompatibility.test.ts
+++ b/src/lib/xtermImeCompatibility.test.ts
@@ -165,6 +165,28 @@ describe("xterm IME compatibility", () => {
     patch.dispose();
   });
 
+  it("does not let stale cleanup erase a new Linux composition", () => {
+    vi.useFakeTimers();
+    platform.isLinux = true;
+    platform.isMacOS = false;
+    const { core, terminal, textarea } = createHarness();
+    const patch = installImeCompatibilityPatch(terminal, true);
+
+    textarea.value = "一";
+    textarea.dispatchEvent(
+      new CompositionEvent("compositionend", { bubbles: true }),
+    );
+
+    core._compositionHelper.compositionstart();
+    expect(textarea.value).toBe("");
+
+    textarea.value = "二";
+    vi.runAllTimers();
+
+    expect(textarea.value).toBe("二");
+    patch.dispose();
+  });
+
   it("cancels pending Linux textarea cleanup when disposed", () => {
     vi.useFakeTimers();
     platform.isLinux = true;

--- a/src/lib/xtermImeCompatibility.test.ts
+++ b/src/lib/xtermImeCompatibility.test.ts
@@ -1,9 +1,18 @@
 import type { Terminal } from "@xterm/xterm";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/platform", () => ({
+const platform = vi.hoisted(() => ({
   isLinux: false,
   isMacOS: true,
+}));
+
+vi.mock("@/lib/platform", () => ({
+  get isLinux() {
+    return platform.isLinux;
+  },
+  get isMacOS() {
+    return platform.isMacOS;
+  },
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -70,6 +79,15 @@ function inputEvent(data: string): InputEvent {
 }
 
 describe("xterm IME compatibility", () => {
+  beforeEach(() => {
+    platform.isLinux = false;
+    platform.isMacOS = true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("forces the first direct-commit character after a held modifier", () => {
     const { core, observedKeyDownSeen, terminal, textarea } = createHarness();
     const patch = installImeCompatibilityPatch(terminal, true);
@@ -119,5 +137,48 @@ describe("xterm IME compatibility", () => {
 
     expect(observedKeyDownSeen).toEqual([true]);
     patch.dispose();
+  });
+
+  it("clears stale Linux textarea state after compositionend", () => {
+    vi.useFakeTimers();
+    platform.isLinux = true;
+    platform.isMacOS = false;
+    const { terminal, textarea } = createHarness();
+    const patch = installImeCompatibilityPatch(terminal, true);
+
+    textarea.value = "一";
+    textarea.dispatchEvent(
+      new CompositionEvent("compositionend", { bubbles: true }),
+    );
+    expect(textarea.value).toBe("一");
+
+    vi.runAllTimers();
+    expect(textarea.value).toBe("");
+
+    textarea.value = "二";
+    textarea.dispatchEvent(
+      new CompositionEvent("compositionend", { bubbles: true }),
+    );
+    vi.runAllTimers();
+    expect(textarea.value).toBe("");
+
+    patch.dispose();
+  });
+
+  it("cancels pending Linux textarea cleanup when disposed", () => {
+    vi.useFakeTimers();
+    platform.isLinux = true;
+    platform.isMacOS = false;
+    const { terminal, textarea } = createHarness();
+    const patch = installImeCompatibilityPatch(terminal, true);
+
+    textarea.value = "一";
+    textarea.dispatchEvent(
+      new CompositionEvent("compositionend", { bubbles: true }),
+    );
+    patch.dispose();
+    vi.runAllTimers();
+
+    expect(textarea.value).toBe("一");
   });
 });

--- a/src/lib/xtermImeCompatibility.ts
+++ b/src/lib/xtermImeCompatibility.ts
@@ -90,6 +90,9 @@ export function installImeCompatibilityPatch(
   // biome-ignore lint/suspicious/noExplicitAny: Accessing xterm.js private compositionHelper
   const compositionHelper = core._compositionHelper as Record<string, any>;
   const originalCompositionStart = compositionHelper.compositionstart;
+  let compositionEndTextarea: HTMLTextAreaElement | null = null;
+  let compositionEndCleanupTimer: number | undefined;
+
   if (typeof originalCompositionStart !== "function") {
     warnSkipped("missing_composition_start", sessionId);
     return noopDisposable;
@@ -97,6 +100,16 @@ export function installImeCompatibilityPatch(
 
   // biome-ignore lint/suspicious/noExplicitAny: xterm compositionstart context and arguments
   const patchedCompositionStart = function (this: any, ...args: any[]) {
+    // Consume pending cleanup before xterm starts the next composition so an
+    // older timer cannot erase text that belongs to the new composition.
+    if (isLinux && compositionEndCleanupTimer !== undefined) {
+      window.clearTimeout(compositionEndCleanupTimer);
+      compositionEndCleanupTimer = undefined;
+      if (compositionEndTextarea?.value) {
+        compositionEndTextarea.value = "";
+      }
+    }
+
     if (this._textareaChangeTimer !== undefined) {
       window.clearTimeout(this._textareaChangeTimer);
       this._textareaChangeTimer = undefined;
@@ -111,8 +124,6 @@ export function installImeCompatibilityPatch(
   let latestKeydownWas229 = false;
   let latestKeydownWasModifierOnly = false;
   let keydownInstalled = false;
-  let compositionEndTextarea: HTMLTextAreaElement | null = null;
-  let compositionEndCleanupTimer: number | undefined;
 
   const handleCompositionEnd = () => {
     if (!compositionEndTextarea) return;

--- a/src/lib/xtermImeCompatibility.ts
+++ b/src/lib/xtermImeCompatibility.ts
@@ -111,6 +111,37 @@ export function installImeCompatibilityPatch(
   let latestKeydownWas229 = false;
   let latestKeydownWasModifierOnly = false;
   let keydownInstalled = false;
+  let compositionEndTextarea: HTMLTextAreaElement | null = null;
+  let compositionEndCleanupTimer: number | undefined;
+
+  const handleCompositionEnd = () => {
+    if (!compositionEndTextarea) return;
+
+    if (compositionEndCleanupTimer !== undefined) {
+      window.clearTimeout(compositionEndCleanupTimer);
+    }
+    compositionEndCleanupTimer = window.setTimeout(() => {
+      compositionEndCleanupTimer = undefined;
+      if (compositionEndTextarea?.value) {
+        compositionEndTextarea.value = "";
+      }
+    }, 0);
+  };
+
+  // WebKitGTK can leave committed composition text in xterm's textarea, so the
+  // next IME commit may replay stale text unless we reset it after xterm handles the event.
+  if (isLinux) {
+    if (core.textarea instanceof HTMLTextAreaElement) {
+      compositionEndTextarea = core.textarea;
+      compositionEndTextarea.addEventListener(
+        "compositionend",
+        handleCompositionEnd,
+        false,
+      );
+    } else {
+      warnSkipped("missing_linux_textarea", sessionId);
+    }
+  }
 
   const handleKeyDown = (event: KeyboardEvent) => {
     latestKeydownWas229 = event.keyCode === 229;
@@ -173,6 +204,17 @@ export function installImeCompatibilityPatch(
 
   return {
     dispose() {
+      if (compositionEndTextarea) {
+        compositionEndTextarea.removeEventListener(
+          "compositionend",
+          handleCompositionEnd,
+          false,
+        );
+      }
+      if (compositionEndCleanupTimer !== undefined) {
+        window.clearTimeout(compositionEndCleanupTimer);
+        compositionEndCleanupTimer = undefined;
+      }
       if (keydownInstalled && textarea) {
         textarea.removeEventListener("keydown", handleKeyDown, true);
       }


### PR DESCRIPTION
## Summary

- clear xterm's hidden textarea after Linux `compositionend` when IME compatibility mode is enabled
- defer cleanup until xterm finishes handling the composition event and cancel pending cleanup on dispose
- add Linux regression coverage for consecutive IME commits and cleanup disposal

## Why

WebKitGTK can leave committed composition text in xterm's textarea. The next IME commit can then replay stale text, matching the cumulative Chinese input reported in #390. This restores the textarea reset that existed in the original #274 Linux IME fix but was lost during the later compatibility refactor.

## Testing

- `pnpm vitest run src/lib/xtermImeCompatibility.test.ts` (6 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint src/lib/xtermImeCompatibility.ts src/lib/xtermImeCompatibility.test.ts`
- `git diff --check`

Fixes #390
