### PR TITLE
fix(transfer): improve SFTP diagnostics and desktop integration

### DIFF
--- a/crates/nyaterm-app/src/main.rs
+++ b/crates/nyaterm-app/src/main.rs
@@ -62,6 +62,8 @@ fn main() -> anyhow::Result<()> {
                         .then(|| point(px(9.), px(11.))),
                     ..Default::default()
                 }),
+                #[cfg(target_os = "linux")]
+                window_decorations: Some(gpui::WindowDecorations::Client),
                 window_bounds: Some(placement.window_bounds),
                 display_id: placement.display_id,
                 ..Default::default()

--- a/crates/nyaterm-desktop/src/features/layout/title_bar/bar.rs
+++ b/crates/nyaterm-desktop/src/features/layout/title_bar/bar.rs
@@ -84,7 +84,7 @@ impl HeaderStatusContent {
 }
 
 impl NyaTermApp {
-    fn handle_title_bar_mouse_down(
+    pub(in crate::features) fn handle_title_bar_mouse_down(
         &mut self,
         _event: &MouseDownEvent,
         _window: &mut Window,

--- a/crates/nyaterm-desktop/src/features/layout/title_bar/bar.rs
+++ b/crates/nyaterm-desktop/src/features/layout/title_bar/bar.rs
@@ -1,7 +1,8 @@
 use rust_i18n::t;
 
 use gpui::{
-    Context, IntoElement, MouseButton, Window, WindowControlArea, div, prelude::*, px, rgb, svg,
+    Context, IntoElement, MouseButton, MouseDownEvent, Window, WindowControlArea, div, prelude::*,
+    px, rgb, svg,
 };
 use nyaterm_transport::SessionKind;
 use nyaterm_ui::NyaDropdownMenu;
@@ -83,6 +84,26 @@ impl HeaderStatusContent {
 }
 
 impl NyaTermApp {
+    fn handle_title_bar_mouse_down(
+        &mut self,
+        _event: &MouseDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.mark_title_drag_activity();
+        #[cfg(target_os = "linux")]
+        {
+            // Linux 的拖动标记不会主动移动窗口；阻止嵌套拖动区重复处理同一次按下。
+            cx.stop_propagation();
+            if _event.click_count == 2 {
+                _window.zoom_window();
+            } else {
+                _window.start_window_move();
+            }
+        }
+        cx.notify();
+    }
+
     pub(in crate::features) fn title_bar(
         &mut self,
         window: &mut Window,
@@ -115,10 +136,7 @@ impl NyaTermApp {
                     .window_control_area(WindowControlArea::Drag)
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|this, _, _, cx| {
-                            this.mark_title_drag_activity();
-                            cx.notify();
-                        }),
+                        cx.listener(Self::handle_title_bar_mouse_down),
                     )
                     .when(!macos, |this| {
                         this.child(
@@ -154,6 +172,11 @@ impl NyaTermApp {
                                             this.text_color(rgb(palette.text))
                                         }),
                                 )
+                                .when(cfg!(target_os = "linux"), |this| {
+                                    this.on_mouse_down(MouseButton::Left, |_, _, cx| {
+                                        cx.stop_propagation();
+                                    })
+                                })
                                 .on_click(cx.listener(|this, _, _, cx| {
                                     this.toggle_mobile_left_drawer(cx);
                                 })),
@@ -173,10 +196,7 @@ impl NyaTermApp {
                     .window_control_area(WindowControlArea::Drag)
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|this, _, _, cx| {
-                            this.mark_title_drag_activity();
-                            cx.notify();
-                        }),
+                        cx.listener(Self::handle_title_bar_mouse_down),
                     )
                     .when(header_status_visible, |this| {
                         this.child(self.header_status_control(header_status, cx))
@@ -223,10 +243,7 @@ impl NyaTermApp {
                             .window_control_area(WindowControlArea::Drag)
                             .on_mouse_down(
                                 MouseButton::Left,
-                                cx.listener(|this, _, _, cx| {
-                                    this.mark_title_drag_activity();
-                                    cx.notify();
-                                }),
+                                cx.listener(Self::handle_title_bar_mouse_down),
                             ),
                     )
                     .when(!macos, |this| {
@@ -311,10 +328,7 @@ impl NyaTermApp {
                     .window_control_area(WindowControlArea::Drag)
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|this, _, _, cx| {
-                            this.mark_title_drag_activity();
-                            cx.notify();
-                        }),
+                        cx.listener(Self::handle_title_bar_mouse_down),
                     )
                     .child(self.header_status_body(content, cx)),
             )

--- a/crates/nyaterm-desktop/src/features/pages/transfers/browser_selection.rs
+++ b/crates/nyaterm-desktop/src/features/pages/transfers/browser_selection.rs
@@ -11,20 +11,24 @@ use crate::models::{TransferBrowserContextTarget, TransferBrowserDragSelectionSt
 
 use super::{TransferPathPart, remote_file_name, transfer_path_part_value};
 
+/// Converts a selection identity key to its display path so raw-path-token is not
+/// treated as a user-facing path.
+fn browser_display_path_for_identity(entries: &[SftpFileEntry], identity: &str) -> String {
+    entries
+        .iter()
+        .find(|entry| entry.matches_identity(identity))
+        .map(|entry| entry.path.clone())
+        .unwrap_or_else(|| identity.to_string())
+}
+
 impl NyaTermApp {
     pub(in crate::features::pages::transfers) fn select_transfer_browser_entry(
         &mut self,
         identity: String,
         cx: &mut Context<Self>,
     ) {
-        let display_path = self
-            .transfer
-            .browser_view()
-            .entries
-            .iter()
-            .find(|entry| entry.matches_identity(&identity))
-            .map(|entry| entry.path.clone())
-            .unwrap_or_else(|| identity.clone());
+        let display_path =
+            browser_display_path_for_identity(self.transfer.browser_view().entries, &identity);
         self.transfer.select_browser_entry(identity);
         self.transfer.set_remote_path(display_path.clone());
         self.shell
@@ -207,7 +211,9 @@ impl NyaTermApp {
     ) {
         window.focus(self.transfer.browser_view().focus, cx);
         if let Some(selected_count) = self.transfer.activate_marked_browser_path(&path) {
-            self.transfer.set_remote_path(path);
+            let display_path =
+                browser_display_path_for_identity(self.transfer.browser_view().entries, &path);
+            self.transfer.set_remote_path(display_path);
             self.shell
                 .set_status(format!("{} remote item(s) marked", selected_count));
             cx.notify();
@@ -332,8 +338,10 @@ impl NyaTermApp {
         path: String,
         cx: &mut Context<Self>,
     ) {
+        let display_path =
+            browser_display_path_for_identity(self.transfer.browser_view().entries, &path);
         let selected_count = self.transfer.toggle_browser_path_mark(path.clone());
-        self.transfer.set_remote_path(path.clone());
+        self.transfer.set_remote_path(display_path);
         self.shell
             .set_status(format!("{} remote item(s) marked", selected_count));
         cx.notify();
@@ -485,7 +493,7 @@ impl NyaTermApp {
         }
         let total = entries.len();
         let base_local_path = if total == 1 {
-            self.normalized_transfer_local_path()
+            self.normalized_transfer_local_path(&entries[0].path)
         } else {
             self.resolved_transfer_download_dir()
                 .unwrap_or_else(|| std::path::PathBuf::from("."))
@@ -501,5 +509,38 @@ impl NyaTermApp {
         self.shell
             .set_status(format!("{total} remote download job(s) started"));
         cx.notify();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nyaterm_transport::{RemoteFilePath, SftpFileEntry, SftpFileType};
+
+    use super::browser_display_path_for_identity;
+
+    #[test]
+    fn browser_display_path_for_identity_uses_display_path_for_raw_tokens() {
+        let entry = SftpFileEntry {
+            name: "client-rust.2026-09-11.log".to_string(),
+            path: "./rocontrol2/client-rust.2026-09-11.log".to_string(),
+            file_type: SftpFileType::File,
+            size: Some(1),
+            permissions: None,
+            owner: String::new(),
+            group: String::new(),
+            modified_at: None,
+            raw_path_token: RemoteFilePath::from_raw(
+                "./rocontrol2/client-rust.2026-09-11.log",
+                b"./rocontrol2/client-rust.2026-09-11.log",
+            )
+            .raw_path_token,
+            symlink_target_is_directory: false,
+        };
+        let identity = entry.identity_key();
+
+        assert_eq!(
+            browser_display_path_for_identity(std::slice::from_ref(&entry), &identity),
+            entry.path
+        );
     }
 }

--- a/crates/nyaterm-desktop/src/features/panels/lock_screen_overlay.rs
+++ b/crates/nyaterm-desktop/src/features/panels/lock_screen_overlay.rs
@@ -1,8 +1,8 @@
 use rust_i18n::t;
 
 use gpui::{
-    Context, FontWeight, IntoElement, KeyDownEvent, SharedString, Window, WindowControlArea, div,
-    prelude::*, px, rgb, rgba, svg,
+    Context, FontWeight, IntoElement, KeyDownEvent, MouseButton, SharedString, Window,
+    WindowControlArea, div, prelude::*, px, rgb, rgba, svg,
 };
 use nyaterm_ui::NyaInput;
 
@@ -72,7 +72,11 @@ impl NyaTermApp {
                             div()
                                 .h_full()
                                 .flex_1()
-                                .window_control_area(WindowControlArea::Drag),
+                                .window_control_area(WindowControlArea::Drag)
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(Self::handle_title_bar_mouse_down),
+                                ),
                         )
                         .child(window_control_button(
                             palette,

--- a/crates/nyaterm-desktop/src/features/shell/tray.rs
+++ b/crates/nyaterm-desktop/src/features/shell/tray.rs
@@ -205,11 +205,15 @@ impl NyaTermApp {
         }
         #[cfg(target_os = "macos")]
         {
+            let _ = window;
             cx.hide();
-            return true;
+            true
         }
-        let _ = (window, cx);
-        false
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (window, cx);
+            false
+        }
     }
 }
 

--- a/crates/nyaterm-desktop/src/features/transfers/transfer_events.rs
+++ b/crates/nyaterm-desktop/src/features/transfers/transfer_events.rs
@@ -1058,7 +1058,7 @@ impl NyaTermApp {
                     *request_id = None;
                     *status = TransferBrowserChildrenMenuStatus::Error(error.clone());
                 }
-                if error == SFTP_TRANSFER_CANCELLED {
+                if error.contains(SFTP_TRANSFER_CANCELLED) {
                     job.status = TransferJobStatus::Cancelled;
                     job.detail = "Cancelled".to_string();
                     self.shell
@@ -1247,7 +1247,9 @@ mod tests {
         TestAppContext, VisualTestContext, div,
     };
     use nyaterm_core::{AppRuntime, RuntimeMode};
-    use nyaterm_transport::{SftpPathTransferOptions, SftpTransferProgress, SftpTransferSummary};
+    use nyaterm_transport::{
+        SFTP_TRANSFER_CANCELLED, SftpPathTransferOptions, SftpTransferProgress, SftpTransferSummary,
+    };
 
     use crate::entities::{OverlayStore, StartupRestoreStore, UiStoreHandles};
     use crate::features::NyaTermApp;
@@ -1617,6 +1619,43 @@ mod tests {
                 Some(TransferJobStatus::Failed),
                 "the failure must have landed, not still be queued"
             );
+        });
+    }
+
+    #[test]
+    fn wrapped_transfer_cancellation_marks_the_job_cancelled() {
+        let test_dir = TestConfigDir::new("nyaterm-transfer-cancelled");
+        let mut cx = TestAppContext::single();
+        let (app, vcx) = hosted(&mut cx, test_dir.path());
+        let sender = vcx.update(|_, cx| {
+            app.update(cx, |app, cx| {
+                app.transfer.enqueue_transfer_job(running_job("job-0"));
+                app.start_transfer_event_drain(cx);
+                app.transfer.transfer_event_sender()
+            })
+        });
+        vcx.run_until_parked();
+
+        sender
+            .unbounded_send(TransferJobResult {
+                id: "job-0".to_string(),
+                event: TransferJobEvent::Finished(Err(format!(
+                    "operation stopped: {SFTP_TRANSFER_CANCELLED}"
+                ))),
+            })
+            .expect("send cancellation event");
+        vcx.run_until_parked();
+
+        vcx.update(|_, cx| {
+            let app = app.read(cx);
+            let job = app
+                .transfer
+                .transfer_jobs()
+                .iter()
+                .find(|job| job.id == "job-0")
+                .expect("cancelled job should remain visible");
+            assert_eq!(job.status, TransferJobStatus::Cancelled);
+            assert_eq!(job.detail, "Cancelled");
         });
     }
 

--- a/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/helpers.rs
+++ b/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/helpers.rs
@@ -2,12 +2,29 @@ use futures::channel::mpsc::UnboundedSender;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use nyaterm_transport::SftpTransferProgress;
+use nyaterm_transport::{SFTP_TRANSFER_CANCELLED, SftpTransferProgress};
 
 use crate::blocking_jobs::BlockingJobScheduler;
 use crate::models::{TransferJobEvent, TransferJobKind, TransferJobResult, TransferJobState};
 
 const TRANSFER_PROGRESS_EVENT_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Records the final error returned by an SFTP upload job at the asynchronous boundary.
+///
+/// The transport layer records protocol and retry details; this adds the desktop task ID
+/// so log entries can be matched to failed rows in the transfer panel. User cancellations
+/// are represented by the job state and are not logged as failures again.
+pub(super) fn log_sftp_upload_job_failure(job_id: &str, error: &anyhow::Error) {
+    if error.to_string().contains(SFTP_TRANSFER_CANCELLED) {
+        return;
+    }
+    tracing::error!(
+        transfer_id = %job_id,
+        error = %error,
+        error_chain = %format!("{error:#}"),
+        "SFTP upload job failed"
+    );
+}
 
 pub(in crate::features) fn submit_transfer_blocking_job(
     scheduler: &BlockingJobScheduler,

--- a/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/helpers.rs
+++ b/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/helpers.rs
@@ -100,12 +100,3 @@ pub(super) fn transfer_job_local_target_path(job: &TransferJobState) -> Option<P
             _ => None,
         })
 }
-
-pub(super) fn transfer_job_reveal_dir(path: PathBuf) -> PathBuf {
-    if path.is_dir() {
-        return path;
-    }
-    path.parent()
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| path.clone())
-}

--- a/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/selection.rs
+++ b/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/selection.rs
@@ -3,7 +3,7 @@ use rust_i18n::t;
 use gpui::{Context, KeyDownEvent, MouseDownEvent, Window};
 
 use super::super::transfer_widgets::transfer_job_title;
-use super::helpers::{transfer_job_local_target_path, transfer_job_reveal_dir};
+use super::helpers::transfer_job_local_target_path;
 use crate::features::NyaTermApp;
 
 impl NyaTermApp {
@@ -116,19 +116,97 @@ impl NyaTermApp {
             cx.notify();
             return;
         };
-        let Some(target_path) = transfer_job_local_target_path(job) else {
+        let Some(target_path) =
+            transfer_job_local_target_path(job).filter(|path| !path.as_os_str().is_empty())
+        else {
             self.shell
                 .set_status(format!("transfer {} has no local target", job.id));
             cx.notify();
             return;
         };
-        let target_dir = transfer_job_reveal_dir(target_path);
-        cx.reveal_path(&target_dir);
-        self.shell.set_status(format!(
-            "opened transfer directory {}",
-            target_dir.display()
-        ));
-        cx.notify();
+        // Keep filesystem checks and file-manager requests off the UI thread.
+        let request = cx.background_executor().spawn(async move {
+            let mut target_path = std::path::absolute(target_path)?;
+            // Follow directory symlinks, preserving the existing open-directory behavior.
+            let target_is_dir = match std::fs::metadata(&target_path) {
+                Ok(metadata) => metadata.is_dir(),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    anyhow::ensure!(target_path.pop(), "transfer target has no parent directory");
+                    anyhow::ensure!(
+                        std::fs::metadata(&target_path)?.is_dir(),
+                        "transfer target directory is unavailable"
+                    );
+                    true
+                }
+                Err(error) => return Err(error.into()),
+            };
+
+            #[cfg(target_os = "macos")]
+            if target_is_dir {
+                // Explicitly use Finder: the default handler could execute an app bundle.
+                let status = std::process::Command::new("/usr/bin/open")
+                    .args(["-b", "com.apple.finder", "--"])
+                    .arg(&target_path)
+                    .output()?
+                    .status;
+                anyhow::ensure!(status.success(), "Finder request failed: {status}");
+                return Ok(None);
+            }
+
+            #[cfg(target_os = "linux")]
+            if !target_is_dir {
+                use gtk::gio;
+                use gtk::gio::prelude::FileExt;
+
+                // GPUI opens the file for the portal. Check access without opening a FIFO/device.
+                let info = gio::File::for_path(&target_path).query_info(
+                    "standard::type,access::can-read",
+                    gio::FileQueryInfoFlags::NONE,
+                    gio::Cancellable::NONE,
+                )?;
+                if info.file_type() != gio::FileType::Regular || !info.boolean("access::can-read") {
+                    anyhow::ensure!(target_path.pop(), "transfer target has no parent directory");
+                    anyhow::ensure!(
+                        std::fs::metadata(&target_path)?.is_dir(),
+                        "transfer target directory is unavailable"
+                    );
+                    return Ok(Some((target_path, true)));
+                }
+            }
+            Ok::<_, anyhow::Error>(Some((target_path, target_is_dir)))
+        });
+        cx.spawn(async move |this, cx| {
+            let result = request.await;
+            let _ = this.update(cx, |this, cx| {
+                match result {
+                    Ok(target) => {
+                        if let Some((target_path, target_is_dir)) = target {
+                            if target_is_dir {
+                                #[cfg(target_os = "linux")]
+                                {
+                                    use gtk::gio::prelude::FileExt;
+                                    // The URI API preserves GPUI's Wayland activation-token handling.
+                                    cx.open_url(
+                                        gtk::gio::File::for_path(&target_path).uri().as_str(),
+                                    );
+                                }
+                                #[cfg(not(target_os = "linux"))]
+                                cx.open_with_system(&target_path);
+                            } else {
+                                cx.reveal_path(&target_path);
+                            }
+                        }
+                        this.shell
+                            .set_status("requested transfer location in file manager".to_string());
+                    }
+                    Err(error) => this
+                        .shell
+                        .set_status(format!("cannot show transfer location: {error}")),
+                }
+                cx.notify();
+            });
+        })
+        .detach();
     }
 
     pub(in crate::features) fn handle_transfer_queue_key_down(

--- a/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/transfer.rs
+++ b/crates/nyaterm-desktop/src/features/transfers/transfer_jobs/transfer.rs
@@ -15,7 +15,8 @@ use crate::models::{
 };
 
 use super::helpers::{
-    TransferProgressEventSender, submit_transfer_blocking_job, transfer_job_remote_parent_path,
+    TransferProgressEventSender, log_sftp_upload_job_failure, submit_transfer_blocking_job,
+    transfer_job_remote_parent_path,
 };
 
 impl NyaTermApp {
@@ -188,8 +189,11 @@ impl NyaTermApp {
                             },
                             Err(_) => TransferJobOutput::Summary(summary),
                         }
-                    })
-                    .map_err(|error| error.to_string());
+                    });
+                if let Err(error) = &result {
+                    log_sftp_upload_job_failure(&id, error);
+                }
+                let result = result.map_err(|error| error.to_string());
                 let _ = finished_tx.unbounded_send(TransferJobResult {
                     id,
                     event: TransferJobEvent::Finished(result),
@@ -482,8 +486,11 @@ impl NyaTermApp {
                                     },
                                     Err(_) => TransferJobOutput::Summary(summary),
                                 }
-                            })
-                            .map_err(|error| error.to_string());
+                            });
+                        if let Err(error) = &result {
+                            log_sftp_upload_job_failure(&job_id, error);
+                        }
+                        let result = result.map_err(|error| error.to_string());
                         let _ = finished_tx.unbounded_send(TransferJobResult {
                             id: job_id,
                             event: TransferJobEvent::Finished(result),

--- a/crates/nyaterm-desktop/src/features/transfers/transfer_paths.rs
+++ b/crates/nyaterm-desktop/src/features/transfers/transfer_paths.rs
@@ -176,11 +176,12 @@ impl NyaTermApp {
         cx.notify();
     }
 
-    pub(in crate::features) fn normalized_transfer_local_path(&self) -> PathBuf {
+    /// Builds a single-file download target from an explicit remote display path; the
+    /// selection identity key must not participate in naming.
+    pub(in crate::features) fn normalized_transfer_local_path(&self, remote_path: &str) -> PathBuf {
         let value = self.transfer.local_path().trim();
         if value.is_empty() {
-            let file_name =
-                download_file_name_from_remote_path(&self.transfer.normalized_remote_path());
+            let file_name = download_file_name_from_remote_path(remote_path);
             self.resolved_transfer_download_dir()
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join(file_name)

--- a/crates/nyaterm-transport/src/sftp/mod.rs
+++ b/crates/nyaterm-transport/src/sftp/mod.rs
@@ -433,6 +433,29 @@ impl SftpService {
         }
     }
 
+    /// Runs an upload and records its final result; ordinary failures are logged as errors,
+    /// while user cancellations are logged as warnings.
+    fn run_upload_operation<T, F>(
+        &self,
+        operation: &'static str,
+        attempts: u32,
+        operation_future: F,
+    ) -> anyhow::Result<T>
+    where
+        T: Send + 'static,
+        F: Future<Output = anyhow::Result<T>> + Send + 'static,
+    {
+        let result = self.run_operation(operation_future);
+        if let Err(error) = &result {
+            if is_sftp_transfer_cancelled(error) {
+                tracing::warn!(operation, "SFTP upload cancelled");
+            } else {
+                log_sftp_upload_failure(operation, attempts, error);
+            }
+        }
+        result
+    }
+
     pub(crate) fn copy_remote_path_to(
         &self,
         source_path: &RemoteFilePath,
@@ -1663,7 +1686,8 @@ impl SftpService {
         let remote_path = remote_path.as_ref().to_string();
         let config = self.config.clone();
         let multiplex = self.multiplex.clone();
-        self.run_operation(async move {
+        let attempts = options.max_retries().saturating_add(1);
+        self.run_upload_operation("upload_file", attempts, async move {
             let remote_path = resolve_remote_upload_target(&local_path, &remote_path)?;
             let mut last_error = None;
             for _attempt in 0..=options.max_retries() {
@@ -1720,7 +1744,8 @@ impl SftpService {
         let remote_path = remote_path.clone();
         let config = self.config.clone();
         let multiplex = self.multiplex.clone();
-        self.run_operation(async move {
+        let attempts = options.max_retries().saturating_add(1);
+        self.run_upload_operation("upload_remote_file", attempts, async move {
             let mut last_error = None;
             for _attempt in 0..=options.max_retries() {
                 control.check_cancelled()?;
@@ -1858,7 +1883,11 @@ impl SftpService {
         let remote_path = remote_path.as_ref().to_string();
         let config = self.config.clone();
         let multiplex = self.multiplex.clone();
-        self.run_operation(async move {
+        let attempts = path_options
+            .transfer_options()
+            .max_retries()
+            .saturating_add(1);
+        self.run_upload_operation("upload_path", attempts, async move {
             let metadata = tokio::fs::metadata(&local_path).await?;
             let remote_path = resolve_remote_upload_target(&local_path, &remote_path)?;
             let mut last_error = None;
@@ -2149,6 +2178,21 @@ fn remote_join_bytes(parent: &[u8], child: &[u8]) -> Vec<u8> {
 
 fn is_sftp_transfer_cancelled(error: &anyhow::Error) -> bool {
     error.to_string().contains(SFTP_TRANSFER_CANCELLED)
+}
+
+/// Records the full error chain before an upload leaves the transport layer so asynchronous
+/// callers do not see only the abbreviated `Display` text.
+///
+/// The log does not include local or remote paths or file contents; the desktop transfer ID
+/// supplies task-level context.
+fn log_sftp_upload_failure(operation: &'static str, attempts: u32, error: &anyhow::Error) {
+    tracing::error!(
+        operation,
+        attempts,
+        error = %error,
+        error_chain = %format!("{error:#}"),
+        "SFTP upload failed"
+    );
 }
 
 fn last_sftp_retry_error(last_error: Option<anyhow::Error>) -> anyhow::Error {


### PR DESCRIPTION
## 概述

本 PR 汇总 GPUI 迁移分支上的传输与桌面交互修复，解决 SFTP 失败信息缺失、远程路径身份被误当作显示路径、用户取消状态不一致、下载完成后无法正确定位文件，以及 Linux 重复窗口标题栏和 macOS 编译警告等问题。

## 问题背景

- SFTP 上传失败时，界面只显示简略的 `Failure: Failure`，日志缺少操作阶段和完整错误链。
- 部分 SFTP 文件使用原始路径 token 作为内部身份；该 token 在特定分支中被当作显示路径或本地文件名，导致下载文件出现 `raw-path-token/...` 一类异常名称。
- 用户主动取消传输时，桌面层可能显示失败，Rust 层也缺少明确的取消日志语义。
- 下载完成后，“打开目标目录”把文件的父目录再次作为待定位对象传给 GPUI，导致文件管理器打开了更上一级目录，且无法聚焦文件。
- Linux 使用系统窗口装饰时，与 NyaTerm 自绘标题栏重复；切换客户端装饰后，自绘标题栏需要显式接管窗口移动和双击最大化。
- macOS 编译时托盘代码存在条件编译导致的不可达代码和未使用变量警告。

## 修改内容

### SFTP 诊断、命名与取消

- 在 transport 层记录上传操作名称、重试次数、错误显示文本和完整错误链。
- 在 desktop 异步任务边界补充传输任务 ID，便于将日志与传输列表对应。
- 保持用户取消与普通失败的日志级别和桌面状态区分：取消记录为 warning，普通失败记录为 error，桌面显示为 Cancelled。
- 将浏览器选中项的内部身份与用户可见远程路径分离。
- 单文件下载使用明确的远程显示路径生成本地文件名，避免 raw path token 污染文件名。
- 保持原始路径字节用于协议和重复文件判断，不改变已有 SFTP 路径兼容逻辑。

### 下载文件定位

- 传入实际下载目标文件进行定位，而不是把父目录当成待定位对象。
- 目录目标显式打开目录；普通文件使用平台文件管理器的定位能力。
- Linux 对不可读文件、特殊文件和已清理目标安全回退到所在目录，并将文件系统检查放到后台执行。
- 保留 macOS Finder、Windows Explorer 和 Linux 文件管理器的原生行为，不启动下载文件本身。

### Linux 窗口交互

- Linux 主窗口使用客户端窗口装饰，消除系统标题栏与自绘标题栏重复。
- 自绘标题栏处理 Linux 原生窗口移动和双击最大化。
- 菜单及嵌套交互区域阻止拖动事件冒泡，避免点击菜单误触窗口移动。

### macOS 托盘

- 调整条件编译分支，消除 macOS 下的不可达代码和未使用变量警告，不改变托盘功能。

## 兼容性与安全性

- 未修改持久化数据格式、凭据、备份、数据库或第三方 fork。
- 未新增依赖。
- 原始路径身份仅用于协议和内部匹配，用户可见路径单独维护。
- 文件定位只调用系统文件管理器，不执行下载文件；特殊或不可读目标只回退到目录。
- Linux 仍兼容 Wayland 和 X11 的 GPUI 窗口交互路径。

## 测试

自动化验证：

- `cargo check --workspace`
- `cargo test --workspace --quiet`（全部通过；desktop 1334 项通过、5 项按原设置忽略，transport 293 项通过）
- `cargo clippy --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- Linux 非 root 路径验证：普通文件、不可读文件、特殊文件、设备文件、目录/文件软链接、断链、缺失目标和不可访问父目录。

手动验证：

- macOS：下载文件定位、窗口行为和应用包安全行为。
- Windows：文件定位及窗口 GUI 行为。
- Linux Plasma Wayland：文件定位、窗口装饰、拖动和最大化。
- Linux Plasma X11：文件定位、窗口装饰、拖动和最大化。

尚未在 GNOME Wayland 或 Xfce/X11 上进行手动 GUI 验证；这些环境可作为后续兼容性补充测试。

## 关联提交

- `c22383725a3375b9e6c07b8955b0c26f3767a2b8`
- `e9a15dae866bc52a32b7290edd6fc90eeb6659eb`
- `994e34e57c20c3b74bec5097a60d7cb7eecfeddb`
- `5ed6ee3d2c75c663323e2fd46a7d2543232b3b53`
验证期间仍会输出仓库已有的 `block 0.1.6` future-incompatibility 警告以及 macOS 链接器的 `__eh_frame` 提示；本 PR 未新增这些警告。
